### PR TITLE
Fix the generated variable name for the inferred type

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/SourceBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/SourceBuilder.java
@@ -181,7 +181,7 @@ public class SourceBuilder {
                 String returnType = flowNode.codedata().inferredReturnType();
                 String inferredType = inferredParam.get().value().toString();
                 String inferredTypeDef = inferredParam.get()
-                        .metadata().label();
+                        .codedata().originalName();
                 typeName = returnType.replace(inferredTypeDef, inferredType);
             }
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/remote_action_call-http-get8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/remote_action_call-http-get8.json
@@ -1,0 +1,206 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "31",
+    "metadata": {
+      "label": "get",
+      "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.14.1.png"
+    },
+    "codedata": {
+      "node": "REMOTE_ACTION_CALL",
+      "org": "ballerina",
+      "module": "http",
+      "packageName": "http",
+      "object": "Client",
+      "symbol": "get",
+      "version": "2.14.2",
+      "isNew": true,
+      "inferredReturnType": "targetType",
+      "lineRange": {
+        "startLine": {
+          "line": 8,
+          "offset": 51
+        },
+        "endLine": {
+          "line": 8,
+          "offset": 51
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "connection": {
+        "metadata": {
+          "label": "Connection",
+          "description": "Connection to use"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:Client",
+        "value": "httpClient",
+        "optional": true,
+        "editable": false,
+        "advanced": false,
+        "hidden": true,
+        "modified": false
+      },
+      "path": {
+        "metadata": {
+          "label": "Path",
+          "description": "Request path"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "string",
+        "placeholder": "\"\"",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "kind": "REQUIRED",
+          "originalName": "path"
+        },
+        "typeMembers": [
+          {
+            "type": "string",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "value": "\"foo\"",
+        "modified": true
+      },
+      "headers": {
+        "metadata": {
+          "label": "Headers",
+          "description": "The entity headers"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "map<string|string[]>|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "DEFAULTABLE",
+          "originalName": "headers"
+        },
+        "typeMembers": [
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          },
+          {
+            "type": "map<string|string[]>",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "MAP_TYPE",
+            "selected": false
+          }
+        ],
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "targetType": {
+        "metadata": {
+          "label": "Target Type",
+          "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
+        },
+        "valueType": "TYPE",
+        "valueTypeConstraint": "anydata",
+        "placeholder": "anydata",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "kind": "PARAM_FOR_TYPE_INFER",
+          "originalName": "targetType"
+        },
+        "defaultValue": "anydata",
+        "value": "json",
+        "modified": true
+      },
+      "type": {
+        "metadata": {
+          "label": "Variable Type",
+          "description": "Type of the variable"
+        },
+        "valueType": "TYPE",
+        "value": "targetType",
+        "placeholder": "var",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {},
+        "modified": false
+      },
+      "variable": {
+        "metadata": {
+          "label": "Result",
+          "description": "Name of the result variable"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "var2",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "modified": false
+      },
+      "checkError": {
+        "metadata": {
+          "label": "Check Error",
+          "description": "Trigger error flow"
+        },
+        "valueType": "FLAG",
+        "value": true,
+        "optional": false,
+        "editable": true,
+        "advanced": true,
+        "hidden": true,
+        "modified": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "import ballerina/http;"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 8,
+            "character": 51
+          },
+          "end": {
+            "line": 8,
+            "character": 51
+          }
+        },
+        "newText": "\njson var2 = check httpClient->get(\"foo\");"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Purpose
$title, as this was broken when we corrected the label of the parameter. This is resolved by considering the original name in the codedata.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/640