### PR TITLE
Fix issue with throwing error for record config

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
@@ -545,16 +545,17 @@ public class TypesManagerService implements ExtendedLanguageServerService {
                                                            String version, Path filePath) {
         // Check cache with filePath
         CacheKey keyWithPath = new CacheKey(org, packageName, version);
-        SemanticModel cachedModel = semanticModelCache.get(keyWithPath);
-        if (cachedModel != null) {
-            return Optional.of(cachedModel);
-        }
         // Try to load via filePath-specific method
         Optional<SemanticModel> model = PackageUtil.getSemanticModelIfMatched(workspaceManager, filePath, org,
                 packageName, moduleName, version);
         if (model.isPresent()) {
             semanticModelCache.put(keyWithPath, model.get());
             return model;
+        }
+
+        SemanticModel cachedModel = semanticModelCache.get(keyWithPath);
+        if (cachedModel != null) {
+            return Optional.of(cachedModel);
         }
 
         // Fallback to general package lookup


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/wso2/product-ballerina-integrator/issues/1282

## Approach 

Previously, we cached the semantic model of a working package. However, this approach was error-prone since the cached model might not reflect the latest types or updated type information. With this fix, the semantic model is freshly loaded from the workspace for the working package. For other packages, we continue to use the cached semantic model if it is available.