### PR TITLE
Disable diagnostics for anonymous types

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/TypeDiagnosticRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/TypeDiagnosticRequest.java
@@ -85,8 +85,15 @@ public class TypeDiagnosticRequest extends DiagnosticsRequest {
 
         // Check for undefined types
         Types types = semanticModel.get().types();
-        Optional<TypeSymbol> typeSymbol =
-                BallerinaCompilerApi.getInstance().getType(types, document.get(), inputExpression);
+        Optional<TypeSymbol> typeSymbol;
+        try {
+            typeSymbol = BallerinaCompilerApi.getInstance().getType(types, document.get(), inputExpression);
+        } catch (NullPointerException e) {
+            // TODO: Tracked with https://github.com/ballerina-platform/ballerina-lang/issues/44347
+            // Handle cases where the type descriptor doesn't have a parent context
+            // (e.g., anonymous record types like "record {}")
+            return diagnostics;
+        }
         if (typeSymbol.isEmpty()) {
             String message = String.format(UNDEFINED_TYPE, inputExpression);
             diagnostics.add(CommonUtils.createDiagnostic(message, context.getExpressionLineRange(),

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types22.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types22.json
@@ -1,0 +1,41 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "record {}",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "lineOffset": 0,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Type",
+        "description": "Type of the variable"
+      },
+      "valueType": "TYPE",
+      "value": "",
+      "placeholder": "var",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}


### PR DESCRIPTION
## Purpose
$title due to a null pointer exception in the `getType` API when an anonymous type is provided.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/960
