### PR TITLE
Add the label to the local index

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/CallBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/CallBuilder.java
@@ -130,9 +130,10 @@ public abstract class CallBuilder extends NodeBuilder {
 
     public static void buildInferredTypeProperty(NodeBuilder nodeBuilder, ParameterData paramData, String value) {
         String unescapedParamName = ParamUtils.removeLeadingSingleQuote(paramData.name());
+        String label = paramData.label();
         nodeBuilder.properties().custom()
                 .metadata()
-                    .label(unescapedParamName)
+                    .label(label == null || label.isEmpty() ? unescapedParamName : label)
                     .description(paramData.description())
                     .stepOut()
                 .codedata()

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_1.json
@@ -520,7 +520,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -547,7 +547,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -574,7 +574,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -601,7 +601,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -628,7 +628,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -655,7 +655,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -682,7 +682,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -716,7 +716,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -750,7 +750,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -777,7 +777,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -804,7 +804,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -880,7 +880,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -914,7 +914,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -948,7 +948,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -982,7 +982,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1009,7 +1009,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1043,7 +1043,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1070,7 +1070,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1097,7 +1097,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1124,7 +1124,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -1252,7 +1252,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1279,7 +1279,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1306,7 +1306,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1333,7 +1333,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1360,7 +1360,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1387,7 +1387,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1414,7 +1414,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1448,7 +1448,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1482,7 +1482,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1509,7 +1509,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1536,7 +1536,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1612,7 +1612,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1646,7 +1646,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1680,7 +1680,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1714,7 +1714,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1741,7 +1741,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1775,7 +1775,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1802,7 +1802,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1829,7 +1829,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1856,7 +1856,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_2.json
@@ -523,7 +523,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -550,7 +550,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -577,7 +577,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -604,7 +604,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -631,7 +631,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -658,7 +658,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -685,7 +685,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -719,7 +719,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -753,7 +753,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -780,7 +780,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -807,7 +807,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -883,7 +883,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -917,7 +917,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -951,7 +951,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -985,7 +985,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1012,7 +1012,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1046,7 +1046,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1073,7 +1073,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1100,7 +1100,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1127,7 +1127,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -1255,7 +1255,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1282,7 +1282,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1309,7 +1309,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1336,7 +1336,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1363,7 +1363,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1390,7 +1390,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1417,7 +1417,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1451,7 +1451,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1485,7 +1485,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1512,7 +1512,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1539,7 +1539,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1615,7 +1615,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1649,7 +1649,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1683,7 +1683,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1717,7 +1717,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1744,7 +1744,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1778,7 +1778,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1805,7 +1805,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1832,7 +1832,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1859,7 +1859,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_3.json
@@ -520,7 +520,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -547,7 +547,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -574,7 +574,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -601,7 +601,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -628,7 +628,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -655,7 +655,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -682,7 +682,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -716,7 +716,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -750,7 +750,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -777,7 +777,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -804,7 +804,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -880,7 +880,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -914,7 +914,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -948,7 +948,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -982,7 +982,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1009,7 +1009,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1043,7 +1043,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1070,7 +1070,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1097,7 +1097,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1124,7 +1124,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -1252,7 +1252,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1279,7 +1279,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1306,7 +1306,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1333,7 +1333,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1360,7 +1360,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1387,7 +1387,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1414,7 +1414,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1448,7 +1448,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1482,7 +1482,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1509,7 +1509,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1536,7 +1536,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1612,7 +1612,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1646,7 +1646,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1680,7 +1680,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1714,7 +1714,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1741,7 +1741,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1775,7 +1775,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1802,7 +1802,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1829,7 +1829,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1856,7 +1856,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -83,7 +83,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -102,7 +102,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Request path"
             },
             "valueType": "EXPRESSION",
@@ -129,7 +129,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -289,7 +289,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -316,7 +316,7 @@
           },
           "config": {
             "metadata": {
-              "label": "config",
+              "label": "Config",
               "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
@@ -452,7 +452,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -471,7 +471,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Request path"
             },
             "valueType": "EXPRESSION",
@@ -498,7 +498,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -792,7 +792,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -819,7 +819,7 @@
           },
           "config": {
             "metadata": {
-              "label": "config",
+              "label": "Config",
               "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
@@ -321,7 +321,7 @@
                   },
                   "key": {
                     "metadata": {
-                      "label": "key",
+                      "label": "Key",
                       "description": "Key referring to a value"
                     },
                     "valueType": "EXPRESSION",
@@ -792,7 +792,7 @@
                           },
                           "targetType": {
                             "metadata": {
-                              "label": "targetType",
+                              "label": "Target Type",
                               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                             },
                             "valueType": "TYPE",
@@ -811,7 +811,7 @@
                           },
                           "path": {
                             "metadata": {
-                              "label": "path",
+                              "label": "Path",
                               "description": "Request path"
                             },
                             "valueType": "EXPRESSION",
@@ -838,7 +838,7 @@
                           },
                           "headers": {
                             "metadata": {
-                              "label": "headers",
+                              "label": "Headers",
                               "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
@@ -1315,7 +1315,7 @@
                           },
                           "key": {
                             "metadata": {
-                              "label": "key",
+                              "label": "Key",
                               "description": "Key referring to a value"
                             },
                             "valueType": "EXPRESSION",
@@ -1342,7 +1342,7 @@
                           },
                           "value": {
                             "metadata": {
-                              "label": "value",
+                              "label": "Value",
                               "description": "Values"
                             },
                             "valueType": "EXPRESSION",
@@ -1709,7 +1709,7 @@
                 "properties": {
                   "msg": {
                     "metadata": {
-                      "label": "msg",
+                      "label": "Msg",
                       "description": "The message to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -1743,7 +1743,7 @@
                   },
                   "error": {
                     "metadata": {
-                      "label": "error",
+                      "label": "Error",
                       "description": "The error struct to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -1778,7 +1778,7 @@
                   },
                   "stackTrace": {
                     "metadata": {
-                      "label": "stackTrace",
+                      "label": "Stack Trace",
                       "description": "The error stack trace to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -1945,7 +1945,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1972,7 +1972,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1999,7 +1999,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -2026,7 +2026,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -2053,7 +2053,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -2080,7 +2080,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -2107,7 +2107,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -2141,7 +2141,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -2175,7 +2175,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -2202,7 +2202,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -2229,7 +2229,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -2305,7 +2305,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -2339,7 +2339,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -2373,7 +2373,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -2407,7 +2407,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -2434,7 +2434,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -2468,7 +2468,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -2495,7 +2495,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -2522,7 +2522,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -2549,7 +2549,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -2677,7 +2677,7 @@
         "properties": {
           "$connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -2712,7 +2712,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -2739,7 +2739,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -2766,7 +2766,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
@@ -882,7 +882,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -909,7 +909,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -936,7 +936,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -963,7 +963,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -990,7 +990,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1017,7 +1017,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1044,7 +1044,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1078,7 +1078,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1112,7 +1112,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1139,7 +1139,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1166,7 +1166,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1242,7 +1242,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1276,7 +1276,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1310,7 +1310,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1344,7 +1344,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1371,7 +1371,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1405,7 +1405,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1432,7 +1432,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1459,7 +1459,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1486,7 +1486,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics4.json
@@ -539,7 +539,7 @@
         "properties": {
           "value": {
             "metadata": {
-              "label": "value",
+              "label": "Value",
               "description": "The `json` value to be prettified"
             },
             "valueType": "EXPRESSION",
@@ -566,7 +566,7 @@
           },
           "indentation": {
             "metadata": {
-              "label": "indentation",
+              "label": "Indentation",
               "description": "The number of spaces for an indentation"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
@@ -200,7 +200,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -219,7 +219,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -246,7 +246,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -491,7 +491,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -518,7 +518,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -545,7 +545,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -572,7 +572,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -599,7 +599,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -626,7 +626,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -653,7 +653,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -687,7 +687,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -721,7 +721,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -748,7 +748,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -775,7 +775,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -851,7 +851,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -885,7 +885,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -919,7 +919,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -953,7 +953,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -980,7 +980,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1014,7 +1014,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1041,7 +1041,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1068,7 +1068,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1095,7 +1095,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
@@ -200,7 +200,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -219,7 +219,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -246,7 +246,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -542,7 +542,7 @@
                           },
                           "targetType": {
                             "metadata": {
-                              "label": "targetType",
+                              "label": "Target Type",
                               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                             },
                             "valueType": "TYPE",
@@ -561,7 +561,7 @@
                           },
                           "path": {
                             "metadata": {
-                              "label": "path",
+                              "label": "Path",
                               "description": "Resource path"
                             },
                             "valueType": "EXPRESSION",
@@ -588,7 +588,7 @@
                           },
                           "message": {
                             "metadata": {
-                              "label": "message",
+                              "label": "Message",
                               "description": "An HTTP outbound request or any allowed payload"
                             },
                             "valueType": "EXPRESSION",
@@ -615,7 +615,7 @@
                           },
                           "headers": {
                             "metadata": {
-                              "label": "headers",
+                              "label": "Headers",
                               "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
@@ -649,7 +649,7 @@
                           },
                           "mediaType": {
                             "metadata": {
-                              "label": "mediaType",
+                              "label": "Media Type",
                               "description": "The MIME type header of the request entity"
                             },
                             "valueType": "EXPRESSION",
@@ -899,7 +899,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -926,7 +926,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -953,7 +953,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -980,7 +980,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1007,7 +1007,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1034,7 +1034,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1061,7 +1061,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1095,7 +1095,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1129,7 +1129,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1156,7 +1156,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1183,7 +1183,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1259,7 +1259,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1293,7 +1293,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1327,7 +1327,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1361,7 +1361,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1388,7 +1388,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1422,7 +1422,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1449,7 +1449,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1476,7 +1476,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1503,7 +1503,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
@@ -126,7 +126,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -145,7 +145,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -172,7 +172,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -433,7 +433,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -460,7 +460,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -487,7 +487,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -514,7 +514,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -541,7 +541,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -568,7 +568,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -595,7 +595,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -629,7 +629,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -663,7 +663,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -690,7 +690,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -717,7 +717,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -793,7 +793,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -827,7 +827,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -861,7 +861,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -895,7 +895,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -922,7 +922,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -956,7 +956,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -983,7 +983,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1010,7 +1010,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1037,7 +1037,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -72,7 +72,7 @@
         "properties": {
           "v": {
             "metadata": {
-              "label": "v",
+              "label": "V",
               "description": "Source anydata value"
             },
             "valueType": "EXPRESSION",
@@ -183,7 +183,7 @@
         "properties": {
           "t": {
             "metadata": {
-              "label": "t",
+              "label": "T",
               "description": "Target type"
             },
             "valueType": "TYPE",
@@ -202,7 +202,7 @@
           },
           "v": {
             "metadata": {
-              "label": "v",
+              "label": "V",
               "description": "Source JSON value"
             },
             "valueType": "EXPRESSION",
@@ -229,7 +229,7 @@
           },
           "options": {
             "metadata": {
-              "label": "options",
+              "label": "Options",
               "description": "Options to be used for filtering in the projection"
             },
             "valueType": "EXPRESSION",
@@ -378,7 +378,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -405,7 +405,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -432,7 +432,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -459,7 +459,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -486,7 +486,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -513,7 +513,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -540,7 +540,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -574,7 +574,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -608,7 +608,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -635,7 +635,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -662,7 +662,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -738,7 +738,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -772,7 +772,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -806,7 +806,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -840,7 +840,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -867,7 +867,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -901,7 +901,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -928,7 +928,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -955,7 +955,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -982,7 +982,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork3.json
@@ -228,7 +228,7 @@
                 "properties": {
                   "seconds": {
                     "metadata": {
-                      "label": "seconds",
+                      "label": "Seconds",
                       "description": "An amount of time to sleep in seconds"
                     },
                     "valueType": "EXPRESSION",
@@ -386,7 +386,7 @@
                 "properties": {
                   "seconds": {
                     "metadata": {
-                      "label": "seconds",
+                      "label": "Seconds",
                       "description": "An amount of time to sleep in seconds"
                     },
                     "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork4.json
@@ -228,7 +228,7 @@
                 "properties": {
                   "seconds": {
                     "metadata": {
-                      "label": "seconds",
+                      "label": "Seconds",
                       "description": "An amount of time to sleep in seconds"
                     },
                     "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -72,7 +72,7 @@
         "properties": {
           "v": {
             "metadata": {
-              "label": "v",
+              "label": "V",
               "description": "Source anydata value"
             },
             "valueType": "EXPRESSION",
@@ -183,7 +183,7 @@
         "properties": {
           "t": {
             "metadata": {
-              "label": "t",
+              "label": "T",
               "description": "Target type"
             },
             "valueType": "TYPE",
@@ -202,7 +202,7 @@
           },
           "v": {
             "metadata": {
-              "label": "v",
+              "label": "V",
               "description": "Source JSON value"
             },
             "valueType": "EXPRESSION",
@@ -229,7 +229,7 @@
           },
           "options": {
             "metadata": {
-              "label": "options",
+              "label": "Options",
               "description": "Options to be used for filtering in the projection"
             },
             "valueType": "EXPRESSION",
@@ -378,7 +378,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -405,7 +405,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -432,7 +432,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -459,7 +459,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -486,7 +486,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -513,7 +513,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -540,7 +540,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -574,7 +574,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -608,7 +608,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -635,7 +635,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -662,7 +662,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -738,7 +738,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -772,7 +772,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -806,7 +806,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -840,7 +840,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -867,7 +867,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -901,7 +901,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -928,7 +928,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -955,7 +955,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -982,7 +982,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
@@ -129,7 +129,7 @@
                 "properties": {
                   "msg": {
                     "metadata": {
-                      "label": "msg",
+                      "label": "Msg",
                       "description": "The message to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -163,7 +163,7 @@
                   },
                   "error": {
                     "metadata": {
-                      "label": "error",
+                      "label": "Error",
                       "description": "The error struct to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -197,7 +197,7 @@
                   },
                   "stackTrace": {
                     "metadata": {
-                      "label": "stackTrace",
+                      "label": "Stack Trace",
                       "description": "The error stack trace to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -287,7 +287,7 @@
         "properties": {
           "msg": {
             "metadata": {
-              "label": "msg",
+              "label": "Msg",
               "description": "The message to be logged"
             },
             "valueType": "EXPRESSION",
@@ -321,7 +321,7 @@
           },
           "error": {
             "metadata": {
-              "label": "error",
+              "label": "Error",
               "description": "The error struct to be logged"
             },
             "valueType": "EXPRESSION",
@@ -355,7 +355,7 @@
           },
           "stackTrace": {
             "metadata": {
-              "label": "stackTrace",
+              "label": "Stack Trace",
               "description": "The error stack trace to be logged"
             },
             "valueType": "EXPRESSION",
@@ -461,7 +461,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -480,7 +480,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Request path"
             },
             "valueType": "EXPRESSION",
@@ -507,7 +507,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -670,7 +670,7 @@
                 "properties": {
                   "msg": {
                     "metadata": {
-                      "label": "msg",
+                      "label": "Msg",
                       "description": "The message to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -704,7 +704,7 @@
                   },
                   "error": {
                     "metadata": {
-                      "label": "error",
+                      "label": "Error",
                       "description": "The error struct to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -738,7 +738,7 @@
                   },
                   "stackTrace": {
                     "metadata": {
-                      "label": "stackTrace",
+                      "label": "Stack Trace",
                       "description": "The error stack trace to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -845,7 +845,7 @@
                 "properties": {
                   "msg": {
                     "metadata": {
-                      "label": "msg",
+                      "label": "Msg",
                       "description": "The message to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -879,7 +879,7 @@
                   },
                   "error": {
                     "metadata": {
-                      "label": "error",
+                      "label": "Error",
                       "description": "The error struct to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -913,7 +913,7 @@
                   },
                   "stackTrace": {
                     "metadata": {
-                      "label": "stackTrace",
+                      "label": "Stack Trace",
                       "description": "The error stack trace to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -1008,7 +1008,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1035,7 +1035,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1062,7 +1062,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1089,7 +1089,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1116,7 +1116,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1143,7 +1143,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1170,7 +1170,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1204,7 +1204,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1238,7 +1238,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1265,7 +1265,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1292,7 +1292,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1368,7 +1368,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1402,7 +1402,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1436,7 +1436,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1470,7 +1470,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1497,7 +1497,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1531,7 +1531,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1558,7 +1558,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1585,7 +1585,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1612,7 +1612,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log2.json
@@ -147,7 +147,7 @@
                 "properties": {
                   "msg": {
                     "metadata": {
-                      "label": "msg",
+                      "label": "Msg",
                       "description": "The message to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -181,7 +181,7 @@
                   },
                   "error": {
                     "metadata": {
-                      "label": "error",
+                      "label": "Error",
                       "description": "The error struct to be logged"
                     },
                     "valueType": "EXPRESSION",
@@ -216,7 +216,7 @@
                   },
                   "stackTrace": {
                     "metadata": {
-                      "label": "stackTrace",
+                      "label": "Stack Trace",
                       "description": "The error stack trace to be logged"
                     },
                     "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
@@ -1008,7 +1008,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1035,7 +1035,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1062,7 +1062,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1089,7 +1089,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1116,7 +1116,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1143,7 +1143,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1170,7 +1170,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1204,7 +1204,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1238,7 +1238,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1265,7 +1265,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1292,7 +1292,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1368,7 +1368,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1402,7 +1402,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1436,7 +1436,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1470,7 +1470,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1497,7 +1497,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1531,7 +1531,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1558,7 +1558,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1585,7 +1585,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1612,7 +1612,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
@@ -388,7 +388,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -415,7 +415,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -442,7 +442,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -469,7 +469,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -523,7 +523,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -550,7 +550,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -584,7 +584,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -618,7 +618,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -748,7 +748,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -782,7 +782,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -816,7 +816,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -850,7 +850,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -877,7 +877,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -911,7 +911,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -938,7 +938,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -965,7 +965,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -992,7 +992,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
@@ -384,7 +384,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -411,7 +411,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -438,7 +438,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -465,7 +465,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -492,7 +492,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -519,7 +519,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -546,7 +546,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -580,7 +580,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -614,7 +614,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -641,7 +641,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -668,7 +668,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -744,7 +744,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -778,7 +778,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -812,7 +812,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -846,7 +846,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -873,7 +873,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -907,7 +907,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -934,7 +934,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -961,7 +961,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -988,7 +988,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
@@ -489,7 +489,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -516,7 +516,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -543,7 +543,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -570,7 +570,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -597,7 +597,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -624,7 +624,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -651,7 +651,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -685,7 +685,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -719,7 +719,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -746,7 +746,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -773,7 +773,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -849,7 +849,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -883,7 +883,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -917,7 +917,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -951,7 +951,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -978,7 +978,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1012,7 +1012,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1039,7 +1039,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1066,7 +1066,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1093,7 +1093,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -632,7 +632,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -659,7 +659,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -686,7 +686,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -713,7 +713,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -740,7 +740,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -767,7 +767,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -794,7 +794,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -828,7 +828,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -862,7 +862,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -889,7 +889,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -916,7 +916,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -992,7 +992,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1026,7 +1026,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1060,7 +1060,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1094,7 +1094,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1121,7 +1121,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1155,7 +1155,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1182,7 +1182,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1209,7 +1209,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1236,7 +1236,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
@@ -558,7 +558,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -585,7 +585,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -612,7 +612,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -639,7 +639,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -666,7 +666,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -693,7 +693,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -720,7 +720,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -754,7 +754,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -788,7 +788,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -815,7 +815,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -842,7 +842,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -918,7 +918,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -952,7 +952,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -986,7 +986,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1020,7 +1020,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1047,7 +1047,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1081,7 +1081,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1108,7 +1108,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1135,7 +1135,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1162,7 +1162,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
@@ -309,7 +309,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -336,7 +336,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -363,7 +363,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -390,7 +390,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -417,7 +417,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -444,7 +444,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -471,7 +471,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -505,7 +505,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -539,7 +539,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -566,7 +566,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -593,7 +593,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -669,7 +669,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -703,7 +703,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -737,7 +737,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -771,7 +771,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -798,7 +798,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -832,7 +832,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -859,7 +859,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -886,7 +886,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -913,7 +913,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
@@ -287,7 +287,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -314,7 +314,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -341,7 +341,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -368,7 +368,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -395,7 +395,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -422,7 +422,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -449,7 +449,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -483,7 +483,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -517,7 +517,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -544,7 +544,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -571,7 +571,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -647,7 +647,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -681,7 +681,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -715,7 +715,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -749,7 +749,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -776,7 +776,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -810,7 +810,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -837,7 +837,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -864,7 +864,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -891,7 +891,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
@@ -432,7 +432,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -459,7 +459,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -486,7 +486,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -513,7 +513,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -540,7 +540,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -567,7 +567,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -594,7 +594,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -628,7 +628,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -662,7 +662,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -689,7 +689,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -716,7 +716,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -792,7 +792,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -826,7 +826,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -860,7 +860,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -894,7 +894,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -921,7 +921,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -955,7 +955,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -982,7 +982,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1009,7 +1009,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1036,7 +1036,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
@@ -507,7 +507,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -534,7 +534,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -561,7 +561,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -588,7 +588,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -615,7 +615,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -642,7 +642,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -669,7 +669,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -703,7 +703,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -737,7 +737,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -764,7 +764,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -791,7 +791,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -867,7 +867,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -901,7 +901,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -935,7 +935,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -969,7 +969,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -996,7 +996,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1030,7 +1030,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1057,7 +1057,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1084,7 +1084,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1111,7 +1111,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
@@ -357,7 +357,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -384,7 +384,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -411,7 +411,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -438,7 +438,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -465,7 +465,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -492,7 +492,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -519,7 +519,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -553,7 +553,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -587,7 +587,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -614,7 +614,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -641,7 +641,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -717,7 +717,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -751,7 +751,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -785,7 +785,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -819,7 +819,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -846,7 +846,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -880,7 +880,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -907,7 +907,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -934,7 +934,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -961,7 +961,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
@@ -388,7 +388,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -415,7 +415,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -442,7 +442,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -469,7 +469,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -523,7 +523,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -550,7 +550,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -584,7 +584,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -618,7 +618,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -748,7 +748,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -782,7 +782,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -816,7 +816,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -850,7 +850,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -877,7 +877,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -911,7 +911,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -938,7 +938,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -965,7 +965,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -992,7 +992,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call2.json
@@ -605,7 +605,7 @@
         "properties": {
           "s": {
             "metadata": {
-              "label": "s",
+              "label": "S",
               "description": "string representation of a integer value"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call3.json
@@ -127,7 +127,7 @@
         "properties": {
           "$connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -161,7 +161,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -188,7 +188,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -215,7 +215,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
@@ -108,7 +108,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -135,7 +135,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -162,7 +162,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -189,7 +189,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -216,7 +216,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -243,7 +243,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -270,7 +270,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -304,7 +304,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -338,7 +338,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -365,7 +365,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -392,7 +392,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -468,7 +468,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -502,7 +502,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -536,7 +536,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -570,7 +570,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -597,7 +597,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -631,7 +631,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -658,7 +658,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -685,7 +685,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -712,7 +712,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
@@ -187,7 +187,7 @@
                           },
                           "targetType": {
                             "metadata": {
-                              "label": "targetType",
+                              "label": "Target Type",
                               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                             },
                             "valueType": "TYPE",
@@ -206,7 +206,7 @@
                           },
                           "path": {
                             "metadata": {
-                              "label": "path",
+                              "label": "Path",
                               "description": "Request path"
                             },
                             "valueType": "EXPRESSION",
@@ -233,7 +233,7 @@
                           },
                           "headers": {
                             "metadata": {
-                              "label": "headers",
+                              "label": "Headers",
                               "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
@@ -386,7 +386,7 @@
                           },
                           "targetType": {
                             "metadata": {
-                              "label": "targetType",
+                              "label": "Target Type",
                               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                             },
                             "valueType": "TYPE",
@@ -405,7 +405,7 @@
                           },
                           "path": {
                             "metadata": {
-                              "label": "path",
+                              "label": "Path",
                               "description": "Request path"
                             },
                             "valueType": "EXPRESSION",
@@ -432,7 +432,7 @@
                           },
                           "headers": {
                             "metadata": {
-                              "label": "headers",
+                              "label": "Headers",
                               "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
@@ -625,7 +625,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -652,7 +652,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -679,7 +679,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -706,7 +706,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -733,7 +733,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -760,7 +760,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -787,7 +787,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -821,7 +821,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -855,7 +855,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -882,7 +882,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -909,7 +909,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -985,7 +985,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1019,7 +1019,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1053,7 +1053,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1087,7 +1087,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1114,7 +1114,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1148,7 +1148,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1175,7 +1175,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1202,7 +1202,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1229,7 +1229,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
@@ -105,7 +105,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -132,7 +132,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -159,7 +159,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -186,7 +186,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -213,7 +213,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -240,7 +240,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -267,7 +267,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -301,7 +301,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -335,7 +335,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -362,7 +362,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -389,7 +389,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -465,7 +465,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -499,7 +499,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -533,7 +533,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -567,7 +567,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -594,7 +594,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -628,7 +628,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -655,7 +655,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -682,7 +682,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -709,7 +709,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
@@ -108,7 +108,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -135,7 +135,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -162,7 +162,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -189,7 +189,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -216,7 +216,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -243,7 +243,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -270,7 +270,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -304,7 +304,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -338,7 +338,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -365,7 +365,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -392,7 +392,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -468,7 +468,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -502,7 +502,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -536,7 +536,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -570,7 +570,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -597,7 +597,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -631,7 +631,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -658,7 +658,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -685,7 +685,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -712,7 +712,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
@@ -108,7 +108,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -135,7 +135,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -162,7 +162,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -189,7 +189,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -216,7 +216,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -243,7 +243,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -270,7 +270,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -304,7 +304,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -338,7 +338,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -365,7 +365,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -392,7 +392,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -468,7 +468,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -502,7 +502,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -536,7 +536,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -570,7 +570,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -597,7 +597,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -631,7 +631,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -658,7 +658,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -685,7 +685,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -712,7 +712,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node6.json
@@ -449,7 +449,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -476,7 +476,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -503,7 +503,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -530,7 +530,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -557,7 +557,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -584,7 +584,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -611,7 +611,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -679,7 +679,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -706,7 +706,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -733,7 +733,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -809,7 +809,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -843,7 +843,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -877,7 +877,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -911,7 +911,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -938,7 +938,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -972,7 +972,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -999,7 +999,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1026,7 +1026,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1053,7 +1053,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
@@ -68,7 +68,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -95,7 +95,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -122,7 +122,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -149,7 +149,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -176,7 +176,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -203,7 +203,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -230,7 +230,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -264,7 +264,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -298,7 +298,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -325,7 +325,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -352,7 +352,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -428,7 +428,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -462,7 +462,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -530,7 +530,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -557,7 +557,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -591,7 +591,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -618,7 +618,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -800,7 +800,7 @@
         "properties": {
           "$connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -834,7 +834,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -861,7 +861,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -888,7 +888,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",
@@ -1011,7 +1011,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1038,7 +1038,7 @@
           },
           "config": {
             "metadata": {
-              "label": "config",
+              "label": "Config",
               "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
@@ -1159,7 +1159,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1186,7 +1186,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1213,7 +1213,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1240,7 +1240,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1267,7 +1267,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1294,7 +1294,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1321,7 +1321,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1355,7 +1355,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1389,7 +1389,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1416,7 +1416,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1443,7 +1443,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1519,7 +1519,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1553,7 +1553,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1587,7 +1587,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1621,7 +1621,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1648,7 +1648,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1682,7 +1682,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1709,7 +1709,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1736,7 +1736,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1763,7 +1763,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -1891,7 +1891,7 @@
         "properties": {
           "$connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -1925,7 +1925,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -1952,7 +1952,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -1979,7 +1979,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",
@@ -2100,7 +2100,7 @@
         "properties": {
           "connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -2134,7 +2134,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -2161,7 +2161,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -2188,7 +2188,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
@@ -68,7 +68,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -95,7 +95,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -122,7 +122,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -149,7 +149,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -176,7 +176,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -203,7 +203,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -230,7 +230,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -264,7 +264,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -298,7 +298,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -325,7 +325,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -352,7 +352,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -428,7 +428,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -462,7 +462,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -530,7 +530,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -557,7 +557,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -591,7 +591,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -618,7 +618,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -800,7 +800,7 @@
         "properties": {
           "connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -834,7 +834,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -861,7 +861,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -888,7 +888,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",
@@ -1011,7 +1011,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1038,7 +1038,7 @@
           },
           "config": {
             "metadata": {
-              "label": "config",
+              "label": "Config",
               "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
@@ -1159,7 +1159,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1186,7 +1186,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1213,7 +1213,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1240,7 +1240,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1267,7 +1267,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1294,7 +1294,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1321,7 +1321,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1355,7 +1355,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1389,7 +1389,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1416,7 +1416,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1443,7 +1443,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1519,7 +1519,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1553,7 +1553,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1587,7 +1587,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1621,7 +1621,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1648,7 +1648,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1682,7 +1682,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1709,7 +1709,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1736,7 +1736,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1763,7 +1763,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -1891,7 +1891,7 @@
         "properties": {
           "$connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -1925,7 +1925,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -1952,7 +1952,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -1979,7 +1979,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",
@@ -2100,7 +2100,7 @@
         "properties": {
           "connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -2134,7 +2134,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -2161,7 +2161,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -2188,7 +2188,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
@@ -67,7 +67,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -94,7 +94,7 @@
           },
           "config": {
             "metadata": {
-              "label": "config",
+              "label": "Config",
               "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
@@ -215,7 +215,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -242,7 +242,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -269,7 +269,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -296,7 +296,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -323,7 +323,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -350,7 +350,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -377,7 +377,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -411,7 +411,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -445,7 +445,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -472,7 +472,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -499,7 +499,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -575,7 +575,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -609,7 +609,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -643,7 +643,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -677,7 +677,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -704,7 +704,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -738,7 +738,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -765,7 +765,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -792,7 +792,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -819,7 +819,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -947,7 +947,7 @@
         "properties": {
           "$connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -981,7 +981,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -1008,7 +1008,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -1035,7 +1035,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",
@@ -1156,7 +1156,7 @@
         "properties": {
           "connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -1190,7 +1190,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -1217,7 +1217,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -1244,7 +1244,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",
@@ -1365,7 +1365,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1392,7 +1392,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1419,7 +1419,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1446,7 +1446,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1473,7 +1473,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1500,7 +1500,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1527,7 +1527,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1561,7 +1561,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1595,7 +1595,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1622,7 +1622,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1649,7 +1649,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1725,7 +1725,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1759,7 +1759,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1793,7 +1793,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1827,7 +1827,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1854,7 +1854,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1888,7 +1888,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1915,7 +1915,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1942,7 +1942,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1969,7 +1969,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -2097,7 +2097,7 @@
         "properties": {
           "$connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -2131,7 +2131,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -2158,7 +2158,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -2185,7 +2185,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection4.json
@@ -68,7 +68,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -95,7 +95,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -122,7 +122,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -149,7 +149,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -176,7 +176,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -203,7 +203,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -230,7 +230,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -264,7 +264,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -298,7 +298,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -325,7 +325,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -352,7 +352,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -428,7 +428,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -462,7 +462,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -530,7 +530,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -557,7 +557,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -591,7 +591,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -618,7 +618,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -800,7 +800,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -827,7 +827,7 @@
           },
           "config": {
             "metadata": {
-              "label": "config",
+              "label": "Config",
               "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
@@ -948,7 +948,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -975,7 +975,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1052,7 +1052,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1079,7 +1079,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1106,7 +1106,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1133,7 +1133,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1160,7 +1160,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1187,7 +1187,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1221,7 +1221,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1255,7 +1255,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1282,7 +1282,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1309,7 +1309,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1343,7 +1343,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1377,7 +1377,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1411,7 +1411,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1438,7 +1438,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1472,7 +1472,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1499,7 +1499,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1526,7 +1526,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1553,7 +1553,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get1.json
@@ -80,7 +80,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -99,7 +99,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Request path"
             },
             "valueType": "EXPRESSION",
@@ -126,7 +126,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -245,7 +245,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -264,7 +264,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Request path"
             },
             "valueType": "EXPRESSION",
@@ -291,7 +291,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -397,7 +397,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -424,7 +424,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -451,7 +451,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -478,7 +478,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -505,7 +505,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -532,7 +532,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -559,7 +559,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -593,7 +593,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -627,7 +627,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -654,7 +654,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -681,7 +681,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -757,7 +757,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -791,7 +791,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -825,7 +825,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -859,7 +859,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -886,7 +886,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -920,7 +920,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -947,7 +947,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -974,7 +974,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1001,7 +1001,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
@@ -83,7 +83,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -102,7 +102,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Request path"
             },
             "valueType": "EXPRESSION",
@@ -129,7 +129,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -260,7 +260,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -279,7 +279,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Request path"
             },
             "valueType": "EXPRESSION",
@@ -306,7 +306,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -398,7 +398,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -417,7 +417,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Request path"
             },
             "valueType": "EXPRESSION",
@@ -444,7 +444,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -562,7 +562,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -589,7 +589,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -616,7 +616,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -643,7 +643,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -670,7 +670,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -697,7 +697,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -724,7 +724,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -758,7 +758,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -792,7 +792,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -819,7 +819,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -846,7 +846,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -922,7 +922,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -956,7 +956,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -990,7 +990,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1024,7 +1024,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1051,7 +1051,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1085,7 +1085,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1112,7 +1112,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1139,7 +1139,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1166,7 +1166,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
@@ -68,7 +68,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -95,7 +95,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -122,7 +122,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -149,7 +149,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -176,7 +176,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -203,7 +203,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -230,7 +230,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -264,7 +264,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -298,7 +298,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -325,7 +325,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -352,7 +352,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -428,7 +428,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -462,7 +462,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -530,7 +530,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -557,7 +557,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -591,7 +591,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -618,7 +618,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -840,7 +840,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -867,7 +867,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -894,7 +894,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -921,7 +921,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -948,7 +948,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -975,7 +975,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1002,7 +1002,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1036,7 +1036,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1070,7 +1070,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1097,7 +1097,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1124,7 +1124,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1200,7 +1200,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1234,7 +1234,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1268,7 +1268,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1302,7 +1302,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1329,7 +1329,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1363,7 +1363,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1390,7 +1390,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1417,7 +1417,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1444,7 +1444,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post1.json
@@ -80,7 +80,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -99,7 +99,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Resource path"
             },
             "valueType": "EXPRESSION",
@@ -126,7 +126,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -153,7 +153,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -187,7 +187,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -347,7 +347,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -366,7 +366,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -393,7 +393,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -427,7 +427,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -527,7 +527,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -554,7 +554,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -581,7 +581,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -608,7 +608,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -635,7 +635,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -662,7 +662,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -689,7 +689,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -723,7 +723,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -757,7 +757,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -784,7 +784,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -811,7 +811,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -887,7 +887,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -921,7 +921,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -955,7 +955,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -989,7 +989,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1016,7 +1016,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1050,7 +1050,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1077,7 +1077,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1104,7 +1104,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1131,7 +1131,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
@@ -83,7 +83,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -102,7 +102,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Resource path"
             },
             "valueType": "EXPRESSION",
@@ -129,7 +129,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -156,7 +156,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -190,7 +190,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -321,7 +321,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -340,7 +340,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
+              "label": "Path",
               "description": "Resource path"
             },
             "valueType": "EXPRESSION",
@@ -367,7 +367,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -394,7 +394,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -428,7 +428,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -545,7 +545,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -572,7 +572,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -599,7 +599,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -626,7 +626,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -653,7 +653,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -680,7 +680,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -707,7 +707,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -741,7 +741,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -775,7 +775,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -802,7 +802,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -829,7 +829,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -905,7 +905,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -939,7 +939,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -973,7 +973,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1007,7 +1007,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1034,7 +1034,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1068,7 +1068,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1095,7 +1095,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1122,7 +1122,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1149,7 +1149,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
@@ -68,7 +68,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -95,7 +95,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -122,7 +122,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -149,7 +149,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -176,7 +176,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -203,7 +203,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -230,7 +230,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -264,7 +264,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -298,7 +298,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -325,7 +325,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -352,7 +352,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -428,7 +428,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -462,7 +462,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -530,7 +530,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -557,7 +557,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -591,7 +591,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -618,7 +618,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -840,7 +840,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -867,7 +867,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -894,7 +894,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -921,7 +921,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -948,7 +948,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -975,7 +975,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1002,7 +1002,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1036,7 +1036,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1070,7 +1070,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1097,7 +1097,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1124,7 +1124,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1200,7 +1200,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1234,7 +1234,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1268,7 +1268,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1302,7 +1302,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1329,7 +1329,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1363,7 +1363,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1390,7 +1390,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1417,7 +1417,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1444,7 +1444,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-mysql1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-mysql1.json
@@ -82,7 +82,7 @@
           },
           "sqlQuery": {
             "metadata": {
-              "label": "sqlQuery",
+              "label": "SQL Query",
               "description": "The SQL query such as `` `SELECT * from Album WHERE name=${albumName}` ``"
             },
             "valueType": "RAW_TEMPLATE",
@@ -113,7 +113,7 @@
           },
           "rowType": {
             "metadata": {
-              "label": "rowType",
+              "label": "Row Type",
               "description": "The `typedesc` of the record to which the result needs to be returned"
             },
             "valueType": "TYPE",
@@ -225,7 +225,7 @@
           },
           "sqlQuery": {
             "metadata": {
-              "label": "sqlQuery",
+              "label": "SQL Query",
               "description": "The SQL query such as `` `SELECT * from Album WHERE name=${albumName}` ``"
             },
             "valueType": "RAW_TEMPLATE",
@@ -256,7 +256,7 @@
           },
           "rowType": {
             "metadata": {
-              "label": "rowType",
+              "label": "Row Type",
               "description": "The `typedesc` of the record to which the result needs to be returned"
             },
             "valueType": "TYPE",
@@ -356,7 +356,7 @@
         "properties": {
           "host": {
             "metadata": {
-              "label": "host",
+              "label": "Host",
               "description": "Hostname of the MySQL server"
             },
             "valueType": "EXPRESSION",
@@ -383,7 +383,7 @@
           },
           "user": {
             "metadata": {
-              "label": "user",
+              "label": "User",
               "description": "If the MySQL server is secured, the username"
             },
             "valueType": "EXPRESSION",
@@ -417,7 +417,7 @@
           },
           "password": {
             "metadata": {
-              "label": "password",
+              "label": "Password",
               "description": "The password of the MySQL server for the provided username"
             },
             "valueType": "EXPRESSION",
@@ -451,7 +451,7 @@
           },
           "database": {
             "metadata": {
-              "label": "database",
+              "label": "Database",
               "description": "The name of the database"
             },
             "valueType": "EXPRESSION",
@@ -485,7 +485,7 @@
           },
           "port": {
             "metadata": {
-              "label": "port",
+              "label": "Port",
               "description": "Port number of the MySQL server"
             },
             "valueType": "EXPRESSION",
@@ -512,7 +512,7 @@
           },
           "options": {
             "metadata": {
-              "label": "options",
+              "label": "Options",
               "description": "MySQL database options"
             },
             "valueType": "EXPRESSION",
@@ -546,7 +546,7 @@
           },
           "connectionPool": {
             "metadata": {
-              "label": "connectionPool",
+              "label": "Connection Pool",
               "description": "The `sql:ConnectionPool` to be used for the connection. If there is no\n`connectionPool` provided, the global connection pool (shared by all clients) will be used"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-mysql2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-mysql2.json
@@ -83,7 +83,7 @@
           },
           "sqlQuery": {
             "metadata": {
-              "label": "sqlQuery",
+              "label": "SQL Query",
               "description": "The SQL query such as `` `SELECT * from Album WHERE name=${albumName}` ``"
             },
             "valueType": "RAW_TEMPLATE",
@@ -129,7 +129,7 @@
           },
           "returnType": {
             "metadata": {
-              "label": "returnType",
+              "label": "Return Type",
               "description": "The `typedesc` of the record to which the result needs to be returned.\nIt can be a basic type if the query result contains only one column"
             },
             "valueType": "TYPE",
@@ -229,7 +229,7 @@
         "properties": {
           "host": {
             "metadata": {
-              "label": "host",
+              "label": "Host",
               "description": "Hostname of the MySQL server"
             },
             "valueType": "EXPRESSION",
@@ -256,7 +256,7 @@
           },
           "user": {
             "metadata": {
-              "label": "user",
+              "label": "User",
               "description": "If the MySQL server is secured, the username"
             },
             "valueType": "EXPRESSION",
@@ -290,7 +290,7 @@
           },
           "password": {
             "metadata": {
-              "label": "password",
+              "label": "Password",
               "description": "The password of the MySQL server for the provided username"
             },
             "valueType": "EXPRESSION",
@@ -324,7 +324,7 @@
           },
           "database": {
             "metadata": {
-              "label": "database",
+              "label": "Database",
               "description": "The name of the database"
             },
             "valueType": "EXPRESSION",
@@ -358,7 +358,7 @@
           },
           "port": {
             "metadata": {
-              "label": "port",
+              "label": "Port",
               "description": "Port number of the MySQL server"
             },
             "valueType": "EXPRESSION",
@@ -385,7 +385,7 @@
           },
           "options": {
             "metadata": {
-              "label": "options",
+              "label": "Options",
               "description": "MySQL database options"
             },
             "valueType": "EXPRESSION",
@@ -419,7 +419,7 @@
           },
           "connectionPool": {
             "metadata": {
-              "label": "connectionPool",
+              "label": "Connection Pool",
               "description": "The `sql:ConnectionPool` to be used for the connection. If there is no\n`connectionPool` provided, the global connection pool (shared by all clients) will be used"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
@@ -124,7 +124,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -143,7 +143,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -309,7 +309,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -328,7 +328,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -501,7 +501,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -520,7 +520,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -686,7 +686,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -705,7 +705,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -875,7 +875,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -894,7 +894,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -1060,7 +1060,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -1079,7 +1079,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -1246,7 +1246,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -1265,7 +1265,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -1431,7 +1431,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -1450,7 +1450,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -1616,7 +1616,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -1635,7 +1635,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -1746,7 +1746,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1773,7 +1773,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1800,7 +1800,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1827,7 +1827,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1854,7 +1854,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1881,7 +1881,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1908,7 +1908,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1942,7 +1942,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1976,7 +1976,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -2003,7 +2003,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -2030,7 +2030,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -2106,7 +2106,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -2140,7 +2140,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -2174,7 +2174,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -2208,7 +2208,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -2235,7 +2235,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -2269,7 +2269,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -2296,7 +2296,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -2323,7 +2323,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -2350,7 +2350,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
@@ -124,7 +124,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -143,7 +143,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -170,7 +170,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -204,7 +204,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -370,7 +370,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -389,7 +389,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -416,7 +416,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -450,7 +450,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -617,7 +617,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -636,7 +636,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -663,7 +663,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -697,7 +697,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -863,7 +863,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -882,7 +882,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -909,7 +909,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -943,7 +943,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -1113,7 +1113,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -1132,7 +1132,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -1159,7 +1159,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -1194,7 +1194,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -1360,7 +1360,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -1379,7 +1379,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -1406,7 +1406,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -1440,7 +1440,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -1606,7 +1606,7 @@
           },
           "targetType": {
             "metadata": {
-              "label": "targetType",
+              "label": "Target Type",
               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "TYPE",
@@ -1625,7 +1625,7 @@
           },
           "message": {
             "metadata": {
-              "label": "message",
+              "label": "Message",
               "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
@@ -1652,7 +1652,7 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
+              "label": "Headers",
               "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
@@ -1686,7 +1686,7 @@
           },
           "mediaType": {
             "metadata": {
-              "label": "mediaType",
+              "label": "Media Type",
               "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
@@ -1798,7 +1798,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1825,7 +1825,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1852,7 +1852,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1879,7 +1879,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1906,7 +1906,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1933,7 +1933,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1960,7 +1960,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1994,7 +1994,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -2028,7 +2028,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -2055,7 +2055,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -2082,7 +2082,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -2158,7 +2158,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -2192,7 +2192,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -2226,7 +2226,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -2260,7 +2260,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -2287,7 +2287,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -2321,7 +2321,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -2348,7 +2348,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -2375,7 +2375,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -2402,7 +2402,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
@@ -141,7 +141,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -160,7 +160,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -187,7 +187,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -378,7 +378,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -397,7 +397,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -424,7 +424,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -585,7 +585,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -612,7 +612,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -639,7 +639,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -666,7 +666,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -693,7 +693,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -720,7 +720,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -747,7 +747,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -781,7 +781,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -815,7 +815,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -842,7 +842,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -869,7 +869,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -945,7 +945,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -979,7 +979,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1013,7 +1013,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1047,7 +1047,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1074,7 +1074,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1108,7 +1108,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1135,7 +1135,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1162,7 +1162,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1189,7 +1189,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -1317,7 +1317,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -1344,7 +1344,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -1371,7 +1371,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -1398,7 +1398,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -1425,7 +1425,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -1452,7 +1452,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -1479,7 +1479,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -1513,7 +1513,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1547,7 +1547,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1574,7 +1574,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1601,7 +1601,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1677,7 +1677,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1711,7 +1711,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1745,7 +1745,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1779,7 +1779,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1806,7 +1806,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1840,7 +1840,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1867,7 +1867,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1894,7 +1894,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1921,7 +1921,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait7.json
@@ -150,7 +150,7 @@
                 "properties": {
                   "seconds": {
                     "metadata": {
-                      "label": "seconds",
+                      "label": "Seconds",
                       "description": "An amount of time to sleep in seconds"
                     },
                     "valueType": "EXPRESSION",
@@ -308,7 +308,7 @@
                 "properties": {
                   "seconds": {
                     "metadata": {
-                      "label": "seconds",
+                      "label": "Seconds",
                       "description": "An amount of time to sleep in seconds"
                     },
                     "valueType": "EXPRESSION",
@@ -466,7 +466,7 @@
                 "properties": {
                   "seconds": {
                     "metadata": {
-                      "label": "seconds",
+                      "label": "Seconds",
                       "description": "An amount of time to sleep in seconds"
                     },
                     "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -282,7 +282,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -301,7 +301,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -328,7 +328,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -689,7 +689,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -716,7 +716,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -743,7 +743,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -770,7 +770,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -797,7 +797,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -824,7 +824,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -851,7 +851,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -885,7 +885,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -919,7 +919,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -946,7 +946,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -973,7 +973,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1049,7 +1049,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1083,7 +1083,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1117,7 +1117,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1151,7 +1151,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1178,7 +1178,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1212,7 +1212,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1239,7 +1239,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1266,7 +1266,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1293,7 +1293,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
@@ -129,7 +129,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -156,7 +156,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -183,7 +183,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -210,7 +210,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -237,7 +237,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -264,7 +264,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -291,7 +291,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -325,7 +325,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -359,7 +359,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -386,7 +386,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -413,7 +413,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -489,7 +489,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -523,7 +523,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -557,7 +557,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -591,7 +591,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -618,7 +618,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -652,7 +652,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -679,7 +679,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -706,7 +706,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -733,7 +733,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -282,7 +282,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -301,7 +301,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -328,7 +328,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -626,7 +626,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -653,7 +653,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -680,7 +680,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -707,7 +707,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -734,7 +734,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -761,7 +761,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -788,7 +788,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -822,7 +822,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -856,7 +856,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -883,7 +883,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -910,7 +910,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -986,7 +986,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1020,7 +1020,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1054,7 +1054,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1088,7 +1088,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1115,7 +1115,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1149,7 +1149,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1176,7 +1176,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1203,7 +1203,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1230,7 +1230,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -282,7 +282,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -301,7 +301,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -328,7 +328,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -666,7 +666,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -693,7 +693,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -720,7 +720,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -747,7 +747,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -774,7 +774,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -801,7 +801,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -828,7 +828,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -862,7 +862,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -896,7 +896,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -923,7 +923,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -950,7 +950,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1026,7 +1026,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1060,7 +1060,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1094,7 +1094,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1128,7 +1128,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1155,7 +1155,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1189,7 +1189,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1216,7 +1216,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1243,7 +1243,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1270,7 +1270,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
@@ -284,7 +284,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -303,7 +303,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -330,7 +330,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -661,7 +661,7 @@
                 "properties": {
                   "url": {
                     "metadata": {
-                      "label": "url",
+                      "label": "Url",
                       "description": "URL of the target service"
                     },
                     "valueType": "EXPRESSION",
@@ -688,7 +688,7 @@
                   },
                   "httpVersion": {
                     "metadata": {
-                      "label": "httpVersion",
+                      "label": "HTTP Version",
                       "description": "The HTTP version understood by the client"
                     },
                     "valueType": "EXPRESSION",
@@ -715,7 +715,7 @@
                   },
                   "http1Settings": {
                     "metadata": {
-                      "label": "http1Settings",
+                      "label": "HTTP1 Settings",
                       "description": "Configurations related to HTTP/1.x protocol"
                     },
                     "valueType": "EXPRESSION",
@@ -742,7 +742,7 @@
                   },
                   "http2Settings": {
                     "metadata": {
-                      "label": "http2Settings",
+                      "label": "HTTP2 Settings",
                       "description": "Configurations related to HTTP/2 protocol"
                     },
                     "valueType": "EXPRESSION",
@@ -769,7 +769,7 @@
                   },
                   "timeout": {
                     "metadata": {
-                      "label": "timeout",
+                      "label": "Timeout",
                       "description": "The maximum time to wait (in seconds) for a response before closing the connection"
                     },
                     "valueType": "EXPRESSION",
@@ -796,7 +796,7 @@
                   },
                   "forwarded": {
                     "metadata": {
-                      "label": "forwarded",
+                      "label": "Forwarded",
                       "description": "The choice of setting `forwarded`/`x-forwarded` header"
                     },
                     "valueType": "EXPRESSION",
@@ -823,7 +823,7 @@
                   },
                   "followRedirects": {
                     "metadata": {
-                      "label": "followRedirects",
+                      "label": "Follow Redirects",
                       "description": "Configurations associated with Redirection"
                     },
                     "valueType": "EXPRESSION",
@@ -857,7 +857,7 @@
                   },
                   "poolConfig": {
                     "metadata": {
-                      "label": "poolConfig",
+                      "label": "Pool Config",
                       "description": "Configurations associated with request pooling"
                     },
                     "valueType": "EXPRESSION",
@@ -891,7 +891,7 @@
                   },
                   "cache": {
                     "metadata": {
-                      "label": "cache",
+                      "label": "Cache",
                       "description": "HTTP caching related configurations"
                     },
                     "valueType": "EXPRESSION",
@@ -918,7 +918,7 @@
                   },
                   "compression": {
                     "metadata": {
-                      "label": "compression",
+                      "label": "Compression",
                       "description": "Specifies the way of handling compression (`accept-encoding`) header"
                     },
                     "valueType": "EXPRESSION",
@@ -945,7 +945,7 @@
                   },
                   "auth": {
                     "metadata": {
-                      "label": "auth",
+                      "label": "Auth",
                       "description": "Configurations related to client authentication"
                     },
                     "valueType": "EXPRESSION",
@@ -1021,7 +1021,7 @@
                   },
                   "circuitBreaker": {
                     "metadata": {
-                      "label": "circuitBreaker",
+                      "label": "Circuit Breaker",
                       "description": "Configurations associated with the behaviour of the Circuit Breaker"
                     },
                     "valueType": "EXPRESSION",
@@ -1055,7 +1055,7 @@
                   },
                   "retryConfig": {
                     "metadata": {
-                      "label": "retryConfig",
+                      "label": "Retry Config",
                       "description": "Configurations associated with retrying"
                     },
                     "valueType": "EXPRESSION",
@@ -1089,7 +1089,7 @@
                   },
                   "cookieConfig": {
                     "metadata": {
-                      "label": "cookieConfig",
+                      "label": "Cookie Config",
                       "description": "Configurations associated with cookies"
                     },
                     "valueType": "EXPRESSION",
@@ -1123,7 +1123,7 @@
                   },
                   "responseLimits": {
                     "metadata": {
-                      "label": "responseLimits",
+                      "label": "Response Limits",
                       "description": "Configurations associated with inbound response size limits"
                     },
                     "valueType": "EXPRESSION",
@@ -1150,7 +1150,7 @@
                   },
                   "proxy": {
                     "metadata": {
-                      "label": "proxy",
+                      "label": "Proxy",
                       "description": "Proxy server related options"
                     },
                     "valueType": "EXPRESSION",
@@ -1184,7 +1184,7 @@
                   },
                   "validation": {
                     "metadata": {
-                      "label": "validation",
+                      "label": "Validation",
                       "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
                     },
                     "valueType": "EXPRESSION",
@@ -1211,7 +1211,7 @@
                   },
                   "socketConfig": {
                     "metadata": {
-                      "label": "socketConfig",
+                      "label": "Socket Config",
                       "description": "Provides settings related to client socket configuration"
                     },
                     "valueType": "EXPRESSION",
@@ -1238,7 +1238,7 @@
                   },
                   "laxDataBinding": {
                     "metadata": {
-                      "label": "laxDataBinding",
+                      "label": "Lax Data Binding",
                       "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
                     },
                     "valueType": "EXPRESSION",
@@ -1265,7 +1265,7 @@
                   },
                   "secureSocket": {
                     "metadata": {
-                      "label": "secureSocket",
+                      "label": "Secure Socket",
                       "description": "SSL/TLS-related options"
                     },
                     "valueType": "EXPRESSION",
@@ -1552,7 +1552,7 @@
                           },
                           "targetType": {
                             "metadata": {
-                              "label": "targetType",
+                              "label": "Target Type",
                               "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                             },
                             "valueType": "TYPE",
@@ -1571,7 +1571,7 @@
                           },
                           "path": {
                             "metadata": {
-                              "label": "path",
+                              "label": "Path",
                               "description": "Resource path"
                             },
                             "valueType": "EXPRESSION",
@@ -1598,7 +1598,7 @@
                           },
                           "message": {
                             "metadata": {
-                              "label": "message",
+                              "label": "Message",
                               "description": "An HTTP outbound request or any allowed payload"
                             },
                             "valueType": "EXPRESSION",
@@ -1625,7 +1625,7 @@
                           },
                           "headers": {
                             "metadata": {
-                              "label": "headers",
+                              "label": "Headers",
                               "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
@@ -1659,7 +1659,7 @@
                           },
                           "mediaType": {
                             "metadata": {
-                              "label": "mediaType",
+                              "label": "Media Type",
                               "description": "The MIME type header of the request entity"
                             },
                             "valueType": "EXPRESSION",
@@ -1991,7 +1991,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -2018,7 +2018,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -2045,7 +2045,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -2072,7 +2072,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -2099,7 +2099,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -2126,7 +2126,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -2153,7 +2153,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -2187,7 +2187,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -2221,7 +2221,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -2248,7 +2248,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -2275,7 +2275,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -2351,7 +2351,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -2385,7 +2385,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -2419,7 +2419,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -2453,7 +2453,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -2480,7 +2480,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -2514,7 +2514,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -2541,7 +2541,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -2568,7 +2568,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -2595,7 +2595,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -282,7 +282,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -301,7 +301,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -328,7 +328,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -701,7 +701,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -728,7 +728,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -755,7 +755,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -782,7 +782,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -809,7 +809,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -836,7 +836,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -863,7 +863,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -897,7 +897,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -931,7 +931,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -958,7 +958,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -985,7 +985,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1061,7 +1061,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1095,7 +1095,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1129,7 +1129,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1163,7 +1163,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1190,7 +1190,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1224,7 +1224,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1251,7 +1251,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1278,7 +1278,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1305,7 +1305,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -282,7 +282,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -301,7 +301,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -328,7 +328,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -701,7 +701,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -728,7 +728,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -755,7 +755,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -782,7 +782,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -809,7 +809,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -836,7 +836,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -863,7 +863,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -897,7 +897,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -931,7 +931,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -958,7 +958,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -985,7 +985,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1061,7 +1061,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1095,7 +1095,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1129,7 +1129,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1163,7 +1163,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1190,7 +1190,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1224,7 +1224,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1251,7 +1251,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1278,7 +1278,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1305,7 +1305,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -282,7 +282,7 @@
                   },
                   "targetType": {
                     "metadata": {
-                      "label": "targetType",
+                      "label": "Target Type",
                       "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
                     },
                     "valueType": "TYPE",
@@ -301,7 +301,7 @@
                   },
                   "path": {
                     "metadata": {
-                      "label": "path",
+                      "label": "Path",
                       "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
@@ -328,7 +328,7 @@
                   },
                   "headers": {
                     "metadata": {
-                      "label": "headers",
+                      "label": "Headers",
                       "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
@@ -788,7 +788,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -815,7 +815,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -842,7 +842,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -869,7 +869,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -896,7 +896,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -923,7 +923,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -950,7 +950,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -984,7 +984,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -1018,7 +1018,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -1045,7 +1045,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -1072,7 +1072,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -1148,7 +1148,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -1182,7 +1182,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -1216,7 +1216,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -1250,7 +1250,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -1277,7 +1277,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -1311,7 +1311,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -1338,7 +1338,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -1365,7 +1365,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1392,7 +1392,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
@@ -35,7 +35,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "The server URL"
             },
             "valueType": "EXPRESSION",
@@ -62,7 +62,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait(in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -89,7 +89,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Connection pool configuration"
             },
             "valueType": "EXPRESSION",
@@ -123,7 +123,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS related options"
             },
             "valueType": "EXPRESSION",
@@ -157,7 +157,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -184,7 +184,7 @@
           },
           "retryConfiguration": {
             "metadata": {
-              "label": "retryConfiguration",
+              "label": "Retry Configuration",
               "description": "Configures the retry functionality"
             },
             "valueType": "EXPRESSION",
@@ -218,7 +218,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -294,7 +294,7 @@
           },
           "maxInboundMessageSize": {
             "metadata": {
-              "label": "maxInboundMessageSize",
+              "label": "Max Inbound Message Size",
               "description": "The maximum message size to be permitted for inbound messages. Default value is 4 MB"
             },
             "valueType": "EXPRESSION",
@@ -415,7 +415,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -442,7 +442,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -469,7 +469,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -523,7 +523,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -550,7 +550,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -577,7 +577,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -611,7 +611,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -699,7 +699,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -775,7 +775,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -809,7 +809,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -843,7 +843,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -877,7 +877,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -904,7 +904,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -938,7 +938,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -965,7 +965,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -992,7 +992,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1019,7 +1019,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -1147,7 +1147,7 @@
         "properties": {
           "connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -1181,7 +1181,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -1208,7 +1208,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -1235,7 +1235,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
@@ -35,7 +35,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "The server URL"
             },
             "valueType": "EXPRESSION",
@@ -62,7 +62,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait(in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -89,7 +89,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Connection pool configuration"
             },
             "valueType": "EXPRESSION",
@@ -123,7 +123,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS related options"
             },
             "valueType": "EXPRESSION",
@@ -157,7 +157,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -184,7 +184,7 @@
           },
           "retryConfiguration": {
             "metadata": {
-              "label": "retryConfiguration",
+              "label": "Retry Configuration",
               "description": "Configures the retry functionality"
             },
             "valueType": "EXPRESSION",
@@ -218,7 +218,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -294,7 +294,7 @@
           },
           "maxInboundMessageSize": {
             "metadata": {
-              "label": "maxInboundMessageSize",
+              "label": "Max Inbound Message Size",
               "description": "The maximum message size to be permitted for inbound messages. Default value is 4 MB"
             },
             "valueType": "EXPRESSION",
@@ -415,7 +415,7 @@
         "properties": {
           "url": {
             "metadata": {
-              "label": "url",
+              "label": "Url",
               "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
@@ -442,7 +442,7 @@
           },
           "httpVersion": {
             "metadata": {
-              "label": "httpVersion",
+              "label": "HTTP Version",
               "description": "The HTTP version understood by the client"
             },
             "valueType": "EXPRESSION",
@@ -469,7 +469,7 @@
           },
           "http1Settings": {
             "metadata": {
-              "label": "http1Settings",
+              "label": "HTTP1 Settings",
               "description": "Configurations related to HTTP/1.x protocol"
             },
             "valueType": "EXPRESSION",
@@ -496,7 +496,7 @@
           },
           "http2Settings": {
             "metadata": {
-              "label": "http2Settings",
+              "label": "HTTP2 Settings",
               "description": "Configurations related to HTTP/2 protocol"
             },
             "valueType": "EXPRESSION",
@@ -523,7 +523,7 @@
           },
           "timeout": {
             "metadata": {
-              "label": "timeout",
+              "label": "Timeout",
               "description": "The maximum time to wait (in seconds) for a response before closing the connection"
             },
             "valueType": "EXPRESSION",
@@ -550,7 +550,7 @@
           },
           "forwarded": {
             "metadata": {
-              "label": "forwarded",
+              "label": "Forwarded",
               "description": "The choice of setting `forwarded`/`x-forwarded` header"
             },
             "valueType": "EXPRESSION",
@@ -577,7 +577,7 @@
           },
           "followRedirects": {
             "metadata": {
-              "label": "followRedirects",
+              "label": "Follow Redirects",
               "description": "Configurations associated with Redirection"
             },
             "valueType": "EXPRESSION",
@@ -611,7 +611,7 @@
           },
           "poolConfig": {
             "metadata": {
-              "label": "poolConfig",
+              "label": "Pool Config",
               "description": "Configurations associated with request pooling"
             },
             "valueType": "EXPRESSION",
@@ -645,7 +645,7 @@
           },
           "cache": {
             "metadata": {
-              "label": "cache",
+              "label": "Cache",
               "description": "HTTP caching related configurations"
             },
             "valueType": "EXPRESSION",
@@ -672,7 +672,7 @@
           },
           "compression": {
             "metadata": {
-              "label": "compression",
+              "label": "Compression",
               "description": "Specifies the way of handling compression (`accept-encoding`) header"
             },
             "valueType": "EXPRESSION",
@@ -699,7 +699,7 @@
           },
           "auth": {
             "metadata": {
-              "label": "auth",
+              "label": "Auth",
               "description": "Configurations related to client authentication"
             },
             "valueType": "EXPRESSION",
@@ -775,7 +775,7 @@
           },
           "circuitBreaker": {
             "metadata": {
-              "label": "circuitBreaker",
+              "label": "Circuit Breaker",
               "description": "Configurations associated with the behaviour of the Circuit Breaker"
             },
             "valueType": "EXPRESSION",
@@ -809,7 +809,7 @@
           },
           "retryConfig": {
             "metadata": {
-              "label": "retryConfig",
+              "label": "Retry Config",
               "description": "Configurations associated with retrying"
             },
             "valueType": "EXPRESSION",
@@ -843,7 +843,7 @@
           },
           "cookieConfig": {
             "metadata": {
-              "label": "cookieConfig",
+              "label": "Cookie Config",
               "description": "Configurations associated with cookies"
             },
             "valueType": "EXPRESSION",
@@ -877,7 +877,7 @@
           },
           "responseLimits": {
             "metadata": {
-              "label": "responseLimits",
+              "label": "Response Limits",
               "description": "Configurations associated with inbound response size limits"
             },
             "valueType": "EXPRESSION",
@@ -904,7 +904,7 @@
           },
           "proxy": {
             "metadata": {
-              "label": "proxy",
+              "label": "Proxy",
               "description": "Proxy server related options"
             },
             "valueType": "EXPRESSION",
@@ -938,7 +938,7 @@
           },
           "validation": {
             "metadata": {
-              "label": "validation",
+              "label": "Validation",
               "description": "Enables the inbound payload validation functionalty which provided by the constraint package. Enabled by default"
             },
             "valueType": "EXPRESSION",
@@ -965,7 +965,7 @@
           },
           "socketConfig": {
             "metadata": {
-              "label": "socketConfig",
+              "label": "Socket Config",
               "description": "Provides settings related to client socket configuration"
             },
             "valueType": "EXPRESSION",
@@ -992,7 +992,7 @@
           },
           "laxDataBinding": {
             "metadata": {
-              "label": "laxDataBinding",
+              "label": "Lax Data Binding",
               "description": "Enables or disables relaxed data binding on the client side. Disabled by default.\nWhen enabled, the JSON data will be projected to the Ballerina record type and\nduring the projection, nil values will be considered as optional fields and\nabsent fields will be considered for nilable types"
             },
             "valueType": "EXPRESSION",
@@ -1019,7 +1019,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket",
               "description": "SSL/TLS-related options"
             },
             "valueType": "EXPRESSION",
@@ -1147,7 +1147,7 @@
         "properties": {
           "connection": {
             "metadata": {
-              "label": "connection",
+              "label": "Connection Type",
               "description": "Connection configurations of the Redis server. This can be either a single URI or a set of parameters"
             },
             "valueType": "EXPRESSION",
@@ -1181,7 +1181,7 @@
           },
           "connectionPooling": {
             "metadata": {
-              "label": "connectionPooling",
+              "label": "Connection Pooling Enabled",
               "description": "Flag to indicate whether connection pooling is enabled"
             },
             "valueType": "EXPRESSION",
@@ -1208,7 +1208,7 @@
           },
           "isClusterConnection": {
             "metadata": {
-              "label": "isClusterConnection",
+              "label": "Cluster Mode Enabled",
               "description": "Flag to indicate whether the connection is a cluster connection"
             },
             "valueType": "EXPRESSION",
@@ -1235,7 +1235,7 @@
           },
           "secureSocket": {
             "metadata": {
-              "label": "secureSocket",
+              "label": "Secure Socket Configurations",
               "description": "Configurations related to SSL/TLS encryption"
             },
             "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-io-fileReadCsv.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-io-fileReadCsv.json
@@ -34,7 +34,7 @@
     "properties": {
       "returnType": {
         "metadata": {
-          "label": "returnType",
+          "label": "Return Type",
           "description": "The type of the return value (string[] or a Ballerina record)"
         },
         "valueType": "TYPE",
@@ -52,7 +52,7 @@
       },
       "path": {
         "metadata": {
-          "label": "path",
+          "label": "Path",
           "description": "The CSV file path"
         },
         "valueType": "EXPRESSION",
@@ -78,7 +78,7 @@
       },
       "skipHeaders": {
         "metadata": {
-          "label": "skipHeaders",
+          "label": "Skip Headers",
           "description": "Number of headers, which should be skipped prior to reading records"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-io-println.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-io-println.json
@@ -33,7 +33,7 @@
     "properties": {
       "values": {
         "metadata": {
-          "label": "values",
+          "label": "Values",
           "description": "The value(s) to be printed"
         },
         "valueType": "EXPRESSION_SET",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-json-parseString.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-json-parseString.json
@@ -34,7 +34,7 @@
     "properties": {
       "t": {
         "metadata": {
-          "label": "t",
+          "label": "T",
           "description": "Target type"
         },
         "valueType": "TYPE",
@@ -52,7 +52,7 @@
       },
       "s": {
         "metadata": {
-          "label": "s",
+          "label": "S",
           "description": "Source JSON string value or byte[] or byte-block-stream"
         },
         "valueType": "EXPRESSION",
@@ -78,7 +78,7 @@
       },
       "options": {
         "metadata": {
-          "label": "options",
+          "label": "Options",
           "description": "Options to be used for filtering in the projection"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-json-toJson.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-json-toJson.json
@@ -33,7 +33,7 @@
     "properties": {
       "v": {
         "metadata": {
-          "label": "v",
+          "label": "V",
           "description": "Source anydata value"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-log-printInfo.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-log-printInfo.json
@@ -33,7 +33,7 @@
     "properties": {
       "msg": {
         "metadata": {
-          "label": "msg",
+          "label": "Msg",
           "description": "The message to be logged"
         },
         "valueType": "EXPRESSION",
@@ -66,7 +66,7 @@
       },
       "error": {
         "metadata": {
-          "label": "error",
+          "label": "Error",
           "description": "The error struct to be logged"
         },
         "valueType": "EXPRESSION",
@@ -100,7 +100,7 @@
       },
       "stackTrace": {
         "metadata": {
-          "label": "stackTrace",
+          "label": "Stack Trace",
           "description": "The error stack trace to be logged"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-time-utcFromCivil.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-time-utcFromCivil.json
@@ -33,7 +33,7 @@
     "properties": {
       "civilTime": {
         "metadata": {
-          "label": "civilTime",
+          "label": "Civil Time",
           "description": "`time:Civil` time"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-array-lastIndexOf.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-array-lastIndexOf.json
@@ -33,7 +33,7 @@
     "properties": {
       "arr": {
         "metadata": {
-          "label": "arr",
+          "label": "Arr",
           "description": "the array"
         },
         "valueType": "EXPRESSION",
@@ -59,7 +59,7 @@
       },
       "val": {
         "metadata": {
-          "label": "val",
+          "label": "Val",
           "description": "member to search for"
         },
         "valueType": "EXPRESSION",
@@ -85,7 +85,7 @@
       },
       "startIndex": {
         "metadata": {
-          "label": "startIndex",
+          "label": "Start Index",
           "description": "index to start searching backwards from"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-array-map.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-array-map.json
@@ -33,7 +33,7 @@
     "properties": {
       "arr": {
         "metadata": {
-          "label": "arr",
+          "label": "Arr",
           "description": "the array"
         },
         "valueType": "EXPRESSION",
@@ -59,7 +59,7 @@
       },
       "func": {
         "metadata": {
-          "label": "func",
+          "label": "Func",
           "description": "a function to apply to each member"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-array-reduce.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-array-reduce.json
@@ -33,7 +33,7 @@
     "properties": {
       "arr": {
         "metadata": {
-          "label": "arr",
+          "label": "Arr",
           "description": "the array"
         },
         "valueType": "EXPRESSION",
@@ -59,7 +59,7 @@
       },
       "func": {
         "metadata": {
-          "label": "func",
+          "label": "Func",
           "description": "combining function"
         },
         "valueType": "EXPRESSION",
@@ -85,7 +85,7 @@
       },
       "initial": {
         "metadata": {
-          "label": "initial",
+          "label": "Initial",
           "description": "initial value for the first argument of combining parameter `func`"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-error-detail.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-error-detail.json
@@ -34,7 +34,7 @@
     "properties": {
       "e": {
         "metadata": {
-          "label": "e",
+          "label": "E",
           "description": "the error value"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-map-reduce.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-map-reduce.json
@@ -33,7 +33,7 @@
     "properties": {
       "m": {
         "metadata": {
-          "label": "m",
+          "label": "M",
           "description": "the map"
         },
         "valueType": "EXPRESSION",
@@ -59,7 +59,7 @@
       },
       "func": {
         "metadata": {
-          "label": "func",
+          "label": "Func",
           "description": "combining function"
         },
         "valueType": "EXPRESSION",
@@ -85,7 +85,7 @@
       },
       "initial": {
         "metadata": {
-          "label": "initial",
+          "label": "Initial",
           "description": "initial value for the first argument of combining parameter `func`"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-stream-reduce.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-stream-reduce.json
@@ -33,7 +33,7 @@
     "properties": {
       "stm": {
         "metadata": {
-          "label": "stm",
+          "label": "Stm",
           "description": "the stream"
         },
         "valueType": "EXPRESSION",
@@ -59,7 +59,7 @@
       },
       "func": {
         "metadata": {
-          "label": "func",
+          "label": "Func",
           "description": "combining function"
         },
         "valueType": "EXPRESSION",
@@ -85,7 +85,7 @@
       },
       "initial": {
         "metadata": {
-          "label": "initial",
+          "label": "Initial",
           "description": "initial value for the first argument of combining parameter `func`"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-table-reduce.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/lang_lib-table-reduce.json
@@ -33,7 +33,7 @@
     "properties": {
       "t": {
         "metadata": {
-          "label": "t",
+          "label": "T",
           "description": "the table"
         },
         "valueType": "EXPRESSION",
@@ -59,7 +59,7 @@
       },
       "func": {
         "metadata": {
-          "label": "func",
+          "label": "Func",
           "description": "combining function"
         },
         "valueType": "EXPRESSION",
@@ -85,7 +85,7 @@
       },
       "initial": {
         "metadata": {
-          "label": "initial",
+          "label": "Initial",
           "description": "initial value for the first argument of combining parameter `func`"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-covid-getStatusByCountry.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-covid-getStatusByCountry.json
@@ -49,7 +49,7 @@
       },
       "country": {
         "metadata": {
-          "label": "country",
+          "label": "Country",
           "description": "A country name, iso2, iso3, or country ID code "
         },
         "valueType": "EXPRESSION",
@@ -75,7 +75,7 @@
       },
       "yesterday": {
         "metadata": {
-          "label": "yesterday",
+          "label": "Yesterday",
           "description": "Enter `true`(1) to receive data reported a day ago. Default is `false`(0) "
         },
         "valueType": "EXPRESSION",
@@ -109,7 +109,7 @@
       },
       "twoDaysAgo": {
         "metadata": {
-          "label": "twoDaysAgo",
+          "label": "Two Days Ago",
           "description": "Enter `true`(1) to receive data reported two days ago. Default is `false`(0) "
         },
         "valueType": "EXPRESSION",
@@ -143,7 +143,7 @@
       },
       "strict": {
         "metadata": {
-          "label": "strict",
+          "label": "Strict",
           "description": "Setting to false gives you the ability to fuzzy search countries (i.e. Oman vs. rOMANia) "
         },
         "valueType": "EXPRESSION",
@@ -170,7 +170,7 @@
       },
       "allowNull": {
         "metadata": {
-          "label": "allowNull",
+          "label": "Allow Null",
           "description": "By default, value is 0. Enter `1` to allow nulls to be returned "
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-http-get.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-http-get.json
@@ -50,7 +50,7 @@
       },
       "targetType": {
         "metadata": {
-          "label": "targetType",
+          "label": "Target Type",
           "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
         },
         "valueType": "TYPE",
@@ -68,7 +68,7 @@
       },
       "path": {
         "metadata": {
-          "label": "path",
+          "label": "Path",
           "description": "Request path"
         },
         "valueType": "EXPRESSION",
@@ -94,7 +94,7 @@
       },
       "headers": {
         "metadata": {
-          "label": "headers",
+          "label": "Headers",
           "description": "The entity headers"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-http-post.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-http-post.json
@@ -50,7 +50,7 @@
       },
       "targetType": {
         "metadata": {
-          "label": "targetType",
+          "label": "Target Type",
           "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
         },
         "valueType": "TYPE",
@@ -68,7 +68,7 @@
       },
       "path": {
         "metadata": {
-          "label": "path",
+          "label": "Path",
           "description": "Resource path"
         },
         "valueType": "EXPRESSION",
@@ -94,7 +94,7 @@
       },
       "message": {
         "metadata": {
-          "label": "message",
+          "label": "Message",
           "description": "An HTTP outbound request or any allowed payload"
         },
         "valueType": "EXPRESSION",
@@ -120,7 +120,7 @@
       },
       "headers": {
         "metadata": {
-          "label": "headers",
+          "label": "Headers",
           "description": "The entity headers"
         },
         "valueType": "EXPRESSION",
@@ -154,7 +154,7 @@
       },
       "mediaType": {
         "metadata": {
-          "label": "mediaType",
+          "label": "Media Type",
           "description": "The MIME type header of the request entity"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-mysql-query.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-mysql-query.json
@@ -52,7 +52,7 @@
       },
       "sqlQuery": {
         "metadata": {
-          "label": "sqlQuery",
+          "label": "SQL Query",
           "description": "The SQL query such as `` `SELECT * from Album WHERE name=${albumName}` ``"
         },
         "valueType": "EXPRESSION",
@@ -82,7 +82,7 @@
       },
       "rowType": {
         "metadata": {
-          "label": "rowType",
+          "label": "Row Type",
           "description": "The `typedesc` of the record to which the result needs to be returned"
         },
         "valueType": "TYPE",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-mysql-queryRow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-mysql-queryRow.json
@@ -52,7 +52,7 @@
       },
       "sqlQuery": {
         "metadata": {
-          "label": "sqlQuery",
+          "label": "SQL Query",
           "description": "The SQL query such as `` `SELECT * from Album WHERE name=${albumName}` ``"
         },
         "valueType": "EXPRESSION",
@@ -82,7 +82,7 @@
       },
       "returnType": {
         "metadata": {
-          "label": "returnType",
+          "label": "Return Type",
           "description": "The `typedesc` of the record to which the result needs to be returned.\nIt can be a basic type if the query result contains only one column"
         },
         "valueType": "TYPE",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-redis-get.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-redis-get.json
@@ -49,7 +49,7 @@
       },
       "key": {
         "metadata": {
-          "label": "key",
+          "label": "Key",
           "description": "Key referring to a value"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-redis-set.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-redis-set.json
@@ -49,7 +49,7 @@
       },
       "key": {
         "metadata": {
-          "label": "key",
+          "label": "Key",
           "description": "Key referring to a value"
         },
         "valueType": "EXPRESSION",
@@ -75,7 +75,7 @@
       },
       "value": {
         "metadata": {
-          "label": "value",
+          "label": "Value",
           "description": "Values"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-snowflake-query.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/remote_action_call-snowflake-query.json
@@ -50,7 +50,7 @@
       },
       "sqlQuery": {
         "metadata": {
-          "label": "sqlQuery",
+          "label": "SQL Query",
           "description": "The SQL query such as `` `SELECT * from Album WHERE name=${albumName}` ``"
         },
         "valueType": "EXPRESSION",
@@ -80,7 +80,7 @@
       },
       "rowType": {
         "metadata": {
-          "label": "rowType",
+          "label": "Row Type",
           "description": "The `typedesc` of the record to which the result needs to be returned"
         },
         "valueType": "TYPE",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/resource_action_call-docusign.dsadmin-get.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/resource_action_call-docusign.dsadmin-get.json
@@ -98,7 +98,7 @@
       },
       "start": {
         "metadata": {
-          "label": "start",
+          "label": "Start",
           "description": "Index of first item to include in the response. The default value is 0."
         },
         "valueType": "EXPRESSION",
@@ -132,7 +132,7 @@
       },
       "take": {
         "metadata": {
-          "label": "take",
+          "label": "Take",
           "description": "Page size of the response. The default value is 20."
         },
         "valueType": "EXPRESSION",
@@ -166,7 +166,7 @@
       },
       "end": {
         "metadata": {
-          "label": "end",
+          "label": "End",
           "description": "Index of the last item to include in the response. Ignored if `take` parameter is specified."
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/resource_action_call-github_2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/resource_action_call-github_2.json
@@ -80,7 +80,7 @@
       },
       "$type": {
         "metadata": {
-          "label": "type",
+          "label": "Type",
           "description": "Specifies the types of repositories you want returned."
         },
         "valueType": "EXPRESSION",
@@ -142,7 +142,7 @@
       },
       "sort": {
         "metadata": {
-          "label": "sort",
+          "label": "Sort",
           "description": "The property to sort the results by."
         },
         "valueType": "EXPRESSION",
@@ -190,7 +190,7 @@
       },
       "direction": {
         "metadata": {
-          "label": "direction",
+          "label": "Direction",
           "description": "The order to sort by. Default: `asc` when using `full_name`, otherwise `desc`."
         },
         "valueType": "EXPRESSION",
@@ -231,7 +231,7 @@
       },
       "per_page": {
         "metadata": {
-          "label": "per_page",
+          "label": "Per Page",
           "description": "The number of results per page (max 100)."
         },
         "valueType": "EXPRESSION",
@@ -258,7 +258,7 @@
       },
       "page": {
         "metadata": {
-          "label": "page",
+          "label": "Page",
           "description": "Page number of the results to fetch."
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/resource_action_call-http-get.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/resource_action_call-http-get.json
@@ -63,7 +63,7 @@
       },
       "targetType": {
         "metadata": {
-          "label": "targetType",
+          "label": "Target Type",
           "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
         },
         "valueType": "TYPE",
@@ -81,7 +81,7 @@
       },
       "headers": {
         "metadata": {
-          "label": "headers",
+          "label": "Headers",
           "description": "The entity headers"
         },
         "valueType": "EXPRESSION",

--- a/flow-model-generator/modules/flow-model-index-generator/src/main/java/io/ballerina/indexgenerator/DatabaseManager.java
+++ b/flow-model-generator/modules/flow-model-index-generator/src/main/java/io/ballerina/indexgenerator/DatabaseManager.java
@@ -107,16 +107,16 @@ class DatabaseManager {
     public static int insertFunctionParameter(int functionId, String paramName, String paramDescription,
                                               Object paramType, String placeholder, String defaultValue,
                                               IndexGenerator.FunctionParameterKind parameterKind,
-                                              int optional, String importStatements) {
+                                              int optional, String importStatements, String label) {
 
         String sql =
                 "INSERT INTO Parameter (function_id, name, description, type, placeholder, default_value, kind, " +
                         "optional, " +
-                        "import_statements) " +
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                        "import_statements, label) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         return insertEntry(sql,
                 new Object[]{functionId, paramName, paramDescription, paramType, placeholder, defaultValue,
-                        parameterKind.name(), optional, importStatements});
+                        parameterKind.name(), optional, importStatements, label});
     }
 
     public static void insertParameterMemberType(int parameterId, String type, String kind,

--- a/flow-model-generator/modules/flow-model-index-generator/src/main/java/io/ballerina/indexgenerator/IndexGenerator.java
+++ b/flow-model-generator/modules/flow-model-index-generator/src/main/java/io/ballerina/indexgenerator/IndexGenerator.java
@@ -275,7 +275,7 @@ class IndexGenerator {
                     parameterData.description(), parameterData.type(), parameterData.placeholder(),
                     parameterData.defaultValue(),
                     FunctionParameterKind.fromString(parameterData.kind().name()),
-                    parameterData.optional() ? 1 : 0, parameterData.importStatements());
+                    parameterData.optional() ? 1 : 0, parameterData.importStatements(), parameterData.label());
 
             // Insert parameter member types
             insertParameterMemberTypesFromParameterData(paramId, parameterData);

--- a/flow-model-generator/modules/flow-model-index-generator/src/main/resources/central-index.sql
+++ b/flow-model-generator/modules/flow-model-index-generator/src/main/resources/central-index.sql
@@ -45,6 +45,7 @@ CREATE TABLE Parameter (
     parameter_id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
     description TEXT,
+    label TEXT,
     kind TEXT CHECK(kind IN ('REQUIRED', 'DEFAULTABLE', 'INCLUDED_RECORD', 'REST_PARAMETER',
     'INCLUDED_FIELD', 'INCLUDED_RECORD_REST', 'PARAM_FOR_TYPE_INFER', 'PATH_PARAM', 'PATH_REST_PARAM')),
     type JSON, -- JSON type for parameter type information

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/DatabaseManager.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/DatabaseManager.java
@@ -360,8 +360,10 @@ public class DatabaseManager {
                 "p.type, " +
                 "p.kind, " +
                 "p.optional, " +
+                "p.placeholder, " +
                 "p.default_value, " +
                 "p.description, " +
+                "p.label, " +
                 "p.import_statements " +
                 "FROM Parameter p " +
                 "WHERE p.function_id = ?;";
@@ -380,7 +382,7 @@ public class DatabaseManager {
                         rs.getString("placeholder"),
                         rs.getString("default_value"),
                         rs.getString("description"),
-                        "",
+                        rs.getString("label"),
                         rs.getBoolean("optional"),
                         rs.getString("import_statements"),
                         new ArrayList<>()
@@ -404,6 +406,7 @@ public class DatabaseManager {
                 "p.placeholder, " +
                 "p.default_value, " +
                 "p.description, " +
+                "p.label, " +
                 "p.import_statements, " +
                 "pmt.type AS member_type, " +
                 "pmt.kind AS member_kind, " +
@@ -429,6 +432,7 @@ public class DatabaseManager {
                 String placeholder = rs.getString("placeholder");
                 String defaultValue = rs.getString("default_value");
                 String description = rs.getString("description");
+                String label = rs.getString("label");
                 boolean optional = rs.getBoolean("optional");
                 String importStatements = rs.getString("import_statements");
 
@@ -449,6 +453,7 @@ public class DatabaseManager {
                     builder.placeholder = placeholder;
                     builder.defaultValue = defaultValue;
                     builder.description = description;
+                    builder.label = label;
                     builder.optional = optional;
                     builder.importStatements = importStatements;
                     builders.put(paramName, builder);
@@ -485,6 +490,7 @@ public class DatabaseManager {
         String placeholder;
         String defaultValue;
         String description;
+        String label;
         boolean optional;
         String importStatements;
         List<ParameterMemberTypeData> typeMembers = new ArrayList<>();
@@ -498,7 +504,7 @@ public class DatabaseManager {
                     placeholder,
                     defaultValue,
                     description,
-                    null,
+                    label,
                     optional,
                     importStatements,
                     typeMembers

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/FunctionDataBuilder.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/FunctionDataBuilder.java
@@ -686,9 +686,9 @@ public class FunctionDataBuilder {
                     placeholder = paramForTypeInfer.type();
                     defaultValue = paramForTypeInfer.type();
                     paramType = paramForTypeInfer.type();
-                    parameters.put(paramName,
-                            ParameterData.from(paramName, paramDescription, paramType, placeholder, defaultValue,
-                                    ParameterData.Kind.PARAM_FOR_TYPE_INFER, optional, importStatements));
+                    parameters.put(paramName, ParameterData.from(paramName, paramDescription,
+                            getLabel(paramSymbol.annotAttachments(), paramName), paramType, placeholder, defaultValue,
+                            ParameterData.Kind.PARAM_FOR_TYPE_INFER, optional, importStatements));
                     return parameters;
                 }
             }


### PR DESCRIPTION
## Purpose
Currently, the label is only applied to forms generated from the semantic model, but not to those fetched from the local index. This PR ensures that the label is also preserved in the index.

Partially completes https://github.com/wso2/product-ballerina-integrator/issues/568
Partially completed https://github.com/wso2/product-ballerina-integrator/issues/573
