### PR TITLE
Add a caching layer for connection actions

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/build.gradle
+++ b/flow-model-generator/modules/flow-model-generator-core/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation "org.ballerinalang:central-client:${ballerinaLangVersion}"
     implementation "org.ballerinalang:formatter-core:${ballerinaLangVersion}"
     implementation "com.google.code.gson:gson:${gsonVersion}"
+    implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
     implementation "com.graphql-java:graphql-java:${graphqlJavaVersion}"
     compileOnly "org.eclipse.lsp4j:org.eclipse.lsp4j:${eclipseLsp4jVersion}"
 

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
@@ -465,7 +465,6 @@ public class AvailableNodesGenerator {
                 return Optional.empty();
             }
             String parentSymbolName = symbol.getName().orElseThrow();
-            String className = classSymbol.getName().orElseThrow();
             ModuleInfo moduleInfo = classSymbol.getModule()
                     .map(moduleSymbol -> ModuleInfo.from(moduleSymbol.id()))
                     .orElse(null);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
@@ -25,7 +25,6 @@ import com.google.gson.JsonObject;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
-import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -43,7 +42,6 @@ import io.ballerina.flowmodelgenerator.core.model.Category;
 import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.flowmodelgenerator.core.model.Item;
 import io.ballerina.flowmodelgenerator.core.model.Metadata;
-import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.node.AgentRunBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ChunkerBuilder;
@@ -55,8 +53,6 @@ import io.ballerina.flowmodelgenerator.core.model.node.NPFunctionCall;
 import io.ballerina.flowmodelgenerator.core.model.node.VectorStoreBuilder;
 import io.ballerina.flowmodelgenerator.core.utils.ConnectorUtil;
 import io.ballerina.modelgenerator.commons.CommonUtils;
-import io.ballerina.modelgenerator.commons.FunctionData;
-import io.ballerina.modelgenerator.commons.FunctionDataBuilder;
 import io.ballerina.modelgenerator.commons.ModuleInfo;
 import io.ballerina.modelgenerator.commons.PackageUtil;
 import io.ballerina.projects.Document;
@@ -76,7 +72,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static io.ballerina.flowmodelgenerator.core.Constants.Ai;
-import static io.ballerina.flowmodelgenerator.core.Constants.BALLERINA;
 import static io.ballerina.flowmodelgenerator.core.Constants.NaturalFunctions;
 import static io.ballerina.modelgenerator.commons.CommonUtils.CONNECTOR_TYPE;
 import static io.ballerina.modelgenerator.commons.CommonUtils.PERSIST;
@@ -85,7 +80,6 @@ import static io.ballerina.modelgenerator.commons.CommonUtils.getPersistDatabase
 import static io.ballerina.modelgenerator.commons.CommonUtils.getPersistModelFilePath;
 import static io.ballerina.modelgenerator.commons.CommonUtils.isAgentClass;
 import static io.ballerina.modelgenerator.commons.CommonUtils.isAiEmbeddingProvider;
-import static io.ballerina.modelgenerator.commons.CommonUtils.isAiKnowledgeBase;
 import static io.ballerina.modelgenerator.commons.CommonUtils.isAiModelProvider;
 import static io.ballerina.modelgenerator.commons.CommonUtils.isPersistClient;
 
@@ -102,9 +96,6 @@ public class AvailableNodesGenerator {
     private final Package pkg;
     private final Gson gson;
     private final Path filePath;
-    private static final String HTTP_MODULE = "http";
-    private static final List<String> HTTP_REMOTE_METHOD_SKIP_LIST = List.of("get", "put", "post", "head",
-            "delete", "patch", "options");
     private static final String BALLERINAX = "ballerinax";
     private static final String TEST_MODULE_PREFIX = "test";
     private static final String TEST_CONFIG_ANNOTATION = "Config";
@@ -484,94 +475,10 @@ public class AvailableNodesGenerator {
                     PackageUtil.resolveModulePackage(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version()) :
                     Optional.empty();
 
-            FunctionDataBuilder functionDataBuilder = new FunctionDataBuilder()
-                    .parentSymbol(classSymbol)
-                    .parentSymbolType(className)
-                    .project(pkg.project())
-                    .moduleInfo(moduleInfo)
-                    .resolvedPackage(resolvedPackage.orElse(null))
-                    .enableIndex();
-
-            // Obtain methods of the classes
-            List<FunctionData> methodFunctionsData = functionDataBuilder.buildChildNodes();
-
-            // Compute tool compatibility for each method using the semantic model (only when requested)
-            if (checkAgentToolCompatibility) {
-                Map<String, MethodSymbol> classMethodSymbols = classSymbol.methods();
-                for (FunctionData methodFunction : methodFunctionsData) {
-                    MethodSymbol methodSymbol = classMethodSymbols.get(methodFunction.name());
-                    if (methodSymbol != null) {
-                        try {
-                            AiUtils.AgentToolCompatibility toolCompat = AiUtils.checkAgentToolCompatibility(
-                                    methodSymbol.qualifiers(), methodSymbol.typeDescriptor(), semanticModel);
-                            methodFunction.setAgentToolCompatible(toolCompat.compatible());
-                        } catch (Throwable ignored) {
-                            // Default to false on failure
-                        }
-                    }
-                }
-            }
-
             Optional<String> persistIcon = isPersistClient(classSymbol, semanticModel)
                     ? getPersistDatabaseIcon(classSymbol) : Optional.empty();
-
-            List<Item> methods = new ArrayList<>();
-            for (FunctionData methodFunction : methodFunctionsData) {
-                String org = methodFunction.org();
-                String packageName = methodFunction.packageName();
-                String version = methodFunction.version();
-                boolean isHttpModule = org.equals(BALLERINA) && packageName.equals(HTTP_MODULE);
-
-                NodeBuilder nodeBuilder;
-                String label;
-                if (methodFunction.kind() == FunctionData.Kind.RESOURCE) {
-                    // TODO: Move this logic to the index
-                    if (isHttpModule && HTTP_REMOTE_METHOD_SKIP_LIST.contains(methodFunction.name())) {
-                        continue;
-                    }
-                    label = methodFunction.name() + (isHttpModule ? "" : methodFunction.resourcePath());
-                    nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.RESOURCE_ACTION_CALL);
-                } else {
-                    label = methodFunction.name();
-                    FunctionData.Kind kind = methodFunction.kind();
-                    if (kind == FunctionData.Kind.REMOTE) {
-                        nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.REMOTE_ACTION_CALL);
-                    } else if (isAgentClass(classSymbol) && label.equals(Ai.AGENT_RUN_METHOD_NAME)) {
-                        nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.AGENT_RUN);
-                    } else if (kind == FunctionData.Kind.FUNCTION && isAiKnowledgeBase(classSymbol)) {
-                        nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.KNOWLEDGE_BASE_CALL);
-                    } else if (kind == FunctionData.Kind.FUNCTION) {
-                        nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.METHOD_CALL);
-                    } else {
-                        throw new IllegalStateException("Unexpected value: " + kind);
-                    }
-                }
-
-                String icon = persistIcon.orElse(CommonUtils.generateIcon(org, packageName, version));
-                nodeBuilder
-                        .metadata()
-                        .label(label)
-                        .icon(icon)
-                        .description(methodFunction.description())
-                        .stepOut()
-                        .codedata()
-                        .org(org)
-                        .module(moduleInfo.moduleName())
-                        .packageName(moduleInfo.packageName())
-                        .object(className)
-                        .symbol(methodFunction.name())
-                        .version(version)
-                        .parentSymbol(parentSymbolName)
-                        .resourcePath(methodFunction.resourcePath());
-                if (checkAgentToolCompatibility) {
-                    nodeBuilder.codedata()
-                            .addData("agentToolCompatible", methodFunction.agentToolCompatible());
-                }
-                Item node = nodeBuilder.codedata()
-                        .stepOut()
-                        .buildAvailableNode();
-                methods.add(node);
-            }
+            List<Item> methods = ConnectionActionProvider.getInstance().getActions(classSymbol, parentSymbolName,
+                    pkg.project(), semanticModel, checkAgentToolCompatibility);
 
             Metadata.Builder<?> metadataBuilder = new Metadata.Builder<>(null)
                     .label(parentSymbolName);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -86,16 +86,6 @@ public class ConnectionActionProvider {
     private final Gson gson;
     private final AtomicBoolean diskAvailable;
 
-    private static final class ProviderHolder {
-
-        private static final ConnectionActionProvider INSTANCE = new ConnectionActionProvider();
-    }
-
-    private record ConnectorContext(String cacheKey, ClassSymbol classSymbol, String className, ModuleInfo moduleInfo,
-                                    Package resolvedPackage, boolean knowledgeBase, boolean agentClass,
-                                    String iconOverride) {
-    }
-
     public static ConnectionActionProvider getInstance() {
         return ProviderHolder.INSTANCE;
     }
@@ -117,14 +107,31 @@ public class ConnectionActionProvider {
                 .build();
     }
 
+    ConnectionActionProvider(Path cacheDirectory, long maxCacheSize) {
+        this.cacheDirectory = cacheDirectory;
+        this.diskAvailable = new AtomicBoolean(true);
+        this.gson = new GsonBuilder()
+                .registerTypeAdapter(Item.class, new ItemDeserializer())
+                .registerTypeAdapter(Category.class, new CategoryDeserializer())
+                .create();
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(maxCacheSize)
+                .removalListener((String key, List<Item> value, RemovalCause cause) -> {
+                    if (cause == RemovalCause.EXPLICIT && key != null) {
+                        deleteFromDisk(key);
+                    }
+                })
+                .build();
+    }
+
     public List<Item> getActions(ClassSymbol classSymbol, String parentSymbolName, Project project,
                                  SemanticModel semanticModel, boolean includeAgentToolCompatibility) {
         ConnectorContext context = createContext(classSymbol, project, semanticModel);
-        List<Item> cachedTemplates = getOrBuildTemplates(context, project);
+        List<Item> cachedTemplates = getOrBuildTemplates(context);
         Map<String, Boolean> compatibilityMap = includeAgentToolCompatibility
                 ? getAgentToolCompatibilityMap(classSymbol, semanticModel)
                 : Map.of();
-        return bindParentSymbol(cachedTemplates, parentSymbolName, compatibilityMap);
+        return bindForParentSymbol(cachedTemplates, parentSymbolName, compatibilityMap);
     }
 
     public void populate(Codedata codedata, WorkspaceManager workspaceManager, Path filePath) {
@@ -137,11 +144,46 @@ public class ConnectionActionProvider {
         if (context == null) {
             return;
         }
-        getOrBuildTemplates(context, project);
+        getOrBuildTemplates(context);
     }
 
     public void invalidate(String cacheKey) {
         cache.invalidate(cacheKey);
+        deleteFromDisk(cacheKey);
+    }
+
+    void clearAll() {
+        cache.invalidateAll();
+        diskAvailable.set(true);
+    }
+
+    void cleanUp() {
+        cache.cleanUp();
+    }
+
+    Path cacheFilePath(String cacheKey) {
+        return cacheDirectory.resolve(keyToFileName(cacheKey));
+    }
+
+    List<Item> bindForParentSymbol(List<Item> cachedMethods, String parentSymbolName,
+                                   Map<String, Boolean> compatibilityMap) {
+        return bindParentSymbol(cachedMethods, parentSymbolName, compatibilityMap);
+    }
+
+    List<Item> getOrBuild(String cacheKey, SupplierFn<List<Item>> supplier) {
+        return cache.get(cacheKey, key -> {
+            List<Item> fromDisk = loadFromDisk(key);
+            if (fromDisk != null && !fromDisk.isEmpty()) {
+                return List.copyOf(fromDisk);
+            }
+            List<Item> built = supplier.get();
+            if (built == null || built.isEmpty()) {
+                return List.of();
+            }
+            List<Item> immutable = List.copyOf(built);
+            persistToDisk(key, immutable);
+            return immutable;
+        });
     }
 
     public static String generateKey(String org, String packageName, String moduleName, String className,
@@ -159,17 +201,8 @@ public class ConnectionActionProvider {
         return generateKey(codedata.org(), packageName, codedata.module(), codedata.object(), codedata.version());
     }
 
-    private List<Item> getOrBuildTemplates(ConnectorContext context, Project project) {
-        List<Item> cachedItems = getCachedTemplates(context.cacheKey());
-        if (!cachedItems.isEmpty()) {
-            return cachedItems;
-        }
-
-        List<Item> builtItems = buildTemplates(context, project);
-        List<Item> immutableItems = List.copyOf(builtItems);
-        cache.put(context.cacheKey(), immutableItems);
-        persistToDisk(context.cacheKey(), immutableItems);
-        return immutableItems;
+    private List<Item> getOrBuildTemplates(ConnectorContext context) {
+        return getOrBuild(context.cacheKey(), () -> buildTemplates(context, context.project()));
     }
 
     private ConnectorContext createContext(ClassSymbol classSymbol, Project project, SemanticModel semanticModel) {
@@ -188,7 +221,8 @@ public class ConnectionActionProvider {
                 resolvedPackage,
                 isAiKnowledgeBase(classSymbol),
                 isAgentClass(classSymbol),
-                persistClient ? getPersistDatabaseIcon(classSymbol).orElse(null) : null
+                persistClient ? getPersistDatabaseIcon(classSymbol).orElse(null) : null,
+                project
         );
     }
 
@@ -379,21 +413,6 @@ public class ConnectionActionProvider {
                 .findFirst();
     }
 
-    private List<Item> getCachedTemplates(String cacheKey) {
-        List<Item> inMemory = cache.getIfPresent(cacheKey);
-        if (inMemory != null && !inMemory.isEmpty()) {
-            return inMemory;
-        }
-
-        List<Item> fromDisk = loadFromDisk(cacheKey);
-        if (fromDisk != null && !fromDisk.isEmpty()) {
-            List<Item> immutableItems = List.copyOf(fromDisk);
-            cache.put(cacheKey, immutableItems);
-            return immutableItems;
-        }
-        return List.of();
-    }
-
     private List<Item> loadFromDisk(String cacheKey) {
         if (!diskAvailable.get()) {
             return null;
@@ -411,7 +430,6 @@ public class ConnectionActionProvider {
                 return List.of(items);
             }
         } catch (Exception ignored) {
-            diskAvailable.set(false);
             return null;
         }
     }
@@ -448,6 +466,23 @@ public class ConnectionActionProvider {
 
     private static String keyToFileName(String cacheKey) {
         return cacheKey.replace(":", "_").replace("/", "-").replace("\\", "-") + ".json";
+    }
+
+    private static final class ProviderHolder {
+
+        private static final ConnectionActionProvider INSTANCE = new ConnectionActionProvider();
+    }
+
+    private record ConnectorContext(String cacheKey, ClassSymbol classSymbol, String className, ModuleInfo moduleInfo,
+                                    Package resolvedPackage, boolean knowledgeBase, boolean agentClass,
+                                    String iconOverride, Project project) {
+    }
+
+    // Exposed for core tests: getOrBuild using Caffeine atomic loading
+    @FunctionalInterface
+    interface SupplierFn<T> {
+
+        T get();
     }
 
     private static class ItemDeserializer implements JsonDeserializer<Item> {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -197,11 +197,6 @@ public class ConnectionActionProvider {
                 sanitizeSegment(version));
     }
 
-    public static String generateKey(Codedata codedata) {
-        String packageName = codedata.packageName() == null ? codedata.module() : codedata.packageName();
-        return generateKey(codedata.org(), packageName, codedata.module(), codedata.object(), codedata.version());
-    }
-
     private List<Item> getOrBuildTemplates(ConnectorContext context) {
         return getOrBuild(context.cacheKey(), () -> buildTemplates(context, context.project()));
     }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -1,0 +1,483 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.flowmodelgenerator.core.model.AvailableNode;
+import io.ballerina.flowmodelgenerator.core.model.Category;
+import io.ballerina.flowmodelgenerator.core.model.Codedata;
+import io.ballerina.flowmodelgenerator.core.model.Item;
+import io.ballerina.flowmodelgenerator.core.model.Metadata;
+import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
+import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+import io.ballerina.modelgenerator.commons.CommonUtils;
+import io.ballerina.modelgenerator.commons.FunctionData;
+import io.ballerina.modelgenerator.commons.FunctionDataBuilder;
+import io.ballerina.modelgenerator.commons.ModuleInfo;
+import io.ballerina.modelgenerator.commons.PackageUtil;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageDescriptor;
+import io.ballerina.projects.Project;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
+
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.ballerina.flowmodelgenerator.core.Constants.BALLERINA;
+import static io.ballerina.modelgenerator.commons.CommonUtils.getPersistDatabaseIcon;
+import static io.ballerina.modelgenerator.commons.CommonUtils.isAgentClass;
+import static io.ballerina.modelgenerator.commons.CommonUtils.isAiKnowledgeBase;
+import static io.ballerina.modelgenerator.commons.CommonUtils.isPersistClient;
+
+/**
+ * Provides connector action templates with memory and disk-backed caching.
+ *
+ * @since 1.7.0
+ */
+public class ConnectionActionProvider {
+
+    private static final int MAX_CACHE_SIZE = 25;
+    private static final String CACHE_DIR_NAME = "ballerina-ls-connector-cache";
+    private static final String HTTP_MODULE = "http";
+    private static final List<String> HTTP_REMOTE_METHOD_SKIP_LIST = List.of("get", "put", "post", "head",
+            "delete", "patch", "options");
+
+    private final Cache<String, List<Item>> cache;
+    private final Path cacheDirectory;
+    private final Gson gson;
+    private final AtomicBoolean diskAvailable;
+
+    private static final class ProviderHolder {
+
+        private static final ConnectionActionProvider INSTANCE = new ConnectionActionProvider();
+    }
+
+    private record ConnectorContext(String cacheKey, ClassSymbol classSymbol, String className, ModuleInfo moduleInfo,
+                                    Package resolvedPackage, boolean knowledgeBase, boolean agentClass,
+                                    String iconOverride) {
+    }
+
+    public static ConnectionActionProvider getInstance() {
+        return ProviderHolder.INSTANCE;
+    }
+
+    private ConnectionActionProvider() {
+        this.cacheDirectory = Path.of(System.getProperty("java.io.tmpdir"), CACHE_DIR_NAME);
+        this.diskAvailable = new AtomicBoolean(true);
+        this.gson = new GsonBuilder()
+                .registerTypeAdapter(Item.class, new ItemDeserializer())
+                .registerTypeAdapter(Category.class, new CategoryDeserializer())
+                .create();
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(MAX_CACHE_SIZE)
+                .removalListener((String key, List<Item> value, RemovalCause cause) -> {
+                    if (cause == RemovalCause.EXPLICIT && key != null) {
+                        deleteFromDisk(key);
+                    }
+                })
+                .build();
+    }
+
+    public List<Item> getActions(ClassSymbol classSymbol, String parentSymbolName, Project project,
+                                 SemanticModel semanticModel, boolean includeAgentToolCompatibility) {
+        ConnectorContext context = createContext(classSymbol, project, semanticModel);
+        List<Item> cachedTemplates = getOrBuildTemplates(context, project);
+        Map<String, Boolean> compatibilityMap = includeAgentToolCompatibility
+                ? getAgentToolCompatibilityMap(classSymbol, semanticModel)
+                : Map.of();
+        return bindParentSymbol(cachedTemplates, parentSymbolName, compatibilityMap);
+    }
+
+    public void populate(Codedata codedata, WorkspaceManager workspaceManager, Path filePath) {
+        if (codedata == null || codedata.object() == null || codedata.org() == null || codedata.module() == null) {
+            return;
+        }
+
+        Project project = PackageUtil.loadProject(workspaceManager, filePath);
+        ConnectorContext context = createContext(codedata, project);
+        if (context == null) {
+            return;
+        }
+        getOrBuildTemplates(context, project);
+    }
+
+    public void invalidate(String cacheKey) {
+        cache.invalidate(cacheKey);
+    }
+
+    public static String generateKey(String org, String packageName, String moduleName, String className,
+                                     String version) {
+        return String.join(":",
+                sanitizeSegment(org),
+                sanitizeSegment(packageName),
+                sanitizeSegment(moduleName),
+                sanitizeSegment(className),
+                sanitizeSegment(version));
+    }
+
+    public static String generateKey(Codedata codedata) {
+        String packageName = codedata.packageName() == null ? codedata.module() : codedata.packageName();
+        return generateKey(codedata.org(), packageName, codedata.module(), codedata.object(), codedata.version());
+    }
+
+    private List<Item> getOrBuildTemplates(ConnectorContext context, Project project) {
+        List<Item> cachedItems = getCachedTemplates(context.cacheKey());
+        if (!cachedItems.isEmpty()) {
+            return cachedItems;
+        }
+
+        List<Item> builtItems = buildTemplates(context, project);
+        List<Item> immutableItems = List.copyOf(builtItems);
+        cache.put(context.cacheKey(), immutableItems);
+        persistToDisk(context.cacheKey(), immutableItems);
+        return immutableItems;
+    }
+
+    private ConnectorContext createContext(ClassSymbol classSymbol, Project project, SemanticModel semanticModel) {
+        String className = classSymbol.getName().orElseThrow();
+        ModuleInfo moduleInfo = classSymbol.getModule()
+                .map(moduleSymbol -> ModuleInfo.from(moduleSymbol.id()))
+                .orElseThrow();
+        Package resolvedPackage = resolvePackage(moduleInfo, project).orElse(null);
+        boolean persistClient = isPersistClient(classSymbol, semanticModel);
+        return new ConnectorContext(
+                generateKey(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.moduleName(), className,
+                        moduleInfo.version()),
+                classSymbol,
+                className,
+                moduleInfo,
+                resolvedPackage,
+                isAiKnowledgeBase(classSymbol),
+                isAgentClass(classSymbol),
+                persistClient ? getPersistDatabaseIcon(classSymbol).orElse(null) : null
+        );
+    }
+
+    private ConnectorContext createContext(Codedata codedata, Project project) {
+        ModuleInfo moduleInfo = new ModuleInfo(codedata.org(),
+                codedata.packageName() == null ? codedata.module() : codedata.packageName(),
+                codedata.module(), codedata.version());
+        Package resolvedPackage = resolvePackage(moduleInfo, project).orElse(null);
+        SemanticModel semanticModel = resolveSemanticModel(moduleInfo, project, resolvedPackage);
+        if (semanticModel == null) {
+            return null;
+        }
+        Optional<ClassSymbol> classSymbol = resolveClassSymbol(semanticModel, codedata.object());
+        if (classSymbol.isEmpty()) {
+            return null;
+        }
+        return createContext(classSymbol.get(), project, semanticModel);
+    }
+
+    private List<Item> buildTemplates(ConnectorContext context, Project project) {
+        List<FunctionData> methodFunctionsData = new FunctionDataBuilder()
+                .parentSymbol(context.classSymbol())
+                .parentSymbolType(context.className())
+                .project(project)
+                .moduleInfo(context.moduleInfo())
+                .resolvedPackage(context.resolvedPackage())
+                .enableIndex()
+                .buildChildNodes();
+
+        List<Item> methods = new ArrayList<>();
+        for (FunctionData methodFunction : methodFunctionsData) {
+            String org = methodFunction.org();
+            String packageName = methodFunction.packageName();
+            String version = methodFunction.version();
+            boolean isHttpModule = BALLERINA.equals(org) && HTTP_MODULE.equals(packageName);
+
+            NodeBuilder nodeBuilder;
+            String label;
+            if (methodFunction.kind() == FunctionData.Kind.RESOURCE) {
+                if (isHttpModule && HTTP_REMOTE_METHOD_SKIP_LIST.contains(methodFunction.name())) {
+                    continue;
+                }
+                label = methodFunction.name() + (isHttpModule ? "" : methodFunction.resourcePath());
+                nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.RESOURCE_ACTION_CALL);
+            } else {
+                label = methodFunction.name();
+                FunctionData.Kind kind = methodFunction.kind();
+                if (kind == FunctionData.Kind.REMOTE) {
+                    nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.REMOTE_ACTION_CALL);
+                } else if (context.agentClass() && label.equals(Constants.Ai.AGENT_RUN_METHOD_NAME)) {
+                    nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.AGENT_RUN);
+                } else if (kind == FunctionData.Kind.FUNCTION && context.knowledgeBase()) {
+                    nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.KNOWLEDGE_BASE_CALL);
+                } else if (kind == FunctionData.Kind.FUNCTION) {
+                    nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.METHOD_CALL);
+                } else {
+                    throw new IllegalStateException("Unexpected value: " + kind);
+                }
+            }
+
+            String icon = context.iconOverride() == null
+                    ? CommonUtils.generateIcon(org, packageName, version)
+                    : context.iconOverride();
+            Item node = nodeBuilder
+                    .metadata()
+                    .label(label)
+                    .icon(icon)
+                    .description(methodFunction.description())
+                    .stepOut()
+                    .codedata()
+                    .org(org)
+                    .module(context.moduleInfo().moduleName())
+                    .packageName(context.moduleInfo().packageName())
+                    .object(context.className())
+                    .symbol(methodFunction.name())
+                    .version(version)
+                    .resourcePath(methodFunction.resourcePath())
+                    .stepOut()
+                    .buildAvailableNode();
+            methods.add(node);
+        }
+        return methods;
+    }
+
+    private List<Item> bindParentSymbol(List<Item> cachedMethods, String parentSymbolName,
+                                        Map<String, Boolean> compatibilityMap) {
+        List<Item> methods = new ArrayList<>(cachedMethods.size());
+        for (Item item : cachedMethods) {
+            if (!(item instanceof AvailableNode availableNode)) {
+                continue;
+            }
+            Codedata codedata = availableNode.codedata();
+            Map<String, Object> data = codedata.data() == null
+                    ? null
+                    : new LinkedHashMap<>(codedata.data());
+            if (!compatibilityMap.isEmpty() && compatibilityMap.containsKey(codedata.symbol())) {
+                if (data == null) {
+                    data = new LinkedHashMap<>();
+                }
+                data.put("agentToolCompatible", compatibilityMap.get(codedata.symbol()));
+            }
+            Codedata boundCodedata = new Codedata(
+                    codedata.node(),
+                    codedata.org(),
+                    codedata.module(),
+                    codedata.packageName(),
+                    codedata.object(),
+                    codedata.symbol(),
+                    codedata.version(),
+                    codedata.lineRange(),
+                    codedata.sourceCode(),
+                    parentSymbolName,
+                    codedata.resourcePath(),
+                    codedata.id(),
+                    codedata.isNew(),
+                    codedata.isGenerated(),
+                    codedata.inferredReturnType(),
+                    data);
+            methods.add(new AvailableNode(availableNode.metadata(), boundCodedata, availableNode.enabled()));
+        }
+        return methods;
+    }
+
+    private Map<String, Boolean> getAgentToolCompatibilityMap(ClassSymbol classSymbol, SemanticModel semanticModel) {
+        Map<String, Boolean> compatibilityMap = new LinkedHashMap<>();
+        for (Map.Entry<String, MethodSymbol> entry : classSymbol.methods().entrySet()) {
+            try {
+                AiUtils.AgentToolCompatibility toolCompat = AiUtils.checkAgentToolCompatibility(
+                        entry.getValue().qualifiers(), entry.getValue().typeDescriptor(), semanticModel);
+                compatibilityMap.put(entry.getKey(), toolCompat.compatible());
+            } catch (Throwable ignored) {
+                compatibilityMap.put(entry.getKey(), false);
+            }
+        }
+        return compatibilityMap;
+    }
+
+    private Optional<Package> resolvePackage(ModuleInfo moduleInfo, Project project) {
+        if (project != null && isProjectModule(moduleInfo, project.currentPackage().descriptor())) {
+            return Optional.of(project.currentPackage());
+        }
+        return PackageUtil.resolveModulePackage(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version());
+    }
+
+    private boolean isProjectModule(ModuleInfo moduleInfo, PackageDescriptor packageDescriptor) {
+        if (moduleInfo == null || packageDescriptor == null || moduleInfo.org() == null) {
+            return false;
+        }
+        if (!moduleInfo.org().equals(packageDescriptor.org().value())) {
+            return false;
+        }
+        String packageName = moduleInfo.packageName();
+        String descriptorName = packageDescriptor.name().value();
+        if (packageName != null) {
+            return packageName.startsWith(descriptorName);
+        }
+        String moduleName = moduleInfo.moduleName();
+        return moduleName != null && moduleName.startsWith(descriptorName);
+    }
+
+    private SemanticModel resolveSemanticModel(ModuleInfo moduleInfo, Project project, Package resolvedPackage) {
+        if (resolvedPackage != null) {
+            SemanticModel semanticModel = findSemanticModel(resolvedPackage, moduleInfo);
+            if (semanticModel != null) {
+                return semanticModel;
+            }
+        }
+        if (project == null) {
+            return null;
+        }
+        return findSemanticModel(project.currentPackage(), moduleInfo);
+    }
+
+    private SemanticModel findSemanticModel(Package pkg, ModuleInfo moduleInfo) {
+        for (Module module : pkg.modules()) {
+            ModuleInfo candidateInfo = ModuleInfo.from(module.descriptor());
+            if (candidateInfo.moduleName().equals(moduleInfo.moduleName())) {
+                return PackageUtil.getCompilation(pkg.project()).getSemanticModel(module.moduleId());
+            }
+        }
+        return null;
+    }
+
+    private Optional<ClassSymbol> resolveClassSymbol(SemanticModel semanticModel, String className) {
+        return semanticModel.moduleSymbols().parallelStream()
+                .filter(symbol -> symbol instanceof ClassSymbol && symbol.nameEquals(className))
+                .map(symbol -> (ClassSymbol) symbol)
+                .findFirst();
+    }
+
+    private List<Item> getCachedTemplates(String cacheKey) {
+        List<Item> inMemory = cache.getIfPresent(cacheKey);
+        if (inMemory != null && !inMemory.isEmpty()) {
+            return inMemory;
+        }
+
+        List<Item> fromDisk = loadFromDisk(cacheKey);
+        if (fromDisk != null && !fromDisk.isEmpty()) {
+            List<Item> immutableItems = List.copyOf(fromDisk);
+            cache.put(cacheKey, immutableItems);
+            return immutableItems;
+        }
+        return List.of();
+    }
+
+    private List<Item> loadFromDisk(String cacheKey) {
+        if (!diskAvailable.get()) {
+            return null;
+        }
+        try {
+            Path file = cacheDirectory.resolve(keyToFileName(cacheKey));
+            if (!Files.exists(file)) {
+                return null;
+            }
+            try (Reader reader = Files.newBufferedReader(file)) {
+                Item[] items = gson.fromJson(reader, Item[].class);
+                if (items == null) {
+                    return null;
+                }
+                return List.of(items);
+            }
+        } catch (Exception ignored) {
+            diskAvailable.set(false);
+            return null;
+        }
+    }
+
+    private void persistToDisk(String cacheKey, List<Item> items) {
+        if (!diskAvailable.get()) {
+            return;
+        }
+        try {
+            Files.createDirectories(cacheDirectory);
+            Path file = cacheDirectory.resolve(keyToFileName(cacheKey));
+            try (Writer writer = Files.newBufferedWriter(file)) {
+                gson.toJson(items, writer);
+            }
+        } catch (Exception ignored) {
+            diskAvailable.set(false);
+        }
+    }
+
+    private void deleteFromDisk(String cacheKey) {
+        if (!diskAvailable.get()) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(cacheDirectory.resolve(keyToFileName(cacheKey)));
+        } catch (Exception ignored) {
+            diskAvailable.set(false);
+        }
+    }
+
+    private static String sanitizeSegment(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static String keyToFileName(String cacheKey) {
+        return cacheKey.replace(":", "_").replace("/", "-").replace("\\", "-") + ".json";
+    }
+
+    private static class ItemDeserializer implements JsonDeserializer<Item> {
+
+        @Override
+        public Item deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+            if (jsonObject.has("items")) {
+                return context.deserialize(jsonObject, Category.class);
+            } else if (jsonObject.has("enabled")) {
+                return context.deserialize(jsonObject, AvailableNode.class);
+            }
+            throw new JsonParseException("Unknown type of Item");
+        }
+    }
+
+    private static class CategoryDeserializer implements JsonDeserializer<Category> {
+
+        @Override
+        public Category deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+            Metadata metadata = context.deserialize(jsonObject.get("metadata"), Metadata.class);
+            JsonArray itemsArray = jsonObject.getAsJsonArray("items");
+            List<Item> items = new ArrayList<>();
+            for (JsonElement itemElement : itemsArray) {
+                items.add(context.deserialize(itemElement, Item.class));
+            }
+            return new Category(metadata, items);
+        }
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -440,7 +440,7 @@ public class ConnectionActionProvider {
             try (Writer writer = Files.newBufferedWriter(file)) {
                 gson.toJson(items, writer);
             }
-        } catch (IOException ignored) {
+        } catch (IOException | RuntimeException ignored) {
             diskAvailable.set(false);
         }
     }
@@ -451,8 +451,7 @@ public class ConnectionActionProvider {
         }
         try {
             Files.deleteIfExists(cacheDirectory.resolve(keyToFileName(cacheKey)));
-        } catch (IOException ignored) {
-            diskAvailable.set(false);
+        } catch (IOException | RuntimeException ignored) {
         }
     }
 

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -50,6 +50,7 @@ import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.Project;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.lang.reflect.Type;
@@ -429,7 +430,7 @@ public class ConnectionActionProvider {
                 }
                 return List.of(items);
             }
-        } catch (Exception ignored) {
+        } catch (IOException | RuntimeException ignored) {
             return null;
         }
     }
@@ -444,7 +445,7 @@ public class ConnectionActionProvider {
             try (Writer writer = Files.newBufferedWriter(file)) {
                 gson.toJson(items, writer);
             }
-        } catch (Exception ignored) {
+        } catch (IOException ignored) {
             diskAvailable.set(false);
         }
     }
@@ -455,7 +456,7 @@ public class ConnectionActionProvider {
         }
         try {
             Files.deleteIfExists(cacheDirectory.resolve(keyToFileName(cacheKey)));
-        } catch (Exception ignored) {
+        } catch (IOException ignored) {
             diskAvailable.set(false);
         }
     }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -174,11 +174,11 @@ public class ConnectionActionProvider {
     List<Item> getOrBuild(String cacheKey, SupplierFn<List<Item>> supplier) {
         return cache.get(cacheKey, key -> {
             List<Item> fromDisk = loadFromDisk(key);
-            if (fromDisk != null && !fromDisk.isEmpty()) {
+            if (fromDisk != null) {
                 return List.copyOf(fromDisk);
             }
             List<Item> built = supplier.get();
-            if (built == null || built.isEmpty()) {
+            if (built == null) {
                 return List.of();
             }
             List<Item> immutable = List.copyOf(built);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
@@ -20,6 +20,7 @@ package io.ballerina.flowmodelgenerator.core.model.node;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.flowmodelgenerator.core.ConnectionActionProvider;
 import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.flowmodelgenerator.core.model.FormBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
@@ -46,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents a new connection node in the flow model.
@@ -170,6 +172,7 @@ public class NewConnectionBuilder extends CallBuilder {
                 .version(functionData.version())
                 .symbol(INIT_SYMBOL)
                 .isGenerated(codedata.isGenerated());
+        preloadConnectorActions(context);
 
         Module module = context.workspaceManager().module(context.filePath()).orElse(null);
         setParameterProperties(functionData, module);
@@ -181,6 +184,17 @@ public class NewConnectionBuilder extends CallBuilder {
         properties()
                 .scope(Property.GLOBAL_SCOPE)
                 .checkError(true, CHECK_ERROR_DOC, false);
+    }
+
+    private void preloadConnectorActions(TemplateContext context) {
+        CompletableFuture.runAsync(() -> {
+            try {
+                ConnectionActionProvider.getInstance().populate(codedataBuilder.build(),
+                        context.workspaceManager(), context.filePath());
+            } catch (RuntimeException ignored) {
+                // Ignore preload failures and continue template generation.
+            }
+        });
     }
 
     @Override

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
@@ -108,6 +108,7 @@ public class NewConnectionBuilder extends CallBuilder {
             sourceBuilder.acceptImport();
         }
 
+        preloadConnectorActions(sourceBuilder);
         return sourceBuilder.build();
     }
 
@@ -172,7 +173,6 @@ public class NewConnectionBuilder extends CallBuilder {
                 .version(functionData.version())
                 .symbol(INIT_SYMBOL)
                 .isGenerated(codedata.isGenerated());
-        preloadConnectorActions(context);
 
         Module module = context.workspaceManager().module(context.filePath()).orElse(null);
         setParameterProperties(functionData, module);
@@ -186,15 +186,15 @@ public class NewConnectionBuilder extends CallBuilder {
                 .checkError(true, CHECK_ERROR_DOC, false);
     }
 
-    private void preloadConnectorActions(TemplateContext context) {
+    private void preloadConnectorActions(SourceBuilder sourceBuilder) {
         CompletableFuture.runAsync(() -> {
             try {
-                ConnectionActionProvider.getInstance().populate(codedataBuilder.build(),
-                        context.workspaceManager(), context.filePath());
+                ConnectionActionProvider.getInstance().populate(sourceBuilder.flowNode.codedata(),
+                        sourceBuilder.workspaceManager, sourceBuilder.filePath);
             } catch (RuntimeException ignored) {
                 // Ignore preload failures and continue template generation.
             }
-        });
+        }, ConnectionActionProvider.backgroundExecutor());
     }
 
     @Override

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
@@ -188,13 +188,9 @@ public class NewConnectionBuilder extends CallBuilder {
 
     private void preloadConnectorActions(SourceBuilder sourceBuilder) {
         CompletableFuture.runAsync(() -> {
-            try {
-                ConnectionActionProvider.getInstance().populate(sourceBuilder.flowNode.codedata(),
-                        sourceBuilder.workspaceManager, sourceBuilder.filePath);
-            } catch (RuntimeException ignored) {
-                // Ignore preload failures and continue template generation.
-            }
-        }, ConnectionActionProvider.backgroundExecutor());
+            ConnectionActionProvider.getInstance().populate(sourceBuilder.flowNode.codedata(),
+                    sourceBuilder.workspaceManager, sourceBuilder.filePath);
+        });
     }
 
     @Override

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/module-info.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module io.ballerina.flow.model.generator {
     requires io.ballerina.diagram.util;
     requires io.ballerina.central.client;
     requires com.google.gson;
+    requires com.github.benmanes.caffeine;
     requires com.graphqljava;
     requires io.ballerina.openapi.core;
     requires io.swagger.v3.oas.models;

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
@@ -1,0 +1,309 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import io.ballerina.flowmodelgenerator.core.model.AvailableNode;
+import io.ballerina.flowmodelgenerator.core.model.Category;
+import io.ballerina.flowmodelgenerator.core.model.Codedata;
+import io.ballerina.flowmodelgenerator.core.model.Item;
+import io.ballerina.flowmodelgenerator.core.model.Metadata;
+import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests for {@link ConnectionActionProvider}.
+ *
+ * @since 1.7.0
+ */
+public class ConnectionActionProviderTest {
+
+    private Path tempDir;
+    private ConnectionActionProvider provider;
+
+    @BeforeMethod
+    public void setup() throws IOException {
+        tempDir = Files.createTempDirectory("connection-action-provider-test");
+        provider = new ConnectionActionProvider(tempDir, 25);
+    }
+
+    @AfterMethod
+    public void cleanup() throws IOException {
+        provider.clearAllForTest();
+        deleteRecursively(tempDir);
+    }
+
+    @Test(description = "Verifies the cache key format is stable for connector identity fields.")
+    public void testCacheKeyGeneration() {
+        String key = ConnectionActionProvider.generateKey("ballerina", "http", "http", "Client", "2.15.1");
+        Assert.assertEquals(key, "ballerina:http:http:Client:2.15.1");
+    }
+
+    @Test(description = "Verifies a built entry is reused from memory without rebuilding on a second lookup.")
+    public void testBuildCachesInMemory() {
+        String key = "cache-hit";
+        AtomicInteger buildCount = new AtomicInteger();
+        List<Item> expected = List.of(availableNode("listPets", null, null));
+
+        List<Item> first = provider.getOrBuild(key, () -> {
+            buildCount.incrementAndGet();
+            return expected;
+        });
+        List<Item> second = provider.getOrBuild(key, () -> {
+            buildCount.incrementAndGet();
+            return List.of(availableNode("should-not-build", null, null));
+        });
+
+        Assert.assertEquals(buildCount.get(), 1);
+        Assert.assertEquals(first, expected);
+        Assert.assertEquals(second, expected);
+    }
+
+    @Test(description = "Verifies a persisted cache entry is reloaded from disk by a fresh provider instance.")
+    public void testCachePersistsToDiskAndLoadsFromFreshProvider() {
+        String key = "disk-hit";
+        AtomicInteger buildCount = new AtomicInteger();
+        List<Item> expected = List.of(availableNode("createOrder", null, null));
+
+        provider.getOrBuild(key, () -> {
+            buildCount.incrementAndGet();
+            return expected;
+        });
+        Assert.assertTrue(Files.exists(provider.cacheFilePath(key)));
+
+        ConnectionActionProvider freshProvider = new ConnectionActionProvider(tempDir, 25);
+        try {
+            List<Item> actual = freshProvider.getOrBuild(key, () -> {
+                buildCount.incrementAndGet();
+                return List.of(availableNode("should-not-build", null, null));
+            });
+
+            Assert.assertEquals(buildCount.get(), 1);
+            Assert.assertEquals(actual, expected);
+        } finally {
+            freshProvider.clearAllForTest();
+        }
+    }
+
+    @Test(description = "Verifies an unreadable cache file is treated as a miss and rebuilt successfully.")
+    public void testCorruptDiskFileTriggersRebuild() throws IOException {
+        String key = "corrupt-entry";
+        Files.createDirectories(tempDir);
+        Files.writeString(provider.cacheFilePath(key), "{ not-json");
+
+        AtomicInteger buildCount = new AtomicInteger();
+        List<Item> expected = List.of(availableNode("recovered", null, null));
+
+        List<Item> actual = provider.getOrBuild(key, () -> {
+            buildCount.incrementAndGet();
+            return expected;
+        });
+
+        Assert.assertEquals(buildCount.get(), 1);
+        Assert.assertEquals(actual, expected);
+        Assert.assertTrue(Files.readString(provider.cacheFilePath(key)).contains("\"metadata\""));
+    }
+
+    @Test(description = "Verifies explicit invalidation removes the corresponding persisted cache file.")
+    public void testInvalidateDeletesDiskFile() {
+        String key = "invalidate";
+        provider.getOrBuild(key, () -> List.of(availableNode("deleteCache", null, null)));
+        Path cacheFile = provider.cacheFilePath(key);
+
+        Assert.assertTrue(Files.exists(cacheFile));
+        provider.invalidate(key);
+        provider.cleanUp();
+
+        Assert.assertFalse(Files.exists(cacheFile));
+    }
+
+    @Test(description = "Verifies size-based eviction removes only the in-memory entry and keeps the disk copy.")
+    public void testSizeEvictionKeepsDiskFile() {
+        ConnectionActionProvider sizeBoundProvider = new ConnectionActionProvider(tempDir, 1);
+        try {
+            AtomicInteger buildCount = new AtomicInteger();
+            sizeBoundProvider.getOrBuild("one", () -> {
+                buildCount.incrementAndGet();
+                return List.of(availableNode("one", null, null));
+            });
+            sizeBoundProvider.getOrBuild("two", () -> {
+                buildCount.incrementAndGet();
+                return List.of(availableNode("two", null, null));
+            });
+            sizeBoundProvider.cleanUp();
+
+            Assert.assertTrue(Files.exists(sizeBoundProvider.cacheFilePath("one")));
+
+            List<Item> reloaded = sizeBoundProvider.getOrBuild("one", () -> {
+                buildCount.incrementAndGet();
+                return List.of(availableNode("should-not-build", null, null));
+            });
+
+            Assert.assertEquals(buildCount.get(), 2);
+            Assert.assertEquals(reloaded, List.of(availableNode("one", null, null)));
+        } finally {
+            sizeBoundProvider.clearAllForTest();
+        }
+    }
+
+    @Test(description = "Verifies nested Item implementations serialize and deserialize correctly through Gson.")
+    public void testPolymorphicSerializationRoundTrip() {
+        String key = "polymorphic";
+        List<Item> expected = List.of(new Category(
+                new Metadata("Connections", "Connector actions", null, null, null, null),
+                List.of(availableNode("query", null, null), availableNode("close", null, null))));
+
+        provider.getOrBuild(key, () -> expected);
+
+        ConnectionActionProvider freshProvider = new ConnectionActionProvider(tempDir, 25);
+        try {
+            List<Item> actual = freshProvider.getOrBuild(key, List::of);
+
+            Assert.assertEquals(actual, expected);
+            Assert.assertTrue(actual.get(0) instanceof Category);
+            Assert.assertTrue(((Category) actual.get(0)).items().get(0) instanceof AvailableNode);
+        } finally {
+            freshProvider.clearAllForTest();
+        }
+    }
+
+    @Test(description = "Verifies parent-symbol rebinding returns caller-specific nodes without mutating templates.")
+    public void testBindForParentSymbolDoesNotMutateCachedTemplates() {
+        String key = "binding";
+        List<Item> templates = provider.getOrBuild(key, () -> List.of(availableNode("invoke", null, null)));
+
+        List<Item> firstBound = provider.bindForParentSymbol(templates, "clientA", Map.of("invoke", true));
+        List<Item> secondBound = provider.bindForParentSymbol(templates, "clientB", Map.of());
+
+        AvailableNode original = (AvailableNode) templates.get(0);
+        AvailableNode first = (AvailableNode) firstBound.get(0);
+        AvailableNode second = (AvailableNode) secondBound.get(0);
+
+        Assert.assertNull(original.codedata().parentSymbol());
+        Assert.assertEquals(first.codedata().parentSymbol(), "clientA");
+        Assert.assertEquals(((Map<?, ?>) first.codedata().data()).get("agentToolCompatible"), true);
+        Assert.assertEquals(second.codedata().parentSymbol(), "clientB");
+        Assert.assertNull(second.codedata().data());
+    }
+
+    @Test(description = "Verifies disk write failures do not prevent successful in-memory cache population.")
+    public void testDiskFailureFallsBackToMemory() throws IOException {
+        Path invalidCacheRoot = Files.createTempFile("connection-action-provider-invalid", ".tmp");
+        ConnectionActionProvider invalidProvider = new ConnectionActionProvider(invalidCacheRoot, 25);
+        try {
+            List<Item> expected = List.of(availableNode("memoryOnly", null, null));
+
+            List<Item> actual = invalidProvider.getOrBuild("memory-only", () -> expected);
+
+            Assert.assertEquals(actual, expected);
+            Assert.assertFalse(Files.isDirectory(invalidCacheRoot));
+        } finally {
+            invalidProvider.clearAllForTest();
+            Files.deleteIfExists(invalidCacheRoot);
+        }
+    }
+
+    @Test(description = "Verifies concurrent requests for the same missing key trigger only one build.")
+    public void testConcurrentMissBuildsOnce() throws InterruptedException, ExecutionException {
+        String key = "concurrent";
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        CountDownLatch ready = new CountDownLatch(4);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger buildCount = new AtomicInteger();
+
+        Callable<List<Item>> task = () -> {
+            ready.countDown();
+            Assert.assertTrue(start.await(5, TimeUnit.SECONDS));
+            return provider.getOrBuild(key, () -> {
+                buildCount.incrementAndGet();
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                return List.of(availableNode("shared", null, null));
+            });
+        };
+
+        try {
+            Future<List<Item>> first = executor.submit(task);
+            Future<List<Item>> second = executor.submit(task);
+            Future<List<Item>> third = executor.submit(task);
+            Future<List<Item>> fourth = executor.submit(task);
+
+            Assert.assertTrue(ready.await(5, TimeUnit.SECONDS));
+            start.countDown();
+
+            List<Item> expected = List.of(availableNode("shared", null, null));
+            Assert.assertEquals(first.get(), expected);
+            Assert.assertEquals(second.get(), expected);
+            Assert.assertEquals(third.get(), expected);
+            Assert.assertEquals(fourth.get(), expected);
+            Assert.assertEquals(buildCount.get(), 1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static AvailableNode availableNode(String symbol, String parentSymbol, Map<String, Object> data) {
+        return new AvailableNode(
+                new Metadata(symbol, symbol + " description", null, "icon-" + symbol, null, null),
+                new Codedata(NodeKind.METHOD_CALL, "ballerina", "http", "http", "Client", symbol, "1.0.0",
+                        null, null, parentSymbol, null, null, false, false, null, data),
+                true);
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (root == null || Files.notExists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            paths.sorted((left, right) -> right.getNameCount() - left.getNameCount())
+                    .forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof IOException ioException) {
+                throw ioException;
+            }
+            throw e;
+        }
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
@@ -61,7 +61,7 @@ public class ConnectionActionProviderTest {
 
     @AfterMethod
     public void cleanup() throws IOException {
-        provider.clearAllForTest();
+        provider.clearAll();
         deleteRecursively(tempDir);
     }
 
@@ -113,7 +113,7 @@ public class ConnectionActionProviderTest {
             Assert.assertEquals(buildCount.get(), 1);
             Assert.assertEquals(actual, expected);
         } finally {
-            freshProvider.clearAllForTest();
+            freshProvider.clearAll();
         }
     }
 
@@ -174,7 +174,7 @@ public class ConnectionActionProviderTest {
             Assert.assertEquals(buildCount.get(), 2);
             Assert.assertEquals(reloaded, List.of(availableNode("one", null, null)));
         } finally {
-            sizeBoundProvider.clearAllForTest();
+            sizeBoundProvider.clearAll();
         }
     }
 
@@ -195,7 +195,7 @@ public class ConnectionActionProviderTest {
             Assert.assertTrue(actual.get(0) instanceof Category);
             Assert.assertTrue(((Category) actual.get(0)).items().get(0) instanceof AvailableNode);
         } finally {
-            freshProvider.clearAllForTest();
+            freshProvider.clearAll();
         }
     }
 
@@ -230,7 +230,7 @@ public class ConnectionActionProviderTest {
             Assert.assertEquals(actual, expected);
             Assert.assertFalse(Files.isDirectory(invalidCacheRoot));
         } finally {
-            invalidProvider.clearAllForTest();
+            invalidProvider.clearAll();
             Files.deleteIfExists(invalidCacheRoot);
         }
     }

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="flow-model-generator-core-test-suite">
+    <test name="flow-model-generator-core-tests">
+        <classes>
+            <class name="io.ballerina.flowmodelgenerator.core.ConnectionActionProviderTest"/>
+        </classes>
+    </test>
+</suite>

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ checkStyleToolVersion=10.12.1
 downloadPluginVersion=5.4.0
 eclipseLsp4jVersion=0.24.0
 gsonVersion=2.10.1
+caffeineVersion=3.1.8
 puppycrawlCheckstyleVersion=10.12.1
 releasePluginVersion=2.8.0
 shadowJarPluginVersion=8.1.1


### PR DESCRIPTION
## Purpose

Cache connector action templates with a two-tiered (in-memory + disk) cache so repeated lookups for the same connector's methods are served without rebuilding from the semantic model each time.

Fixes https://github.com/wso2/product-integrator/issues/195

## Approach

- Extract the action-building logic from `AvailableNodesGenerator` into a new `ConnectionActionProvider` singleton.
- Use a Caffeine in-memory cache (max 25 entries, keyed by `org:package:module:class:version`) backed by JSON files on disk under `java.io.tmpdir`.
- On a cache miss: check Caffeine → check disk → build fresh via `FunctionDataBuilder` → persist to disk → store in Caffeine.
- `NewConnectionBuilder.toSource()` fire-and-forget pre-warms the cache for the connector being created.

### Structural Overview

```mermaid
classDiagram
    class AvailableNodesGenerator {
        +getAvailableNodes() List~Item~
    }

    class ConnectionActionProvider {
        -Cache~String, List~Item~~ cache
        -Path cacheDirectory
        -AtomicBoolean diskAvailable
        +getInstance() ConnectionActionProvider
        +getActions(ClassSymbol, String, Project, SemanticModel, boolean) List~Item~
        +populate(Codedata, WorkspaceManager, Path) void
        +invalidate(String) void
        -buildTemplates(ConnectorContext, Project) List~Item~
        -loadFromDisk(String) List~Item~
        -persistToDisk(String, List~Item~) void
    }

    class NewConnectionBuilder {
        +toSource() String
        -preloadConnectorActions(SourceBuilder) void
    }

    AvailableNodesGenerator --> ConnectionActionProvider : delegates action lookup
    NewConnectionBuilder --> ConnectionActionProvider : async preload via populate()
```

### Cache Lifecycle

```mermaid
flowchart LR
    A[getActions / populate called] --> B{Caffeine cache hit?}
    B -- Yes --> C[Return cached items]
    B -- No --> D{Disk file exists & parseable?}
    D -- Yes --> E[Load from disk into Caffeine]
    E --> C
    D -- No --> F[Build via FunctionDataBuilder]
    F --> G[Persist to disk + store in Caffeine]
    G --> C
```

## What Was Changed

- **New `ConnectionActionProvider`** — encapsulates action template building, Caffeine caching, and disk persistence.
- **Added Caffeine 3.1.8** dependency for size-bounded in-memory caching with atomic loading.
- **Async preloading** in `NewConnectionBuilder.toSource()` to warm the cache eagerly.
- **Graceful disk degradation** — corrupt files trigger rebuilds; write failures silently disable persistence while in-memory caching continues.

## Affected Components

- `flow-model-generator/modules/flow-model-generator-core/`
- Root (`gradle.properties`)

## How Has This Been Tested

10 unit tests in `ConnectionActionProviderTest`: cache hit/miss, disk persistence across provider instances, corrupt file recovery, invalidation, size eviction, polymorphic serialization, parent-symbol rebinding immutability, disk-failure fallback, and concurrent-miss atomic loading (single build across 4 threads).

## Remarks

- The cache directory lives under `java.io.tmpdir` and may be cleared on reboot — this is intentional since the cache is a performance optimization, not a source of truth.
- The cache entry is not currently evicted when the underlying item is removed, because the `DeleteHandler` implementation is not robust enough to detect such changes. Adding this detection would directly impact the performance of the `/delete` API, so it will be addressed in a separate issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request introduces a two-tiered caching layer for connector action templates to improve performance when expanding connector actions in flow diagrams. Previously, users experienced significant delays (21+ seconds) when loading action templates; this change eliminates that lag through intelligent caching.

## Key Changes

**Caching Infrastructure**: Adds a new `ConnectionActionProvider` singleton that implements L1 (in-memory Caffeine) and L2 (JSON file-based) caching. The in-memory cache supports up to 25 entries with org:package:module:class:version composite keys. Cache misses fall through to disk, then rebuild via the existing `FunctionDataBuilder` if needed, with automatic persistence back to disk and memory.

**Core Refactoring**: Extracts action-building logic from `AvailableNodesGenerator` into the dedicated `ConnectionActionProvider` class. The provider handles function categorization (resource, remote, agent run, knowledge base), HTTP remote method filtering, and optional icon overrides. It computes action compatibility information when requested and binds actions to parent symbols without mutating cached templates.

**Async Preloading**: Adds background cache warming in `NewConnectionBuilder.toSource()` via `CompletableFuture.runAsync(...)`, allowing connector actions to be preloaded concurrently during source generation.

**Graceful Degradation**: Disk I/O failures disable persistence but preserve in-memory caching. Corrupted cache files automatically trigger rebuilds. Explicit invalidation removes corresponding disk files.

**Dependencies & Testing**: Adds Caffeine 3.1.8 as a runtime dependency. Includes 10 comprehensive unit tests covering cache hits/misses, disk persistence, corruption recovery, invalidation, eviction, serialization, and concurrent access patterns.

## Impact

Resolves performance bottleneck (#195) that caused multi-second delays when users expanded connector actions in the flow diagram UI for HTTP service resources. The two-tiered cache ensures actions load from memory on first access and subsequent accesses, with automatic recovery from missing or corrupted disk files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->