### PR TITLE
Extend support for `codeLens` and `getFlowModel` to class definitions

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -229,8 +229,13 @@ public class CodeAnalyzer extends NodeVisitor {
         if (functionDefinitionNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
             accessor = functionName;
             functionName = getPathString(functionDefinitionNode.relativeResourcePath());
-            ServiceDeclarationNode serviceDeclarationNode = getParentServiceDeclaration(functionDefinitionNode);
-            kind = isAgent(serviceDeclarationNode) ? FunctionKind.AI_CHAT_AGENT : FunctionKind.RESOURCE;
+            NonTerminalNode parentNode = getParentNode(functionDefinitionNode);
+            if (parentNode instanceof ServiceDeclarationNode serviceDeclarationNode &&
+                    isAgent(serviceDeclarationNode)) {
+                kind = FunctionKind.AI_CHAT_AGENT;
+            } else {
+                kind = FunctionKind.RESOURCE;
+            }
         } else if (hasQualifier(functionDefinitionNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
             kind = FunctionKind.REMOTE_FUNCTION;
         } else {
@@ -501,6 +506,18 @@ public class CodeAnalyzer extends NodeVisitor {
             throw new IllegalStateException("Service declaration not found");
         }
         return (ServiceDeclarationNode) currentNode;
+    }
+
+    private NonTerminalNode getParentNode(NonTerminalNode node) {
+        NonTerminalNode currentNode = node;
+        while (currentNode != null && currentNode.kind() != SyntaxKind.SERVICE_DECLARATION &&
+                currentNode.kind() != SyntaxKind.CLASS_DEFINITION) {
+            currentNode = currentNode.parent();
+        }
+        if (currentNode == null) {
+            throw new IllegalStateException("Parent node not found");
+        }
+        return currentNode;
     }
 
     private void setFunctionProperties(String functionName, ExpressionNode expressionNode,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/service_class1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/service_class1.json
@@ -1,0 +1,273 @@
+{
+  "start": {
+    "line": 9,
+    "offset": 0
+  },
+  "end": {
+    "line": 16,
+    "offset": 1
+  },
+  "source": "service_class.bal",
+  "description": "Tests a simple diagram flow",
+  "diagram": {
+    "fileName": "service_class.bal",
+    "nodes": [
+      {
+        "id": "42413",
+        "metadata": {
+          "label": "Start",
+          "data": {
+            "kind": "Resource",
+            "label": "name1",
+            "accessor": "get",
+            "return": "string"
+          }
+        },
+        "codedata": {
+          "node": "EVENT_START",
+          "lineRange": {
+            "fileName": "service_class.bal",
+            "startLine": {
+              "line": 9,
+              "offset": 49
+            },
+            "endLine": {
+              "line": 16,
+              "offset": 5
+            }
+          },
+          "sourceCode": "resource function get name1() returns string {\n        do {\n            panic error(\"Unimplemented function\");\n        } on fail error err {\n            //handle error\n            panic error(\"Unhandled error\");\n        }\n    }"
+        },
+        "returning": false,
+        "flags": 0
+      },
+      {
+        "id": "42076",
+        "metadata": {
+          "label": "ErrorHandler",
+          "description": "Catch and handle errors"
+        },
+        "codedata": {
+          "node": "ERROR_HANDLER",
+          "lineRange": {
+            "fileName": "service_class.bal",
+            "startLine": {
+              "line": 10,
+              "offset": 8
+            },
+            "endLine": {
+              "line": 15,
+              "offset": 9
+            }
+          },
+          "sourceCode": "do {\n            panic error(\"Unimplemented function\");\n        } on fail error err {\n            //handle error\n            panic error(\"Unhandled error\");\n        }"
+        },
+        "returning": false,
+        "branches": [
+          {
+            "label": "Body",
+            "kind": "BLOCK",
+            "codedata": {
+              "node": "BODY",
+              "lineRange": {
+                "fileName": "service_class.bal",
+                "startLine": {
+                  "line": 10,
+                  "offset": 11
+                },
+                "endLine": {
+                  "line": 12,
+                  "offset": 9
+                }
+              },
+              "sourceCode": "{\n            panic error(\"Unimplemented function\");\n        }"
+            },
+            "repeatable": "ONE",
+            "children": [
+              {
+                "id": "43078",
+                "metadata": {
+                  "label": "Panic",
+                  "description": "Panic and stop the execution"
+                },
+                "codedata": {
+                  "node": "PANIC",
+                  "lineRange": {
+                    "fileName": "service_class.bal",
+                    "startLine": {
+                      "line": 11,
+                      "offset": 12
+                    },
+                    "endLine": {
+                      "line": 11,
+                      "offset": 50
+                    }
+                  },
+                  "sourceCode": "panic error(\"Unimplemented function\");"
+                },
+                "returning": false,
+                "properties": {
+                  "expression": {
+                    "metadata": {
+                      "label": "Expression",
+                      "description": "Panic value"
+                    },
+                    "valueType": "EXPRESSION",
+                    "valueTypeConstraint": "error",
+                    "value": "error(\"Unimplemented function\")",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                  }
+                },
+                "flags": 0
+              }
+            ]
+          },
+          {
+            "label": "On Failure",
+            "kind": "BLOCK",
+            "codedata": {
+              "node": "ON_FAILURE",
+              "lineRange": {
+                "fileName": "service_class.bal",
+                "startLine": {
+                  "line": 12,
+                  "offset": 28
+                },
+                "endLine": {
+                  "line": 15,
+                  "offset": 9
+                }
+              },
+              "sourceCode": "{\n            //handle error\n            panic error(\"Unhandled error\");\n        }"
+            },
+            "repeatable": "ZERO_OR_ONE",
+            "properties": {
+              "ignore": {
+                "metadata": {
+                  "label": "Ignore",
+                  "description": "Ignore the error value"
+                },
+                "valueType": "EXPRESSION",
+                "value": "false",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false
+              },
+              "errorVariable": {
+                "metadata": {
+                  "label": "Error Variable",
+                  "description": "Name of the error variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "err ",
+                "placeholder": "err",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false
+              },
+              "errorType": {
+                "metadata": {
+                  "label": "Error Type",
+                  "description": "Type of the error"
+                },
+                "valueType": "TYPE",
+                "value": "error",
+                "placeholder": "error",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false
+              }
+            },
+            "children": [
+              {
+                "id": "44666",
+                "metadata": {
+                  "label": "Comment",
+                  "description": ""
+                },
+                "codedata": {
+                  "node": "COMMENT",
+                  "lineRange": {
+                    "fileName": "service_class.bal",
+                    "startLine": {
+                      "line": 13,
+                      "offset": 0
+                    },
+                    "endLine": {
+                      "line": 13,
+                      "offset": 26
+                    }
+                  },
+                  "sourceCode": ""
+                },
+                "returning": false,
+                "properties": {
+                  "comment": {
+                    "metadata": {
+                      "label": "Comment",
+                      "description": "Comment to describe the flow"
+                    },
+                    "valueType": "STRING",
+                    "value": "",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                  }
+                },
+                "flags": 0
+              },
+              {
+                "id": "46047",
+                "metadata": {
+                  "label": "Panic",
+                  "description": "Panic and stop the execution"
+                },
+                "codedata": {
+                  "node": "PANIC",
+                  "lineRange": {
+                    "fileName": "service_class.bal",
+                    "startLine": {
+                      "line": 14,
+                      "offset": 12
+                    },
+                    "endLine": {
+                      "line": 14,
+                      "offset": 43
+                    }
+                  },
+                  "sourceCode": "//handle error\n            panic error(\"Unhandled error\");"
+                },
+                "returning": false,
+                "properties": {
+                  "expression": {
+                    "metadata": {
+                      "label": "Expression",
+                      "description": "Panic value"
+                    },
+                    "valueType": "EXPRESSION",
+                    "valueTypeConstraint": "error",
+                    "value": "error(\"Unhandled error\")",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                  }
+                },
+                "flags": 0
+              }
+            ]
+          }
+        ],
+        "flags": 0
+      }
+    ],
+    "connections": []
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/service_class.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/service_class.bal
@@ -16,4 +16,3 @@ service class MyTypeObj1 {
         }
     }
 }
-    

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/service_class.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/service_class.bal
@@ -1,0 +1,19 @@
+type MyTypeInput record {|
+    string name1;
+    string name2;
+|};
+
+service class MyTypeObj1 {
+    function init() {
+    }
+
+    resource function get name1() returns string {
+        do {
+            panic error("Unimplemented function");
+        } on fail error err {
+            //handle error
+            panic error("Unhandled error");
+        }
+    }
+}
+    

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/CodeLensUtil.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/CodeLensUtil.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.langserver.codelenses;
 
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
@@ -87,6 +88,12 @@ public final class CodeLensUtil {
             if (member instanceof ServiceDeclarationNode serviceDeclarationNode) {
                 for (Node serviceMember : serviceDeclarationNode.members()) {
                     traverseCodeLensProviders(codeLensContext, serviceMember, providers, lenses);
+                }
+            }
+
+            if (member instanceof ClassDefinitionNode classDefinitionNode) {
+                for (Node classMember : classDefinitionNode.members()) {
+                    traverseCodeLensProviders(codeLensContext, classMember, providers, lenses);
                 }
             }
 

--- a/langserver-core/src/test/resources/codelens/config/visualize.json
+++ b/langserver-core/src/test/resources/codelens/config/visualize.json
@@ -272,6 +272,93 @@
           "visualize.bal"
         ]
       }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 32,
+          "character": 4
+        },
+        "end": {
+          "line": 33,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Visualize",
+        "command": "ballerina.showVisualizer",
+        "arguments": [
+          "visualize.bal",
+          {
+            "start": {
+              "line": 32,
+              "character": 4
+            },
+            "end": {
+              "line": 33,
+              "character": 5
+            }
+          }
+        ]
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 35,
+          "character": 4
+        },
+        "end": {
+          "line": 42,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Visualize",
+        "command": "ballerina.showVisualizer",
+        "arguments": [
+          "visualize.bal",
+          {
+            "start": {
+              "line": 35,
+              "character": 4
+            },
+            "end": {
+              "line": 42,
+              "character": 5
+            }
+          }
+        ]
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 31,
+          "character": 0
+        },
+        "end": {
+          "line": 43,
+          "character": 1
+        }
+      },
+      "command": {
+        "title": "Visualize",
+        "command": "ballerina.showVisualizer",
+        "arguments": [
+          "visualize.bal",
+          {
+            "start": {
+              "line": 31,
+              "character": 0
+            },
+            "end": {
+              "line": 43,
+              "character": 1
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/langserver-core/src/test/resources/codelens/source/visualize.bal
+++ b/langserver-core/src/test/resources/codelens/source/visualize.bal
@@ -28,3 +28,17 @@ service / on new module1:Listener(9090) {
         
     }
 }
+
+service class MyTypeObj1 {
+    function init() {
+    }
+
+    resource function get name1() returns string {
+        do {
+            panic error("Unimplemented function");
+        } on fail error err {
+            //handle error
+            panic error("Unhandled error");
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
The current implementation only supports resources and remote functions when defined under a service declaration. This PR extends this support to class definitions.

Related to https://github.com/wso2/product-ballerina-integrator/issues/823