### PR TITLE
Improve library search with weighted BM25 ranking and keyword priority                                                                                                        

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/database/LibraryDatabaseAccessor.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/database/LibraryDatabaseAccessor.java
@@ -42,6 +42,27 @@ public class LibraryDatabaseAccessor {
     private static final String MODE_CORE = "CORE";
     private static final String MODE_HEALTHCARE = "HEALTHCARE";
 
+    // BM25 column weights shared across all FTS tables:
+    // primary-name column (10.0), description column (2.0), secondary-name column (5.0)
+    private static final String BM25_WEIGHTS = "10.0, 2.0, 5.0";
+
+    // Per-source scaling factors applied to bm25() scores.
+    // BM25 scores in SQLite FTS5 are negative (more negative = better match); the query
+    // uses ORDER BY combined_score ASC. A factor < 1.0 reduces the magnitude of the score
+    // (makes it less negative), which LOWERS the source's priority in the ranking.
+    // PackageFTS is the baseline (implicit factor 1.0); Type and Connector matches are
+    // intentionally ranked below it.
+    private static final String TYPE_SCORE_WEIGHT = "0.9";
+    private static final String CONNECTOR_SCORE_WEIGHT = "0.8";
+
+    // Score adjustment (subtracted from combined_score; lower = better) applied once per
+    // additional distinct source table that matched — rewards breadth of coverage.
+    private static final String MULTI_SOURCE_BONUS = "0.2";
+
+    // Fixed score adjustment applied when the primary keyword matched at least one source —
+    // a package-level bonus independent of how many rows that keyword produced.
+    private static final String PRIMARY_KEYWORD_BOOST = "0.3";
+
     private LibraryDatabaseAccessor() {
         // Prevent instantiation
     }
@@ -124,15 +145,69 @@ public class LibraryDatabaseAccessor {
         return Optional.empty();
     }
 
+    // Maximum number of libraries returned by keyword search.
+    private static final int MAX_SEARCH_RESULTS = 9;
+
+    private static final String SEARCH_SQL =
+            "SELECT p.org, p.package_name, p.description, " +
+                    "MIN(weighted_score) - (COUNT(DISTINCT source) - 1) * " + MULTI_SOURCE_BONUS +
+                    " - MAX(is_primary) * " + PRIMARY_KEYWORD_BOOST + " AS combined_score " +
+                    "FROM ( " +
+                    "    SELECT p.id, bm25(PackageFTS, " + BM25_WEIGHTS + ") AS weighted_score,"
+                    + " 'Package' AS source, ? AS is_primary " +
+                    "    FROM PackageFTS fts INNER JOIN Package p ON fts.rowid = p.id " +
+                    "    WHERE PackageFTS MATCH ? AND p.org IS NOT NULL AND p.package_name IS NOT NULL " +
+                    "    UNION ALL " +
+                    "    SELECT p.id, bm25(PackageFTS, " + BM25_WEIGHTS + ") AS weighted_score,"
+                    + " 'Package' AS source, 0 AS is_primary " +
+                    "    FROM PackageFTS fts INNER JOIN Package p ON fts.rowid = p.id " +
+                    "    WHERE PackageFTS MATCH ? AND p.org IS NOT NULL AND p.package_name IS NOT NULL " +
+                    "    UNION ALL " +
+                    "    SELECT p.id, bm25(TypeFTS, " + BM25_WEIGHTS + ") * " + TYPE_SCORE_WEIGHT
+                    + " AS weighted_score, 'Type' AS source, ? AS is_primary " +
+                    "    FROM TypeFTS fts INNER JOIN Type t ON fts.rowid = t.id"
+                    + " INNER JOIN Package p ON t.package_id = p.id " +
+                    "    WHERE TypeFTS MATCH ? AND p.org IS NOT NULL AND p.package_name IS NOT NULL " +
+                    "    UNION ALL " +
+                    "    SELECT p.id, bm25(TypeFTS, " + BM25_WEIGHTS + ") * " + TYPE_SCORE_WEIGHT
+                    + " AS weighted_score, 'Type' AS source, 0 AS is_primary " +
+                    "    FROM TypeFTS fts INNER JOIN Type t ON fts.rowid = t.id"
+                    + " INNER JOIN Package p ON t.package_id = p.id " +
+                    "    WHERE TypeFTS MATCH ? AND p.org IS NOT NULL AND p.package_name IS NOT NULL " +
+                    "    UNION ALL " +
+                    "    SELECT p.id, bm25(ConnectorFTS, " + BM25_WEIGHTS + ") * " + CONNECTOR_SCORE_WEIGHT
+                    + " AS weighted_score, 'Connector' AS source, ? AS is_primary " +
+                    "    FROM ConnectorFTS fts INNER JOIN Connector c ON fts.rowid = c.id"
+                    + " INNER JOIN Package p ON c.package_id = p.id " +
+                    "    WHERE ConnectorFTS MATCH ? AND p.org IS NOT NULL AND p.package_name IS NOT NULL " +
+                    "    UNION ALL " +
+                    "    SELECT p.id, bm25(ConnectorFTS, " + BM25_WEIGHTS + ") * " + CONNECTOR_SCORE_WEIGHT
+                    + " AS weighted_score, 'Connector' AS source, 0 AS is_primary " +
+                    "    FROM ConnectorFTS fts INNER JOIN Connector c ON fts.rowid = c.id"
+                    + " INNER JOIN Package p ON c.package_id = p.id " +
+                    "    WHERE ConnectorFTS MATCH ? AND p.org IS NOT NULL AND p.package_name IS NOT NULL " +
+                    "    UNION ALL " +
+                    "    SELECT p.id, bm25(FunctionFTS, " + BM25_WEIGHTS + ") AS weighted_score,"
+                    + " 'Function' AS source, ? AS is_primary " +
+                    "    FROM FunctionFTS fts INNER JOIN Function f ON fts.rowid = f.id"
+                    + " INNER JOIN Package p ON f.package_id = p.id " +
+                    "    WHERE FunctionFTS MATCH ? AND p.org IS NOT NULL AND p.package_name IS NOT NULL " +
+                    "    UNION ALL " +
+                    "    SELECT p.id, bm25(FunctionFTS, " + BM25_WEIGHTS + ") AS weighted_score,"
+                    + " 'Function' AS source, 0 AS is_primary " +
+                    "    FROM FunctionFTS fts INNER JOIN Function f ON fts.rowid = f.id"
+                    + " INNER JOIN Package p ON f.package_id = p.id " +
+                    "    WHERE FunctionFTS MATCH ? AND p.org IS NOT NULL AND p.package_name IS NOT NULL " +
+                    ") AS combined INNER JOIN Package p ON combined.id = p.id " +
+                    "GROUP BY p.org, p.package_name, p.description " +
+                    "ORDER BY combined_score LIMIT ?;";
+
     /**
-     * Searches libraries by keywords across packages, types, connectors, and functions using BM25 ranking.
-     * Searches in PackageFTS (package_name, description, keywords),
-     * TypeFTS (description), ConnectorFTS (description), and FunctionFTS (description).
-     * Returns a map with package name (org/package_name) as key and description as value,
-     * ordered by relevance score (best matches first).
+     * Searches libraries by keywords across packages, types, connectors, and functions using
+     * weighted BM25 ranking with keyword priority and multi-source relevance aggregation.
      *
-     * @param keywords Array of search keywords
-     * @return map of matching package names to descriptions, ordered by BM25 relevance score
+     * @param keywords Array of search keywords ordered by priority (highest priority first)
+     * @return map of matching package names to descriptions, ordered by weighted relevance score
      * @throws SQLException if database query fails
      */
     public static Map<String, String> searchLibrariesByKeywords(String[] keywords) throws SQLException {
@@ -142,76 +217,49 @@ public class LibraryDatabaseAccessor {
             return packageToDescriptionMap;
         }
 
-        // Format queries for different FTS table column structures
-        String packageQuery = formatForPackageFTS(keywords);
-        String typeConnectorFunctionQuery = formatForNameDescriptionFTS(keywords);
+        // Format queries
+        String allPackageQuery = formatForPackageFTS(keywords);
+        String allNameDescQuery = formatForNameDescriptionFTS(keywords);
 
-        // If no valid keywords after filtering, return empty
-        if (packageQuery.isEmpty() && typeConnectorFunctionQuery.isEmpty()) {
+        if (allPackageQuery.isEmpty() && allNameDescQuery.isEmpty()) {
             return packageToDescriptionMap;
         }
 
-        // Union query to search across all FTS tables and aggregate results by package
-        String sql = """
-                SELECT p.org, p.package_name, p.description, MIN(score) as best_score
-                FROM (
-                    -- Search in PackageFTS (package_name, description, keywords)
-                    SELECT p.id, bm25(PackageFTS) as score
-                    FROM PackageFTS fts
-                    INNER JOIN Package p ON fts.rowid = p.id
-                    WHERE PackageFTS MATCH ?
-                      AND p.org IS NOT NULL
-                      AND p.package_name IS NOT NULL
+        String primaryPackageQuery = formatForPackageFTS(new String[]{keywords[0]});
+        String primaryNameDescQuery = formatForNameDescriptionFTS(new String[]{keywords[0]});
 
-                    UNION ALL
+        // Use integer for is_primary placeholder
+        int primaryFlag = (!primaryPackageQuery.isEmpty() && !primaryNameDescQuery.isEmpty()) ? 1 : 0;
 
-                    -- Search in TypeFTS (name, description)
-                    SELECT p.id, bm25(TypeFTS) as score
-                    FROM TypeFTS fts
-                    INNER JOIN Type t ON fts.rowid = t.id
-                    INNER JOIN Package p ON t.package_id = p.id
-                    WHERE TypeFTS MATCH ?
-                      AND p.org IS NOT NULL
-                      AND p.package_name IS NOT NULL
-
-                    UNION ALL
-
-                    -- Search in ConnectorFTS (name, description)
-                    SELECT p.id, bm25(ConnectorFTS) as score
-                    FROM ConnectorFTS fts
-                    INNER JOIN Connector c ON fts.rowid = c.id
-                    INNER JOIN Package p ON c.package_id = p.id
-                    WHERE ConnectorFTS MATCH ?
-                      AND p.org IS NOT NULL
-                      AND p.package_name IS NOT NULL
-
-                    UNION ALL
-
-                    -- Search in FunctionFTS (name, description)
-                    SELECT p.id, bm25(FunctionFTS) as score
-                    FROM FunctionFTS fts
-                    INNER JOIN Function f ON fts.rowid = f.id
-                    INNER JOIN Package p ON f.package_id = p.id
-                    WHERE FunctionFTS MATCH ?
-                      AND p.org IS NOT NULL
-                      AND p.package_name IS NOT NULL
-                ) AS combined
-                INNER JOIN Package p ON combined.id = p.id
-                GROUP BY p.org, p.package_name, p.description
-                ORDER BY best_score
-                LIMIT 9;
-                """;
+        if (primaryPackageQuery.isEmpty()) {
+            primaryPackageQuery = allPackageQuery;
+        }
+        if (primaryNameDescQuery.isEmpty()) {
+            primaryNameDescQuery = allNameDescQuery;
+        }
 
         String dbPath = getDatabasePath();
         try (Connection conn = DriverManager.getConnection(dbPath);
-             PreparedStatement stmt = conn.prepareStatement(sql)) {
+             PreparedStatement stmt = conn.prepareStatement(SEARCH_SQL)) {
 
-            // Set the FTS queries - PackageFTS searches package_name, description, keywords
-            // TypeFTS, ConnectorFTS, FunctionFTS search name and description
-            stmt.setString(1, packageQuery);
-            stmt.setString(2, typeConnectorFunctionQuery);
-            stmt.setString(3, typeConnectorFunctionQuery);
-            stmt.setString(4, typeConnectorFunctionQuery);
+            // Bind parameters for the 8 UNION branches + LIMIT
+            stmt.setInt(1, primaryFlag);
+            stmt.setString(2, primaryPackageQuery);
+            stmt.setString(3, allPackageQuery);
+
+            stmt.setInt(4, primaryFlag);
+            stmt.setString(5, primaryNameDescQuery);
+            stmt.setString(6, allNameDescQuery);
+
+            stmt.setInt(7, primaryFlag);
+            stmt.setString(8, primaryNameDescQuery);
+            stmt.setString(9, allNameDescQuery);
+
+            stmt.setInt(10, primaryFlag);
+            stmt.setString(11, primaryNameDescQuery);
+            stmt.setString(12, allNameDescQuery);
+
+            stmt.setInt(13, MAX_SEARCH_RESULTS);
 
             try (ResultSet rs = stmt.executeQuery()) {
                 populatePackageMap(packageToDescriptionMap, rs);
@@ -284,8 +332,9 @@ public class LibraryDatabaseAccessor {
     }
 
     /**
-     * Formats keywords for TypeFTS, ConnectorFTS, and FunctionFTS which search in name and description columns.
-     * Uses column filters to explicitly search across name and description.
+     * Formats keywords for TypeFTS, ConnectorFTS, and FunctionFTS which search in
+     * name, description, and package_name columns.
+     * Uses column filters to explicitly search across all three columns.
      *
      * @param keywords array of pre-filtered keywords
      * @return FTS5-formatted query string with column filters
@@ -301,8 +350,8 @@ public class LibraryDatabaseAccessor {
             if (sanitized.isEmpty()) {
                 continue;
             }
-            // Search in name and description columns
-            tokens.add("{name description}: " + sanitized);
+            // Search in name, description, and package_name columns
+            tokens.add("{name description package_name}: " + sanitized);
         }
 
         // Combine tokens with OR operator


### PR DESCRIPTION
## Description
It resolves: https://github.com/wso2/product-integrator/issues/284

Refactors LibraryDatabaseAccessor.searchLibrariesByKeywords to produce more relevant results by:

  - Applying column-specific BM25 weights (e.g. `package_name` weighted higher than description)
  - Boosting the primary (first) keyword by running it as a separate sub-query, so packages that match the top-priority keyword rank higher
  - Applying source-type multipliers (TypeFTS ×0.9, ConnectorFTS ×0.8) to reflect relative relevance of each FTS table
  - Giving a multi-source bonus to packages that match across multiple FTS tables
  - Extending FTS search in TypeFTS/ConnectorFTS/FunctionFTS to also cover the package_name column

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This pull request refactors the library keyword search functionality to improve result relevance and ranking accuracy. The changes introduce weighted scoring mechanisms and keyword-priority boosting to ensure more relevant packages appear higher in search results.

## Key Changes
- **Enhanced scoring algorithm**: Replaced the previous simple aggregation approach with a weighted BM25-based ranking system that computes combined scores across multiple criteria, including:
  - Column-specific weights (higher priority given to package names)
  - Source-type relevance multipliers to differentiate the importance of different full-text search sources
  - Multi-source bonus to promote packages that match across multiple search tables
  - Primary keyword boost to ensure the first/priority keyword influences ranking more strongly

- **Expanded search coverage**: Extended full-text search queries for type, connector, and function FTS tables to also include package name matching, broadening the range of searchable fields and improving discoverability.

- **Improved keyword handling**: Implemented separate query paths for "all keywords" vs "primary keyword only" matching, allowing the search algorithm to apply different ranking logic based on keyword specificity while maintaining fallback behavior for edge cases.

- **Code refactoring**: Updated parameter binding and control flow to align with the new SQL-based scoring approach, resulting in +122/-73 lines changed.

## Impact
These changes address limitations in the previous implementation that caused missed relevant results and inefficient multiple search calls when querying different library categories. The new approach provides more accurate ranking while maintaining flexibility in search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->