### PR TITLE
Add workspace semantic model resolution support for the typesmanager

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
@@ -2698,15 +2698,15 @@ public class DataMapManager {
             semanticModel = sm;
         } else {
             ModuleInfo moduleInfo = new ModuleInfo(org, codedata.packageName(), codedata.module(), codedata.version());
-            Optional<SemanticModel> optSemanticModel = PackageUtil.getSemanticModelFromWorkspace(
+            Optional<SemanticModel> semanticModelOpt = PackageUtil.getSemanticModelFromWorkspace(
                     project, org, codedata.packageName(), codedata.module());
-            if (optSemanticModel.isEmpty()) {
-                optSemanticModel = PackageUtil.getSemanticModel(moduleInfo);
+            if (semanticModelOpt.isEmpty()) {
+                semanticModelOpt = PackageUtil.getSemanticModel(moduleInfo);
             }
-            if (optSemanticModel.isEmpty()) {
+            if (semanticModelOpt.isEmpty()) {
                 throw new IllegalStateException("Semantic model cannot be found for the module: " + moduleInfo);
             }
-            semanticModel = optSemanticModel.get();
+            semanticModel = semanticModelOpt.get();
         }
 
         String symbolStr = codedata.symbol();

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
@@ -2690,7 +2690,7 @@ public class DataMapManager {
         return modules;
     }
 
-    public JsonElement getVisualizableProperties(SemanticModel sm, JsonElement node) {
+    public JsonElement getVisualizableProperties(SemanticModel sm, JsonElement node, Project project) {
         Codedata codedata = gson.fromJson(node, Codedata.class);
         String org = codedata.org();
         SemanticModel semanticModel;
@@ -2698,7 +2698,11 @@ public class DataMapManager {
             semanticModel = sm;
         } else {
             ModuleInfo moduleInfo = new ModuleInfo(org, codedata.packageName(), codedata.module(), codedata.version());
-            Optional<SemanticModel> optSemanticModel = PackageUtil.getSemanticModel(moduleInfo);
+            Optional<SemanticModel> optSemanticModel = PackageUtil.getSemanticModelFromWorkspace(
+                    project, org, codedata.packageName(), codedata.module());
+            if (optSemanticModel.isEmpty()) {
+                optSemanticModel = PackageUtil.getSemanticModel(moduleInfo);
+            }
             if (optSemanticModel.isEmpty()) {
                 throw new IllegalStateException("Semantic model cannot be found for the module: " + moduleInfo);
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/DataMapperService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/DataMapperService.java
@@ -306,7 +306,7 @@ public class DataMapperService implements ExtendedLanguageServerService {
             DataMapperVisualizeResponse response = new DataMapperVisualizeResponse();
             try {
                 Path filePath = Path.of(request.filePath());
-                workspaceManager.loadProject(filePath);
+                Project project = workspaceManager.loadProject(filePath);
                 Optional<SemanticModel> semanticModel = workspaceManager.semanticModel(filePath);
                 Optional<Document> document = workspaceManager.document(filePath);
                 if (semanticModel.isEmpty() || document.isEmpty()) {
@@ -314,7 +314,8 @@ public class DataMapperService implements ExtendedLanguageServerService {
                 }
                 DataMapManager dataMapManager = new DataMapManager(document.get());
                 response.setVisualizableProperties(
-                        dataMapManager.getVisualizableProperties(semanticModel.get(), request.codedata()));
+                        dataMapManager.getVisualizableProperties(semanticModel.get(), request.codedata(),
+                                project));
             } catch (Throwable e) {
                 response.setError(e);
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
@@ -69,7 +69,9 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.diagramutil.connector.models.connector.Type;
 import org.ballerinalang.langserver.common.utils.PathUtil;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManagerProxy;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -613,6 +615,19 @@ public class TypesManagerService implements ExtendedLanguageServerService {
         cachedModel = semanticModelCache.get(keyWithoutPath);
         if (cachedModel != null) {
             return Optional.of(cachedModel);
+        }
+
+        // Check workspace sibling projects (same workspace, different integration)
+        try {
+            Project project = workspaceManager.loadProject(filePath);
+            Optional<SemanticModel> workspaceModel = PackageUtil.getSemanticModelFromWorkspace(
+                    project, org, packageName, moduleName);
+            if (workspaceModel.isPresent()) {
+                semanticModelCache.put(keyWithoutPath, workspaceModel.get());
+                return workspaceModel;
+            }
+        } catch (WorkspaceDocumentException | EventSyncException e) {
+            // Fall through to general package lookup
         }
 
         ModuleInfo moduleInfo = new ModuleInfo(org, packageName, moduleName, version);

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/DataMappingVisualizeTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/DataMappingVisualizeTest.java
@@ -45,6 +45,7 @@ public class DataMappingVisualizeTest extends AbstractLSTest {
     @Override
     protected Object[] getConfigsList() {
         return new Object[][]{
+                {Path.of("multiproject.json")},
                 {Path.of("variable1.json")},
                 {Path.of("variable2.json")},
                 {Path.of("variable3.json")},

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/typesmanager/RecordConfigTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/typesmanager/RecordConfigTest.java
@@ -51,7 +51,7 @@ public class RecordConfigTest extends AbstractLSTest {
         if (!configResponse.equals(testConfig.output())) {
             TestConfig updateConfig = new TestConfig(testConfig.filePath(), testConfig.description(),
                     testConfig.codedata(), testConfig.typeConstraint(), configResponse);
-//             updateConfig(configJsonPath, updateConfig);
+             updateConfig(configJsonPath, updateConfig);
             compareJsonElements(configResponse, testConfig.output());
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/typesmanager/RecordConfigTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/typesmanager/RecordConfigTest.java
@@ -51,7 +51,7 @@ public class RecordConfigTest extends AbstractLSTest {
         if (!configResponse.equals(testConfig.output())) {
             TestConfig updateConfig = new TestConfig(testConfig.filePath(), testConfig.description(),
                     testConfig.codedata(), testConfig.typeConstraint(), configResponse);
-             updateConfig(configJsonPath, updateConfig);
+//             updateConfig(configJsonPath, updateConfig);
             compareJsonElements(configResponse, testConfig.output());
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/config/multiproject.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/config/multiproject.json
@@ -1,0 +1,16 @@
+{
+  "source": "multiproject/project2/functions.bal",
+  "description": "Test reference type visualization",
+  "codedata": {
+    "node": "RECORD",
+    "org": "org",
+    "module": "project1",
+    "packageName": "project1",
+    "symbol": "Student",
+    "version": "0.1.0"
+  },
+  "visualizableProperties": {
+    "isDataMapped": true,
+    "defaultValue": "{}"
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/Ballerina.toml
@@ -1,0 +1,2 @@
+[workspace]
+packages = ["project1", "project2"]

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/project1/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/project1/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "org"
+name = "project1"
+version = "0.1.0"
+title = "project1"
+
+[build-options]
+sticky = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/project1/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/project1/types.bal
@@ -1,0 +1,5 @@
+public type Student record {|
+    string name;
+    int age;
+|};
+

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/project2/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/project2/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "org"
+name = "project2"
+version = "0.1.0"
+title = "project2"
+
+[build-options]
+sticky = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/project2/functions.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/multiproject/project2/functions.bal
@@ -1,0 +1,2 @@
+function function1() {
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/config/config4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/config/config4.json
@@ -1,0 +1,38 @@
+{
+  "filePath": "multiproject/project2/functions.bal",
+  "codedata": {
+    "org": "org",
+    "module": "project1",
+    "packageName": "project1",
+    "version": "0.1.0"
+  },
+  "typeConstraint": "Student",
+  "output": {
+    "fields": [
+      {
+        "name": "name",
+        "typeName": "string",
+        "optional": false,
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      },
+      {
+        "name": "age",
+        "typeName": "int",
+        "optional": false,
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      }
+    ],
+    "hasRestType": false,
+    "typeName": "record",
+    "optional": false,
+    "defaultable": false,
+    "isRestType": false,
+    "selected": false
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/Ballerina.toml
@@ -1,0 +1,2 @@
+[workspace]
+packages = ["project1", "project2"]

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/project1/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/project1/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "org"
+name = "project1"
+version = "0.1.0"
+title = "project1"
+
+[build-options]
+sticky = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/project1/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/project1/types.bal
@@ -1,0 +1,5 @@
+public type Student record {|
+    string name;
+    int age;
+|};
+

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/project2/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/project2/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "org"
+name = "project2"
+version = "0.1.0"
+title = "project2"
+
+[build-options]
+sticky = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/project2/functions.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/multiproject/project2/functions.bal
@@ -1,0 +1,2 @@
+function function1() {
+}

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -41,6 +41,7 @@ import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.repos.TempDirCompilationCache;
 import org.ballerinalang.langserver.LSClientLogger;
+import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
@@ -53,6 +54,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -277,6 +279,44 @@ public class PackageUtil {
                 return Optional.of(PackageUtil.getCompilation(currentPackage).getSemanticModel(moduleId));
             }
         } catch (WorkspaceDocumentException | EventSyncException e) {
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Retrieves the semantic model for a package from sibling projects within the same workspace.
+     *
+     * @param project     the current project used to find the workspace
+     * @param org         the organization name of the target package
+     * @param packageName the package name of the target package
+     * @param moduleName  the module name of the target package
+     * @return an Optional containing the semantic model if a matching sibling project is found
+     */
+    public static Optional<SemanticModel> getSemanticModelFromWorkspace(Project project, String org,
+                                                                        String packageName, String moduleName) {
+        BallerinaCompilerApi compilerApi = BallerinaCompilerApi.getInstance();
+        Optional<Project> workspaceProject = compilerApi.getWorkspaceProject(project);
+        if (workspaceProject.isEmpty()) {
+            return Optional.empty();
+        }
+        List<Project> childProjects = compilerApi.getWorkspaceProjectsInOrder(workspaceProject.get());
+        for (Project childProject : childProjects) {
+            Package currentPackage = childProject.currentPackage();
+            String currentPackageName = currentPackage.packageName().value();
+            if (currentPackage.packageOrg().value().equals(org) &&
+                    (currentPackageName.equals(packageName) ||
+                            currentPackageName.equals(moduleName))) {
+                ModuleId moduleId = currentPackage.getDefaultModule().moduleId();
+                if (moduleName != null && !moduleName.isEmpty() && !packageName.equals(moduleName)) {
+                    for (Module mod : currentPackage.modules()) {
+                        if (mod.moduleName().toString().equals(moduleName)) {
+                            moduleId = mod.moduleId();
+                            break;
+                        }
+                    }
+                }
+                return Optional.of(getCompilation(childProject).getSemanticModel(moduleId));
+            }
         }
         return Optional.empty();
     }

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -303,20 +303,23 @@ public class PackageUtil {
         for (Project childProject : childProjects) {
             Package currentPackage = childProject.currentPackage();
             String currentPackageName = currentPackage.packageName().value();
-            if (currentPackage.packageOrg().value().equals(org) &&
-                    (currentPackageName.equals(packageName) ||
-                            currentPackageName.equals(moduleName))) {
-                ModuleId moduleId = currentPackage.getDefaultModule().moduleId();
-                if (moduleName != null && !moduleName.isEmpty() && !packageName.equals(moduleName)) {
-                    for (Module mod : currentPackage.modules()) {
-                        if (mod.moduleName().toString().equals(moduleName)) {
-                            moduleId = mod.moduleId();
-                            break;
-                        }
-                    }
-                }
+            boolean orgMatches = currentPackage.packageOrg().value().equals(org);
+            boolean nameMatches = currentPackageName.equals(packageName) || currentPackageName.equals(moduleName);
+            if (!orgMatches || !nameMatches) {
+                continue;
+            }
+
+            ModuleId moduleId = currentPackage.getDefaultModule().moduleId();
+            if (moduleName == null || moduleName.isEmpty() || packageName.equals(moduleName)) {
                 return Optional.of(getCompilation(childProject).getSemanticModel(moduleId));
             }
+            for (Module mod : currentPackage.modules()) {
+                if (mod.moduleName().toString().equals(moduleName)) {
+                    moduleId = mod.moduleId();
+                    break;
+                }
+            }
+            return Optional.of(getCompilation(childProject).getSemanticModel(moduleId));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
## Purpose
Fixes : https://github.com/wso2/product-integrator/issues/658

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
https://github.com/user-attachments/assets/a6a42b3f-5689-43c3-959f-05b9c6c958c9


## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This pull request adds workspace semantic model resolution support to improve type and symbol resolution in the flow model generator and record configuration editor. The changes enable the system to resolve semantic models from workspace sibling projects in addition to standard package-based resolution.

## Changes Made

### Core Functionality Enhancements
- **PackageUtil**: Added a new public method `getSemanticModelFromWorkspace()` that searches workspace projects for matching packages and modules by organization and name, providing an additional resolution path for semantic models.

- **DataMapManager**: Enhanced `getVisualizableProperties()` to accept a `Project` parameter and implement workspace-first semantic model resolution. The method now attempts workspace-based lookup before falling back to standard package resolution.

- **DataMapperService**: Updated to capture the loaded project and pass it to `DataMapManager` for improved semantic model resolution.

- **TypesManagerService**: Extended `getCachedSemanticModel()` with an additional retrieval path that loads the project and queries workspace sibling projects via the new `getSemanticModelFromWorkspace()` method, caching results when found before attempting general package lookup.

### Test Infrastructure
- Added comprehensive multi-project test workspace configuration with test resources:
  - Workspace and project manifests defining a multi-project structure with `project1` and `project2`
  - Test data including record type definitions and function declarations
  - Test configurations validating workspace semantic model resolution across the flow mapper visualization and record configuration features
  
## Impact
These changes enable more robust type resolution in workspace-based Ballerina projects, allowing the flow model generator and record configuration editor to correctly locate and resolve types defined in sibling projects within the same workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->