### PR TITLE
Refactor `getAllTypes` method to accept package and aggregate types from all sub-modules

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Codedata.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Codedata.java
@@ -39,12 +39,13 @@ import io.ballerina.tools.text.LineRange;
  * @param isNew              Whether the component is a node template
  * @param isGenerated        The component is auto generated or not
  * @param inferredReturnType The inferred return type of the component if exists
+ * @param filePath           The file path of the component
  * @since 1.0.0
  */
 public record Codedata(NodeKind node, String org, String module, String packageName, String object, String symbol,
                        String version, LineRange lineRange, String sourceCode, String parentSymbol,
                        String resourcePath, Integer id, Boolean isNew, Boolean isGenerated,
-                       String inferredReturnType) {
+                       String inferredReturnType, String filePath) {
 
     @Override
     public String toString() {
@@ -88,6 +89,7 @@ public record Codedata(NodeKind node, String org, String module, String packageN
         private Boolean isNew;
         private Boolean isGenerated;
         private String inferredReturnType;
+        private String filePath;
 
         public Builder(T parentBuilder) {
             super(parentBuilder);
@@ -139,6 +141,11 @@ public record Codedata(NodeKind node, String org, String module, String packageN
             return this;
         }
 
+        public Builder<T> filePath(String filePath) {
+            this.filePath = filePath;
+            return this;
+        }
+
         public Builder<T> sourceCode(String sourceCode) {
             this.sourceCode = sourceCode;
             return this;
@@ -181,7 +188,7 @@ public record Codedata(NodeKind node, String org, String module, String packageN
 
         public Codedata build() {
             return new Codedata(node, org, module, packageName, object, symbol, version, lineRange, sourceCode,
-                    parentSymbol, resourcePath, id, isNew, isGenerated, inferredReturnType);
+                    parentSymbol, resourcePath, id, isNew, isGenerated, inferredReturnType, filePath);
         }
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/SourceCodeGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/SourceCodeGenerator.java
@@ -75,9 +75,10 @@ public class SourceCodeGenerator {
             }
         }
 
-        String template = "%n%sservice class %s {%s%n\tfunction init() {%n\t}%s%n}";
+        String template = "%n%%ssservice class %s {%s%n\tfunction init() {%n\t}%s%n}";
 
         return template.formatted(
+                isPublicFlagOn(typeData.properties()) ? "public " : "",
                 isReadonlyFlagOn(typeData.properties()) ? "readonly " : "",
                 typeData.name(),
                 fieldBuilder.toString(),
@@ -105,9 +106,14 @@ public class SourceCodeGenerator {
             }
         }
 
-        String template = "%senum %s {%s%n}%n";
+        String template = "%s%senum %s {%s%n}%n";
 
-        return template.formatted(docs, typeData.name(), enumValues.toString());
+        return template.formatted(
+                docs,
+                isPublicFlagOn(typeData.properties()) ? "public " : "",
+                typeData.name(),
+                enumValues.toString()
+        );
     }
 
     private String generateTypeDefCodeSnippet(TypeData typeData) {
@@ -115,6 +121,7 @@ public class SourceCodeGenerator {
         if (typeData.metadata() != null && typeData.metadata().description() != null) {
             docs = generateDocs(typeData.metadata().description(), "");
         }
+
         String typeDescriptor = generateTypeDescriptor(typeData);
 
         // Check for readonly property to generate `readonly & <type-desc>` type
@@ -126,9 +133,14 @@ public class SourceCodeGenerator {
             }
         }
 
-        String template = "%stype %s %s;";
+        String template = "%s%stype %s %s;";
 
-        return template.formatted(docs, typeData.name(), typeDescriptor);
+        return template.formatted(
+                docs,
+                isPublicFlagOn(typeData.properties()) ? "public " : "",
+                typeData.name(),
+                typeDescriptor
+        );
     }
 
     private String generateTypeDescriptor(Object typeDescriptor) {
@@ -457,5 +469,10 @@ public class SourceCodeGenerator {
     private boolean isReadonlyFlagOn(Map<String, Property> properties) {
         Property readonlyProperty = properties.get(Property.IS_READ_ONLY_KEY);
         return readonlyProperty != null && readonlyProperty.value().equals("true");
+    }
+
+    private boolean isPublicFlagOn(Map<String, Property> properties) {
+        Property publicProperty = properties.get(Property.IS_PUBLIC_KEY);
+        return publicProperty != null && publicProperty.value().equals("true");
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/TypeTransformer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/TypeTransformer.java
@@ -257,6 +257,7 @@ public class TypeTransformer {
                     .stepOut()
                 .properties()
                     .name(typeName, false, false, false)
+                    .isPublic(enumSymbol.qualifiers().contains(Qualifier.PUBLIC), true, true, false)
                     .isArray("false", true, true, true)
                     .arraySize("", false, false, false);
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
@@ -51,6 +51,7 @@ import io.ballerina.flowmodelgenerator.extension.response.TypeUpdateResponse;
 import io.ballerina.modelgenerator.commons.ModuleInfo;
 import io.ballerina.modelgenerator.commons.PackageUtil;
 import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.diagramutil.connector.models.connector.Type;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
@@ -104,12 +105,12 @@ public class TypesManagerService implements ExtendedLanguageServerService {
                 Path filePath = Path.of(request.filePath());
                 this.workspaceManager.loadProject(filePath);
                 Optional<Document> document = this.workspaceManager.document(filePath);
-                Optional<SemanticModel> semanticModel = this.workspaceManager.semanticModel(filePath);
-                if (document.isEmpty() || semanticModel.isEmpty()) {
+                Optional<Project> project = this.workspaceManager.project(filePath);
+                if (project.isEmpty() || document.isEmpty()) {
                     return response;
                 }
                 TypesManager typesManager = new TypesManager(document.get());
-                JsonElement allTypes = typesManager.getAllTypes(semanticModel.get());
+                JsonElement allTypes = typesManager.getAllTypes(project.get().currentPackage());
                 response.setTypes(allTypes);
             } catch (Throwable e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
## Purpose
$title

Addresses https://github.com/wso2/product-ballerina-integrator/issues/856

## TODO

- [ ] Refactor temporary file-name resolution with relative path and use `codedata.filePath`