### PR TITLE
Display a pop-up notification when a BIR issue occurs due to an unresolved module

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveCompilationErrorsSubscriber.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveCompilationErrorsSubscriber.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.eventsync.subscribers;
+
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.compiler.BLangCompilerException;
+import org.ballerinalang.langserver.command.executors.PullModuleExecutor;
+import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
+import org.ballerinalang.langserver.commons.eventsync.EventKind;
+import org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+
+import java.util.List;
+
+/**
+ * Subscriber to popup notification and resolve compilation errors on project updates.
+ *
+ * @since 1.2.0
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber")
+public class ResolveCompilationErrorsSubscriber implements EventSubscriber {
+
+    public static final String NAME = "Resolve compilation errors subscriber";
+    private static final String PULL_MODULES_ACTION = "Pull Modules";
+
+    @Override
+    public EventKind eventKind() {
+        return EventKind.PROJECT_UPDATE;
+    }
+
+    @Override
+    public void onEvent(ExtendedLanguageClient client, DocumentServiceContext context,
+                        LanguageServerContext serverContext) {
+        try {
+            context.workspace().waitAndGetPackageCompilation(context.filePath());
+        } catch (BLangCompilerException e) {
+            String message = e.getMessage();
+            if (message != null && message.startsWith("failed to load the module")) {
+                ShowMessageRequestParams showMessageRequestParams = new ShowMessageRequestParams();
+                showMessageRequestParams.setType(MessageType.Error);
+                showMessageRequestParams.setMessage(
+                        "Language Server has stopped working. Compilation has failed due to corrupted modules.");
+                showMessageRequestParams.setActions(List.of(new MessageActionItem(PULL_MODULES_ACTION)));
+
+                client.showMessageRequest(showMessageRequestParams).thenAccept(action -> {
+                    if (action != null && PULL_MODULES_ACTION.equals(action.getTitle())) {
+                        PullModuleExecutor.resolveModules(context.fileUri(), client, context.workspace(),
+                                context.languageServercontext());
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveCompilationErrorsSubscriber.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveCompilationErrorsSubscriber.java
@@ -42,8 +42,8 @@ public class ResolveCompilationErrorsSubscriber implements EventSubscriber {
 
     public static final String NAME = "Resolve compilation errors subscriber";
     private static final String PULL_MODULES_ACTION = "Pull Modules";
-    private static final String ERROR_MESSAGE =
-            "Language Server has stopped working. Compilation has failed due to corrupted modules.";
+    private static final String ERROR_MESSAGE = "Language server has stopped working due to unresolved modules " +
+            "in your project. Please resolve them to proceed.";
 
     @Override
     public EventKind eventKind() {

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveModulesSubscriber.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveModulesSubscriber.java
@@ -55,10 +55,10 @@ public class ResolveModulesSubscriber implements EventSubscriber {
     @Override
     public void onEvent(ExtendedLanguageClient client, DocumentServiceContext context,
                         LanguageServerContext serverContext) {
-        // Do this only for the load project or did open
+        // Do this only for the did open
         // TODO: Explore the UX on how we can provide this for each `didChange` with a proper interval
         LSOperation operation = context.operation();
-        if (!operation.equals(LSContextOperation.LOAD_PROJECT) && !operation.equals(LSContextOperation.TXT_DID_OPEN)) {
+        if (!operation.equals(LSContextOperation.TXT_DID_OPEN)) {
             return;
         }
 

--- a/langserver-core/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber
+++ b/langserver-core/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber
@@ -1,3 +1,4 @@
 org.ballerinalang.langserver.eventsync.subscribers.PublishDiagnosticSubscriber
+org.ballerinalang.langserver.eventsync.subscribers.ResolveCompilationErrorsSubscriber
 org.ballerinalang.langserver.eventsync.subscribers.ResolveModulesSubscriber
 org.ballerinalang.langserver.eventsync.subscribers.PullModuleSubscriber


### PR DESCRIPTION
## Purpose

Until https://github.com/ballerina-platform/ballerina-lang/issues/44275 is fixed, the LS crashes without providing feedback to the user. Hence, the LS should gracefully handle this scenario by offering the user an option to resolve the modules.

Addresses https://github.com/wso2/product-ballerina-integrator/issues/1101


## Remarks
- Once the fix is available in the distribution, the UX will align with how direct dependencies are resolved. This interim fix is only relevant for users running an older distribution with the latest extension.
- The fix targets both Ballerina and WSO2: BI users, and therefore uses the standard LSP to produce the notification. As a result, the WSO2: BI GUI is still not aware of this compilation state. To make it more strict, new sequence calls between the extension and LS may be required to communicate the status. However, since a proper solution is expected from [https://github.com/ballerina-platform/ballerina-lang/issues/44275](https://github.com/ballerina-platform/ballerina-lang/issues/44275), we are not prioritizing this at the moment.

## Samples


https://github.com/user-attachments/assets/cdac3e3e-76b5-483f-b215-313e96645d6a

https://github.com/user-attachments/assets/9116ffbb-c62e-48e3-b83e-f14996a317e6

