### PR TITLE
[Release Stage] Change the type of the data mapper to anydata

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataMapperDefinitionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataMapperDefinitionBuilder.java
@@ -54,8 +54,8 @@ public class DataMapperDefinitionBuilder extends NodeBuilder {
 
     private static final Gson gson = new Gson();
 
-    public static final String RETURN_TYPE = TypeKind.JSON.typeName();
-    public static final String PARAMETER_TYPE = TypeKind.JSON.typeName();
+    public static final String RETURN_TYPE = TypeKind.ANYDATA.typeName();
+    public static final String PARAMETER_TYPE = TypeKind.ANYDATA.typeName();
 
     @Override
     public void setConcreteConstData() {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def1.json
@@ -57,7 +57,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "Employee",
         "optional": false,
         "editable": true,
@@ -83,7 +83,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,
@@ -122,7 +122,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "Person",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def2.json
@@ -57,7 +57,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "Employee",
         "optional": false,
         "editable": true,
@@ -83,7 +83,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,
@@ -122,7 +122,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "string",
                 "optional": false,
                 "editable": true,
@@ -173,7 +173,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "int",
                 "optional": false,
                 "editable": true,
@@ -224,7 +224,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "decimal",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def3.json
@@ -57,7 +57,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "Summary",
         "optional": false,
         "editable": true,
@@ -83,7 +83,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,
@@ -122,7 +122,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "Employee[]",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def4.json
@@ -57,7 +57,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "Person",
         "optional": false,
         "editable": true,
@@ -83,7 +83,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,
@@ -122,7 +122,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "string",
                 "optional": false,
                 "editable": true,
@@ -173,7 +173,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "string",
                 "optional": false,
                 "editable": true,
@@ -224,7 +224,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "Address",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def5.json
@@ -57,7 +57,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "Employee",
         "optional": false,
         "editable": true,
@@ -83,7 +83,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,
@@ -122,7 +122,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "Person",
                 "optional": false,
                 "editable": true,
@@ -173,7 +173,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "Admission",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def6.json
@@ -57,7 +57,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "nats:AnydataMessage",
         "optional": false,
         "editable": true,
@@ -83,7 +83,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,
@@ -122,7 +122,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "string",
                 "optional": false,
                 "editable": true,
@@ -173,7 +173,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "int",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def7.json
@@ -57,7 +57,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "nats:AnydataMessage|http:AccessLogConfiguration",
         "optional": false,
         "editable": true,
@@ -83,7 +83,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,
@@ -122,7 +122,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "string",
                 "optional": false,
                 "editable": true,
@@ -173,7 +173,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "int",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def8.json
@@ -57,7 +57,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "nats:AnydataMessage",
         "optional": false,
         "editable": true,
@@ -83,7 +83,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,
@@ -122,7 +122,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "nats:BytesMessage",
                 "optional": false,
                 "editable": true,
@@ -173,7 +173,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "json",
+                "valueTypeConstraint": "anydata",
                 "value": "string",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-main.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-main.json
@@ -39,7 +39,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "",
         "optional": false,
         "editable": true,
@@ -65,7 +65,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-service.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-service.json
@@ -39,7 +39,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "json",
+        "valueTypeConstraint": "anydata",
         "value": "",
         "optional": false,
         "editable": true,
@@ -65,7 +65,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "json",
+              "valueTypeConstraint": "anydata",
               "value": "",
               "optional": false,
               "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config10.json
@@ -7,22 +7,13 @@
   },
   "completions": [
     {
-      "label": "map<Person>",
+      "label": "string|int",
       "labelDetails": {
         "detail": "Used Variable Types",
-        "description": "Map"
+        "description": "Union"
       },
-      "kind": "TypeParameter",
-      "insertText": "map<Person>"
-    },
-    {
-      "label": "Person",
-      "labelDetails": {
-        "detail": "User-Defined",
-        "description": "Record"
-      },
-      "kind": "Struct",
-      "insertText": "Person"
+      "kind": "Enum",
+      "insertText": "string|int"
     },
     {
       "label": "string[]",
@@ -43,13 +34,130 @@
       "insertText": "Person[]"
     },
     {
-      "label": "string|int",
+      "label": "Employee",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Employee"
+    },
+    {
+      "label": "Person",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Person"
+    },
+    {
+      "label": "map<Person>",
       "labelDetails": {
         "detail": "Used Variable Types",
-        "description": "Union"
+        "description": "Map"
       },
-      "kind": "Enum",
-      "insertText": "string|int"
+      "kind": "TypeParameter",
+      "insertText": "map<Person>"
+    },
+    {
+      "label": "any",
+      "labelDetails": {
+        "detail": "Other Types",
+        "description": "Any"
+      },
+      "kind": "TypeParameter",
+      "insertText": "any"
+    },
+    {
+      "label": "readonly",
+      "labelDetails": {
+        "detail": "Other Types",
+        "description": "Readonly"
+      },
+      "kind": "TypeParameter",
+      "insertText": "readonly"
+    },
+    {
+      "label": "json",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Json"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json"
+    },
+    {
+      "label": "xml",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Xml"
+      },
+      "kind": "TypeParameter",
+      "insertText": "xml"
+    },
+    {
+      "label": "anydata",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Anydata"
+      },
+      "kind": "TypeParameter",
+      "insertText": "anydata"
+    },
+    {
+      "label": "error",
+      "labelDetails": {
+        "detail": "Error Types",
+        "description": "Error"
+      },
+      "kind": "Event",
+      "insertText": "error"
+    },
+    {
+      "label": "function",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Function"
+      },
+      "kind": "TypeParameter",
+      "insertText": "function"
+    },
+    {
+      "label": "future",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Future"
+      },
+      "kind": "TypeParameter",
+      "insertText": "future"
+    },
+    {
+      "label": "typedesc",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Typedesc"
+      },
+      "kind": "TypeParameter",
+      "insertText": "typedesc"
+    },
+    {
+      "label": "handle",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Handle"
+      },
+      "kind": "TypeParameter",
+      "insertText": "handle"
+    },
+    {
+      "label": "stream",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Stream"
+      },
+      "kind": "TypeParameter",
+      "insertText": "stream"
     },
     {
       "label": "byte[]",
@@ -104,105 +212,6 @@
       },
       "kind": "Struct",
       "insertText": "record"
-    },
-    {
-      "label": "function",
-      "labelDetails": {
-        "detail": "Behaviour Types",
-        "description": "Function"
-      },
-      "kind": "TypeParameter",
-      "insertText": "function"
-    },
-    {
-      "label": "future",
-      "labelDetails": {
-        "detail": "Behaviour Types",
-        "description": "Future"
-      },
-      "kind": "TypeParameter",
-      "insertText": "future"
-    },
-    {
-      "label": "typedesc",
-      "labelDetails": {
-        "detail": "Behaviour Types",
-        "description": "Typedesc"
-      },
-      "kind": "TypeParameter",
-      "insertText": "typedesc"
-    },
-    {
-      "label": "handle",
-      "labelDetails": {
-        "detail": "Behaviour Types",
-        "description": "Handle"
-      },
-      "kind": "TypeParameter",
-      "insertText": "handle"
-    },
-    {
-      "label": "stream",
-      "labelDetails": {
-        "detail": "Behaviour Types",
-        "description": "Stream"
-      },
-      "kind": "TypeParameter",
-      "insertText": "stream"
-    },
-    {
-      "label": "error",
-      "labelDetails": {
-        "detail": "Error Types",
-        "description": "Error"
-      },
-      "kind": "Event",
-      "insertText": "error"
-    },
-    {
-      "label": "json",
-      "labelDetails": {
-        "detail": "Data Types",
-        "description": "Json"
-      },
-      "kind": "TypeParameter",
-      "insertText": "json"
-    },
-    {
-      "label": "xml",
-      "labelDetails": {
-        "detail": "Data Types",
-        "description": "Xml"
-      },
-      "kind": "TypeParameter",
-      "insertText": "xml"
-    },
-    {
-      "label": "anydata",
-      "labelDetails": {
-        "detail": "Data Types",
-        "description": "Anydata"
-      },
-      "kind": "TypeParameter",
-      "insertText": "anydata"
-    },
-    {
-      "label": "any",
-      "labelDetails": {
-        "detail": "Other Types",
-        "description": "Any"
-      },
-      "kind": "TypeParameter",
-      "insertText": "any"
-    },
-    {
-      "label": "readonly",
-      "labelDetails": {
-        "detail": "Other Types",
-        "description": "Readonly"
-      },
-      "kind": "TypeParameter",
-      "insertText": "readonly"
     },
     {
       "label": "string",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/proj/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/proj/types.bal
@@ -2,3 +2,9 @@ type Person record {|
     int id;
     string name;
 |};
+
+type Employee record {
+    int id;
+    string name;
+    string department?;
+};


### PR DESCRIPTION
## Purpose
Currently, this was set to `json` due to the limited type support in the initial version of the data mapper. Ideally, it should support `anydata`, and this PR introduces that change.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/708