### PR TITLE
Skip validation for 'var' type in diagnostics

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types20.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types20.json
@@ -1,0 +1,40 @@
+{
+  "description": "var type should not produce diagnostics",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "var",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 4,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Type",
+        "description": "Type of the variable"
+      },
+      "valueType": "TYPE",
+      "value": "",
+      "placeholder": "var",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types21.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types21.json
@@ -1,0 +1,49 @@
+{
+  "description": "var type with type constraint should not produce diagnostics",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "var",
+    "startLine": {
+      "line": 30,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "REMOTE_ACTION_CALL",
+      "org": "ballerina",
+      "module": "http",
+      "object": "Client",
+      "symbol": "get",
+      "version": "2.13.2",
+      "lineRange": {
+        "fileName": "sample.bal",
+        "startLine": {
+          "line": 6,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 6,
+          "offset": 45
+        }
+      },
+      "sourceCode": "json val = check httpClient->get(\"/foo\");"
+    },
+    "property": {
+      "metadata": {
+        "label": "targetType",
+        "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
+      },
+      "valueType": "TYPE",
+      "valueTypeConstraint": "anydata",
+      "placeholder": "json",
+      "optional": true,
+      "editable": true,
+      "advanced": true,
+      "codedata": {
+        "kind": "PARAM_FOR_TYPE_INFER",
+        "originalName": "targetType"
+      }
+    }
+  },
+  "diagnostics": []
+}


### PR DESCRIPTION
## Purpose
Added early exit conditions in both syntax and semantic diagnostic methods to skip validation when the input is `var`, since type inference keywords cannot be validated like concrete types.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/1304