### PR TITLE
Add extended fields of CDC into the integrator artifact

### DIFF
--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/AbstractCdcServiceBuilder.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/AbstractCdcServiceBuilder.java
@@ -507,7 +507,7 @@ public abstract class AbstractCdcServiceBuilder extends AbstractServiceBuilder {
         for (String key : List.of(KEY_OPTIONS, KEY_LIVENESS_INTERVAL,
                                   KEY_INTERNAL_SCHEMA_STORAGE, KEY_OFFSET_STORAGE)) {
             Value v = properties.get(key);
-            if (v != null && isInvalidValue(v.getValue())) {
+            if (v != null && v.getValue() != null && isInvalidValue(v.getValue())) {
                 properties.remove(key);
             }
         }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/AbstractCdcServiceBuilder.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/AbstractCdcServiceBuilder.java
@@ -103,6 +103,11 @@ public abstract class AbstractCdcServiceBuilder extends AbstractServiceBuilder {
     protected static final String CDC_MODULE_NAME = "cdc";
     protected static final String UNNAMED_IMPORT_SUFFIX = " as _";
 
+    // Schema driver module names
+    private static final String SCHEMA_DRIVER_AMAZON_S3 = "cdc.schema.aws.s3.driver";
+    private static final String SCHEMA_DRIVER_AZURE_BLOB = "cdc.schema.azure.blob.driver";
+    private static final String SCHEMA_DRIVER_ROCKETMQ = "cdc.schema.rocketmq.driver";
+
     // Property keys
     protected static final String KEY_LISTENER_VAR_NAME = "listenerVarName";
     protected static final String KEY_HOST = "host";
@@ -113,6 +118,9 @@ public abstract class AbstractCdcServiceBuilder extends AbstractServiceBuilder {
     protected static final String KEY_SCHEMAS = "schemas";
     protected static final String KEY_SECURE_SOCKET = "secureSocket";
     protected static final String KEY_OPTIONS = "options";
+    protected static final String KEY_LIVENESS_INTERVAL = "livenessInterval";
+    protected static final String KEY_INTERNAL_SCHEMA_STORAGE = "internalSchemaStorage";
+    protected static final String KEY_OFFSET_STORAGE = "offsetStorage";
     protected static final String KEY_CONFIGURE_LISTENER = "configureListener";
     protected static final String KEY_ADVANCED_CONFIGURATIONS = "advancedConfigurations";
     protected static final String KEY_TABLE = "table";
@@ -360,6 +368,11 @@ public abstract class AbstractCdcServiceBuilder extends AbstractServiceBuilder {
         } else {
             // Build new listener declaration
             applyListenerConfigurations(properties);
+            // Add driver imports for schema storage types that require external drivers
+            List<Import> schemaDriverImports = getSchemaDriverImports(properties);
+            if (!schemaDriverImports.isEmpty()) {
+                addImportTextEdits(modulePartNode, schemaDriverImports.toArray(new Import[0]), edits);
+            }
             ListenerDTO listenerDTO = buildCdcListenerDTO(
                     serviceInitModel.getModuleName(), properties);
             listenerName = listenerDTO.listenerVarName();
@@ -422,7 +435,15 @@ public abstract class AbstractCdcServiceBuilder extends AbstractServiceBuilder {
                 requiredParams.add(value.getValue());
             } else if (argType.equals(ARG_TYPE_LISTENER_PARAM_INCLUDED_FIELD)
                     || argType.equals(ARG_TYPE_LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD)) {
-                includedParams.add(entry.getKey() + " = " + value.getValue());
+                String key = entry.getKey();
+                String fieldValue = value.getValue();
+                if (KEY_INTERNAL_SCHEMA_STORAGE.equals(key) || KEY_OFFSET_STORAGE.equals(key)) {
+                    String selectedType = getSelectedTypeMemberName(value);
+                    if (selectedType != null) {
+                        fieldValue = "<" + CDC_MODULE_NAME + ":" + selectedType + ">" + fieldValue;
+                    }
+                }
+                includedParams.add(key + " = " + fieldValue);
             }
         }
         String listenerProtocol = getProtocol(moduleName);
@@ -441,7 +462,7 @@ public abstract class AbstractCdcServiceBuilder extends AbstractServiceBuilder {
      */
     private void applyListenerConfigurations(Map<String, Value> properties) {
         addDatabaseConfiguration(properties);
-        validateAndRemoveInvalidOptions(properties);
+        validateAndRemoveInvalidParams(properties);
     }
 
     private String buildServiceConfigurations(Value tableValue) {
@@ -482,11 +503,52 @@ public abstract class AbstractCdcServiceBuilder extends AbstractServiceBuilder {
         return value.isBlank() || emptyStringTemplate.matcher(value.trim()).matches();
     }
 
-    private void validateAndRemoveInvalidOptions(Map<String, Value> properties) {
-        Value optionsValue = properties.get(KEY_OPTIONS);
-        if (optionsValue != null && isInvalidValue(optionsValue.getValue())) {
-            properties.remove(KEY_OPTIONS);
+    private void validateAndRemoveInvalidParams(Map<String, Value> properties) {
+        for (String key : List.of(KEY_OPTIONS, KEY_LIVENESS_INTERVAL,
+                                  KEY_INTERNAL_SCHEMA_STORAGE, KEY_OFFSET_STORAGE)) {
+            Value v = properties.get(key);
+            if (v != null && isInvalidValue(v.getValue())) {
+                properties.remove(key);
+            }
         }
+    }
+
+    private String getSelectedTypeMemberName(Value value) {
+        if (value == null || value.getTypes() == null) {
+            return null;
+        }
+        return value.getTypes().stream()
+                .filter(t -> t.fieldType() == Value.FieldType.RECORD_MAP_EXPRESSION && t.selected())
+                .findFirst()
+                .map(t -> t.typeMembers() == null ? null :
+                        t.typeMembers().stream()
+                                .filter(PropertyTypeMemberInfo::selected)
+                                .findFirst()
+                                .map(PropertyTypeMemberInfo::type)
+                                .orElse(null))
+                .orElse(null);
+    }
+
+    private List<Import> getSchemaDriverImports(Map<String, Value> properties) {
+        List<Import> driverImports = new ArrayList<>();
+        Value schemaStorage = properties.get(KEY_INTERNAL_SCHEMA_STORAGE);
+        if (schemaStorage == null) {
+            return driverImports;
+        }
+        String selectedType = getSelectedTypeMemberName(schemaStorage);
+        if (selectedType == null) {
+            return driverImports;
+        }
+        switch (selectedType) {
+            case "AmazonS3InternalSchemaStorage" ->
+                    driverImports.add(new Import(BALLERINAX, SCHEMA_DRIVER_AMAZON_S3, true));
+            case "AzureBlobInternalSchemaStorage" ->
+                    driverImports.add(new Import(BALLERINAX, SCHEMA_DRIVER_AZURE_BLOB, true));
+            case "RocketMQInternalSchemaStorage" ->
+                    driverImports.add(new Import(BALLERINAX, SCHEMA_DRIVER_ROCKETMQ, true));
+            default -> { }
+        }
+        return driverImports;
     }
 
     private void unwrapGroupSections(Map<String, Value> properties) {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/MssqlCdcServiceBuilder.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/MssqlCdcServiceBuilder.java
@@ -72,7 +72,8 @@ public final class MssqlCdcServiceBuilder extends AbstractCdcServiceBuilder {
     private static final Set<String> METADATA_KEYS = Set.of(
             KEY_HOST, KEY_PORT, KEY_USERNAME, KEY_PASSWORD,
             KEY_DATABASES, KEY_SCHEMAS, KEY_DATABASE_INSTANCE,
-            KEY_SECURE_SOCKET, KEY_OPTIONS
+            KEY_SECURE_SOCKET, KEY_OPTIONS,
+            KEY_LIVENESS_INTERVAL, KEY_INTERNAL_SCHEMA_STORAGE, KEY_OFFSET_STORAGE
     );
 
     @Override
@@ -219,6 +220,15 @@ public final class MssqlCdcServiceBuilder extends AbstractCdcServiceBuilder {
                 case "options" -> config.put(KEY_OPTIONS,
                         ListenerUtil.buildReadOnlyTextValue("Options",
                                 "Additional options for the CDC engine", argValue));
+                case "livenessInterval" -> config.put(KEY_LIVENESS_INTERVAL,
+                        ListenerUtil.buildReadOnlyNumberValue("Liveness Interval",
+                                "Interval in seconds for the CDC engine liveness check", argValue));
+                case "internalSchemaStorage" -> config.put(KEY_INTERNAL_SCHEMA_STORAGE,
+                        ListenerUtil.buildReadOnlyTextValue("Internal Schema Storage",
+                                "Storage configuration for the internal schema history", argValue));
+                case "offsetStorage" -> config.put(KEY_OFFSET_STORAGE,
+                        ListenerUtil.buildReadOnlyTextValue("Offset Storage",
+                                "Storage configuration for CDC offsets", argValue));
                 default -> {
                 }
             }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/PostgresqlCdcServiceBuilder.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/service/PostgresqlCdcServiceBuilder.java
@@ -70,7 +70,8 @@ public final class PostgresqlCdcServiceBuilder extends AbstractCdcServiceBuilder
     private static final String DISPLAY_LABEL = "PostgreSQL CDC";
     private static final Set<String> METADATA_KEYS = Set.of(
             KEY_HOST, KEY_PORT, KEY_USERNAME, KEY_PASSWORD,
-            KEY_DATABASE, KEY_SCHEMAS, KEY_SECURE_SOCKET, KEY_OPTIONS
+            KEY_DATABASE, KEY_SCHEMAS, KEY_SECURE_SOCKET, KEY_OPTIONS,
+            KEY_LIVENESS_INTERVAL, KEY_INTERNAL_SCHEMA_STORAGE, KEY_OFFSET_STORAGE
     );
 
     @Override
@@ -216,6 +217,18 @@ public final class PostgresqlCdcServiceBuilder extends AbstractCdcServiceBuilder
                 case "options" -> config.put(KEY_OPTIONS,
                         ListenerUtil.buildReadOnlyTextValue("Options",
                                 "Additional options for the CDC engine",
+                                namedArg.expression().toSourceCode().trim()));
+                case "livenessInterval" -> config.put(KEY_LIVENESS_INTERVAL,
+                        ListenerUtil.buildReadOnlyNumberValue("Liveness Interval",
+                                "Interval in seconds for the CDC engine liveness check",
+                                namedArg.expression().toSourceCode().trim()));
+                case "internalSchemaStorage" -> config.put(KEY_INTERNAL_SCHEMA_STORAGE,
+                        ListenerUtil.buildReadOnlyTextValue("Internal Schema Storage",
+                                "Storage configuration for the internal schema history",
+                                namedArg.expression().toSourceCode().trim()));
+                case "offsetStorage" -> config.put(KEY_OFFSET_STORAGE,
+                        ListenerUtil.buildReadOnlyTextValue("Offset Storage",
+                                "Storage configuration for CDC offsets",
                                 namedArg.expression().toSourceCode().trim()));
                 default -> {
                 }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/services/cdc_mssql.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/services/cdc_mssql.json
@@ -350,6 +350,179 @@
                       "editable": true,
                       "optional": true,
                       "advanced": false
+                    },
+                    "livenessInterval": {
+                      "metadata": {
+                        "label": "Liveness Interval",
+                        "description": "Interval in seconds for the CDC engine liveness check"
+                      },
+                      "codedata": {
+                        "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                      },
+                      "placeholder": "60",
+                      "types": [
+                        {
+                          "fieldType": "NUMBER",
+                          "ballerinaType": "decimal",
+                          "selected": true
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "decimal",
+                          "selected": false
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": true,
+                      "advanced": false
+                    },
+                    "internalSchemaStorage": {
+                      "metadata": {
+                        "label": "Internal Schema Storage",
+                        "description": "Storage configuration for the internal schema history"
+                      },
+                      "codedata": {
+                        "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                      },
+                      "placeholder": "",
+                      "types": [
+                        {
+                          "fieldType": "RECORD_MAP_EXPRESSION",
+                          "ballerinaType": "cdc:InternalSchemaStorage",
+                          "typeMembers": [
+                            {
+                              "type": "FileInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": true
+                            },
+                            {
+                              "type": "KafkaInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "MemoryInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "JdbcInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "RedisInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "AmazonS3InternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "AzureBlobInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "RocketMQInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            }
+                          ],
+                          "selected": true
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "cdc:InternalSchemaStorage",
+                          "selected": false
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": true,
+                      "advanced": false
+                    },
+                    "offsetStorage": {
+                      "metadata": {
+                        "label": "Offset Storage",
+                        "description": "Storage configuration for CDC offsets"
+                      },
+                      "codedata": {
+                        "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                      },
+                      "placeholder": "",
+                      "types": [
+                        {
+                          "fieldType": "RECORD_MAP_EXPRESSION",
+                          "ballerinaType": "cdc:OffsetStorage",
+                          "typeMembers": [
+                            {
+                              "type": "FileOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": true
+                            },
+                            {
+                              "type": "KafkaOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "MemoryOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "JdbcOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "RedisOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            }
+                          ],
+                          "selected": true
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "cdc:OffsetStorage",
+                          "selected": false
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": true,
+                      "advanced": false
                     }
                   }
                 }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/services/cdc_postgresql.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/services/cdc_postgresql.json
@@ -328,6 +328,179 @@
                       "editable": true,
                       "optional": true,
                       "advanced": false
+                    },
+                    "livenessInterval": {
+                      "metadata": {
+                        "label": "Liveness Interval",
+                        "description": "Interval in seconds for the CDC engine liveness check"
+                      },
+                      "codedata": {
+                        "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                      },
+                      "placeholder": "60",
+                      "types": [
+                        {
+                          "fieldType": "NUMBER",
+                          "ballerinaType": "decimal",
+                          "selected": true
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "decimal",
+                          "selected": false
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": true,
+                      "advanced": false
+                    },
+                    "internalSchemaStorage": {
+                      "metadata": {
+                        "label": "Internal Schema Storage",
+                        "description": "Storage configuration for the internal schema history"
+                      },
+                      "codedata": {
+                        "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                      },
+                      "placeholder": "",
+                      "types": [
+                        {
+                          "fieldType": "RECORD_MAP_EXPRESSION",
+                          "ballerinaType": "cdc:InternalSchemaStorage",
+                          "typeMembers": [
+                            {
+                              "type": "FileInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": true
+                            },
+                            {
+                              "type": "KafkaInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "MemoryInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "JdbcInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "RedisInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "AmazonS3InternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "AzureBlobInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "RocketMQInternalSchemaStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            }
+                          ],
+                          "selected": true
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "cdc:InternalSchemaStorage",
+                          "selected": false
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": true,
+                      "advanced": false
+                    },
+                    "offsetStorage": {
+                      "metadata": {
+                        "label": "Offset Storage",
+                        "description": "Storage configuration for CDC offsets"
+                      },
+                      "codedata": {
+                        "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                      },
+                      "placeholder": "",
+                      "types": [
+                        {
+                          "fieldType": "RECORD_MAP_EXPRESSION",
+                          "ballerinaType": "cdc:OffsetStorage",
+                          "typeMembers": [
+                            {
+                              "type": "FileOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": true
+                            },
+                            {
+                              "type": "KafkaOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "MemoryOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "JdbcOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            },
+                            {
+                              "type": "RedisOffsetStorage",
+                              "packageInfo": "ballerinax:cdc:1.3.0",
+                              "packageName": "cdc",
+                              "kind": "RECORD_TYPE",
+                              "selected": false
+                            }
+                          ],
+                          "selected": true
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "cdc:OffsetStorage",
+                          "selected": false
+                        }
+                      ],
+                      "enabled": true,
+                      "editable": true,
+                      "optional": true,
+                      "advanced": false
                     }
                   }
                 }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/cdc_mssql_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/cdc_mssql_service_model.json
@@ -328,6 +328,179 @@
                           "editable": true,
                           "optional": true,
                           "advanced": false
+                        },
+                        "livenessInterval": {
+                          "metadata": {
+                            "label": "Liveness Interval",
+                            "description": "Interval in seconds for the CDC engine liveness check"
+                          },
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                          },
+                          "placeholder": "60",
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "decimal",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "decimal",
+                              "selected": false
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": false
+                        },
+                        "internalSchemaStorage": {
+                          "metadata": {
+                            "label": "Internal Schema Storage",
+                            "description": "Storage configuration for the internal schema history"
+                          },
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                          },
+                          "placeholder": "",
+                          "types": [
+                            {
+                              "fieldType": "RECORD_MAP_EXPRESSION",
+                              "ballerinaType": "cdc:InternalSchemaStorage",
+                              "typeMembers": [
+                                {
+                                  "type": "FileInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": true
+                                },
+                                {
+                                  "type": "KafkaInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "MemoryInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "JdbcInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "RedisInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "AmazonS3InternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "AzureBlobInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "RocketMQInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                }
+                              ],
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "cdc:InternalSchemaStorage",
+                              "selected": false
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": false
+                        },
+                        "offsetStorage": {
+                          "metadata": {
+                            "label": "Offset Storage",
+                            "description": "Storage configuration for CDC offsets"
+                          },
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                          },
+                          "placeholder": "",
+                          "types": [
+                            {
+                              "fieldType": "RECORD_MAP_EXPRESSION",
+                              "ballerinaType": "cdc:OffsetStorage",
+                              "typeMembers": [
+                                {
+                                  "type": "FileOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": true
+                                },
+                                {
+                                  "type": "KafkaOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "MemoryOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "JdbcOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "RedisOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                }
+                              ],
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "cdc:OffsetStorage",
+                              "selected": false
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": false
                         }
                       },
                       "types": [

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/cdc_postgresql_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/cdc_postgresql_service_model.json
@@ -305,6 +305,179 @@
                           "editable": true,
                           "optional": true,
                           "advanced": false
+                        },
+                        "livenessInterval": {
+                          "metadata": {
+                            "label": "Liveness Interval",
+                            "description": "Interval in seconds for the CDC engine liveness check"
+                          },
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                          },
+                          "placeholder": "60",
+                          "types": [
+                            {
+                              "fieldType": "NUMBER",
+                              "ballerinaType": "decimal",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "decimal",
+                              "selected": false
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": false
+                        },
+                        "internalSchemaStorage": {
+                          "metadata": {
+                            "label": "Internal Schema Storage",
+                            "description": "Storage configuration for the internal schema history"
+                          },
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                          },
+                          "placeholder": "",
+                          "types": [
+                            {
+                              "fieldType": "RECORD_MAP_EXPRESSION",
+                              "ballerinaType": "cdc:InternalSchemaStorage",
+                              "typeMembers": [
+                                {
+                                  "type": "FileInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": true
+                                },
+                                {
+                                  "type": "KafkaInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "MemoryInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "JdbcInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "RedisInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "AmazonS3InternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "AzureBlobInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "RocketMQInternalSchemaStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                }
+                              ],
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "cdc:InternalSchemaStorage",
+                              "selected": false
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": false
+                        },
+                        "offsetStorage": {
+                          "metadata": {
+                            "label": "Offset Storage",
+                            "description": "Storage configuration for CDC offsets"
+                          },
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD"
+                          },
+                          "placeholder": "",
+                          "types": [
+                            {
+                              "fieldType": "RECORD_MAP_EXPRESSION",
+                              "ballerinaType": "cdc:OffsetStorage",
+                              "typeMembers": [
+                                {
+                                  "type": "FileOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": true
+                                },
+                                {
+                                  "type": "KafkaOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "MemoryOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "JdbcOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                },
+                                {
+                                  "type": "RedisOffsetStorage",
+                                  "packageInfo": "ballerinax:cdc:1.3.0",
+                                  "packageName": "cdc",
+                                  "kind": "RECORD_TYPE",
+                                  "selected": false
+                                }
+                              ],
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "cdc:OffsetStorage",
+                              "selected": false
+                            }
+                          ],
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": false
                         }
                       },
                       "types": [


### PR DESCRIPTION
Part of https://github.com/wso2/product-integrator/issues/616

> **Depends on**: wso2/vscode-extensions#1884

## Summary
- Introduce livenessInterval, internalSchemaStorage, offsetStorage fields into the advancedConfig section of the CDC listener init forms.

<img width="589" height="677" alt="image" src="https://github.com/user-attachments/assets/a42fb81f-af5d-40cb-9df1-ba6630488efe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request adds support for three new configuration fields to CDC (Change Data Capture) listener initialization: `livenessInterval`, `internalSchemaStorage`, and `offsetStorage`. These fields expand the advanced configuration options available when setting up CDC connectors for both MSSQL and PostgreSQL databases.

## Changes

**Service Model Generator Extension**
- Extended `AbstractCdcServiceBuilder` to handle the new configuration fields, including logic to determine selected storage implementation types and apply appropriate type wrapping
- Updated parameter validation to handle the new fields alongside existing configuration options
- Added helper methods to infer storage implementation types and map them to corresponding module imports

**Configuration Schemas**
- Added three new listener parameters to both MSSQL and PostgreSQL CDC service definitions:
  - `livenessInterval`: A numeric interval (in seconds) for CDC liveness checks, configurable via text or expression input
  - `internalSchemaStorage`: A configurable storage backend for CDC schema history with support for multiple implementations (File, Kafka, Memory, Jdbc, Redis, S3, Azure Blob, RocketMQ)
  - `offsetStorage`: A configurable storage backend for CDC offsets with support for multiple implementations (File, Kafka, Memory, Jdbc, Redis)

**Test Resources**
- Updated service init model test fixtures to include metadata and type information for the new configuration fields

## Outcome

CDC service integrations now support more granular configuration of liveness monitoring and storage backends for both schema history and offset management, providing users with greater flexibility in tuning their data capture pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->