### PR TITLE
Ambigious type fix

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/type/RecordValueGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/type/RecordValueGenerator.java
@@ -83,12 +83,19 @@ public class RecordValueGenerator {
             return;
         }
 
+        // Only applicable for the FTP coordination config's `task:DatabaseConfig` union
+        // type
+        boolean needsExplicitTypeCast = isAmbiguousUnionModulePrefix(union);
         if (union.has("members")) {
             JsonElement members = union.get("members");
             if (members.isJsonArray()) {
                 for (JsonElement member : members.getAsJsonArray()) {
                     JsonObject memberObj = member.getAsJsonObject();
                     if (memberObj.has("selected") && memberObj.get("selected").getAsBoolean()) {
+                        if (needsExplicitTypeCast) {
+                            memberObj.addProperty("explicitTypeCast",
+                                    "task:" + memberObj.get("name").getAsString());
+                        }
                         generateValue(memberObj, builder, indentLevel);
                         break;
                     }
@@ -97,9 +104,35 @@ public class RecordValueGenerator {
         }
     }
 
+    /**
+     * Returns the module prefix for the {@code task:DatabaseConfig} union type used
+     * in the FTP
+     * coordination config, or {@code null} if this is not that union. Both members
+     * ({@code MysqlConfig} and {@code PostgresqlConfig}) are structurally
+     * identical, so the
+     * compiler requires an explicit type cast like {@code <task:MysqlConfig>}.
+     */
+    private static boolean isAmbiguousUnionModulePrefix(JsonObject union) {
+        if (!union.has("name") || !"databaseConfig".equals(union.get("name").getAsString())
+                || !union.has("typeInfo") || !union.get("typeInfo").isJsonObject()) {
+            return false;
+        }
+        JsonObject typeInfo = union.get("typeInfo").getAsJsonObject();
+        if ("task".equals(typeInfo.has("moduleName") ? typeInfo.get("moduleName").getAsString() : null)
+                && "DatabaseConfig".equals(typeInfo.has("name") ? typeInfo.get("name").getAsString() : null)) {
+            return true;
+        }
+        return false;
+    }
+
     private static void generateRecordValue(JsonObject jsonObject, StringBuilder builder, int indentLevel) {
         if (jsonObject.has("selected") && !jsonObject.get("selected").getAsBoolean()) {
             return;
+        }
+
+        // Add explicit type cast if specified (for ambiguous union record types)
+        if (jsonObject.has("explicitTypeCast") && !jsonObject.get("explicitTypeCast").getAsString().isEmpty()) {
+            builder.append("<").append(jsonObject.get("explicitTypeCast").getAsString()).append("> ");
         }
 
         String indent = getIndent(indentLevel);

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_value_gen/config/config13.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_value_gen/config/config13.json
@@ -1,0 +1,35 @@
+{
+  "filePath": "proj",
+  "description": "Record with explicit type cast for ambiguous union types",
+  "type": {
+    "typeName": "record",
+    "name": "MysqlConfig",
+    "explicitTypeCast": "task:MysqlConfig",
+    "selected": true,
+    "fields": [
+      {
+        "name": "host",
+        "typeName": "string",
+        "optional": false,
+        "defaultable": true,
+        "isRestType": false,
+        "selected": true,
+        "value": "\"localhost\""
+      },
+      {
+        "name": "port",
+        "typeName": "int",
+        "optional": false,
+        "defaultable": true,
+        "isRestType": false,
+        "selected": true,
+        "value": "3306"
+      }
+    ],
+    "hasRestType": false,
+    "optional": false,
+    "defaultable": false,
+    "isRestType": false
+  },
+  "output": "<task:MysqlConfig> {\n    host: \"localhost\",\n    port: 3306\n}"
+}

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/core/ServiceModelGeneratorService.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/core/ServiceModelGeneratorService.java
@@ -753,8 +753,15 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
 
                 LineRange lineRange = listener.getCodedata().getLineRange();
                 String listenerDeclaration = listener.getListenerDefinition();
-                TextEdit basePathEdit = new TextEdit(Utils.toRange(lineRange), listenerDeclaration);
-                return new CommonSourceResponse(Map.of(request.filePath(), List.of(basePathEdit)));
+
+                List<TextEdit> edits = new ArrayList<>();
+                edits.add(new TextEdit(Utils.toRange(lineRange), listenerDeclaration));
+
+                // Add imports required by the FTP coordination config type cast
+                ModulePartNode modulePartNode = document.get().syntaxTree().rootNode();
+                FTPListenerUtil.addCoordinationConfigImports(listenerDeclaration, modulePartNode, edits);
+
+                return new CommonSourceResponse(Map.of(request.filePath(), edits));
             } catch (Throwable e) {
                 return new CommonSourceResponse(e);
             }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/FTPListenerUtil.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/FTPListenerUtil.java
@@ -58,6 +58,7 @@ import io.ballerina.servicemodelgenerator.extension.model.PropertyTypeMemberInfo
 import io.ballerina.servicemodelgenerator.extension.model.Value;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.TextRange;
+import org.eclipse.lsp4j.TextEdit;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -724,5 +725,35 @@ public class FTPListenerUtil {
             return parts[parts.length - 1];
         }
         return moduleName;
+    }
+
+    /**
+     * Adds import text edits required by the FTP listener's coordination config.
+     * When the listener declaration contains {@code <task:MysqlConfig>} or {@code <task:PostgresqlConfig>},
+     * the corresponding driver import ({@code ballerinax/mysql.driver as _} or
+     * {@code ballerinax/postgresql.driver as _}) and the {@code ballerina/task} import are added.
+     *
+     * @param listenerDeclaration the generated listener declaration source code
+     * @param modulePartNode      the module part node for checking existing imports
+     * @param edits               the list of text edits to append to
+     */
+    public static void addCoordinationConfigImports(String listenerDeclaration, ModulePartNode modulePartNode,
+                                                    List<TextEdit> edits) {
+        if (listenerDeclaration.contains("<task:MysqlConfig>")) {
+            addImportIfMissing(modulePartNode, edits, "ballerina", "task", false);
+            addImportIfMissing(modulePartNode, edits, "ballerinax", "mysql.driver", true);
+        } else if (listenerDeclaration.contains("<task:PostgresqlConfig>")) {
+            addImportIfMissing(modulePartNode, edits, "ballerina", "task", false);
+            addImportIfMissing(modulePartNode, edits, "ballerinax", "postgresql.driver", true);
+        }
+    }
+
+    private static void addImportIfMissing(ModulePartNode modulePartNode, List<TextEdit> edits,
+                                           String org, String module, boolean unnamed) {
+        if (!Utils.importExists(modulePartNode, org, module)) {
+            String importModule = unnamed ? module + " as _" : module;
+            edits.add(new TextEdit(Utils.toRange(modulePartNode.lineRange().startLine()),
+                    Utils.getImportStmt(org, importModule)));
+        }
     }
 }


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/94

This pull request adds support for explicit type casts when generating record values for ambiguous union types in the FTP coordination config, specifically for the `task:DatabaseConfig` union. It also ensures that the necessary import statements are automatically added when such type casts are present in the generated listener code. Additionally, a new test case validates this behavior.

**Support for explicit type casts in ambiguous union types:**

* Updated `RecordValueGenerator.java` to detect ambiguous unions (like `task:DatabaseConfig`) and add an `explicitTypeCast` property to the selected member, ensuring the generated code includes the correct type cast (e.g., `<task:MysqlConfig> {...}`) [[1]](diffhunk://#diff-c2d6ba166c43b40e899c914b2214ceaad013d460fb02d08fb80a09a2ee828c4aR86-R98) [[2]](diffhunk://#diff-c2d6ba166c43b40e899c914b2214ceaad013d460fb02d08fb80a09a2ee828c4aR107-R137).
* Added a new test configuration (`config13.json`) to verify that record generation includes the explicit type cast for ambiguous union types.

**Automatic import management for generated listener code:**

* Modified `ServiceModelGeneratorService.java` to invoke a utility that appends required import statements (for `ballerina/task` and the relevant database driver) when the listener declaration uses an explicit type cast [[1]](diffhunk://#diff-e16d2d39b31992b5f179b8306cf2864b2c822b95f1821350b214870fd3e0d554L756-R764) [[2]](diffhunk://#diff-bafbe3abe00a47756c39813eade2d9390cedf6228b234875048840f62cca85deR61).
* Added `FTPListenerUtil.addCoordinationConfigImports`, which analyzes the generated listener declaration and appends missing import statements for `task` and the appropriate driver module if needed.
