### PR TITLE
 Fix workflow function node detection and context parameter preservation

### DIFF
--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/connection.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/connection.json
@@ -42,7 +42,7 @@
         "name": "httpConnection",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       },

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/http_service.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/http_service.json
@@ -21,7 +21,7 @@
         "name": "httpClient",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       }
@@ -44,7 +44,7 @@
         "name": "refListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       },
@@ -65,7 +65,7 @@
         "name": "securedEP",
         "scope": "Global",
         "visibility": "public",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       }
@@ -88,7 +88,7 @@
         "name": "HTTP Service - /root/path-id",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {
           "post#data": {
@@ -210,7 +210,7 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {
           "init": {
@@ -271,7 +271,7 @@
         "name": "HTTP Service - /api/v1",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {
           "get#path": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/listener.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/listener.json
@@ -21,7 +21,7 @@
         "name": "httpDefaultListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       },
@@ -82,7 +82,7 @@
         "name": "refListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       }

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/project.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/project.json
@@ -21,7 +21,7 @@
         "name": "httpClient",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       },
@@ -42,7 +42,7 @@
         "name": "httpClient2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       }
@@ -65,7 +65,7 @@
         "name": "ls",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       },
@@ -86,7 +86,7 @@
         "name": "securedEP",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       },
@@ -107,7 +107,7 @@
         "name": "securedEP2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {}
       }
@@ -170,7 +170,7 @@
         "name": "HTTP Service - /api2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {
           "get#path": {
@@ -212,7 +212,7 @@
         "name": "HTTP Service - /api1",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {
           "get#path": {
@@ -273,7 +273,7 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {
           "init": {
@@ -334,7 +334,7 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
         "module": "http",
         "children": {
           "init": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/connections.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/connections.json
@@ -22,7 +22,7 @@
           "name": "httpEp",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {}
         }

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/main.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/main.json
@@ -89,7 +89,7 @@
           "name": "httpListener",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {}
         }
@@ -114,7 +114,7 @@
           "name": "HTTP Service - /restaurant",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {
             "post#orders": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/resources/existing_project.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/resources/existing_project.json
@@ -121,7 +121,7 @@
           "name": "httpEp",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {}
         }
@@ -232,7 +232,7 @@
           "name": "httpListener",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {}
         }
@@ -542,7 +542,7 @@
           "name": "HTTP Service - /restaurant",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {
             "post#orders": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/resources/no_preexisting_project.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/resources/no_preexisting_project.json
@@ -121,7 +121,7 @@
           "name": "httpEp",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {}
         }
@@ -245,7 +245,7 @@
           "name": "httpListener",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {}
         }
@@ -565,7 +565,7 @@
           "name": "HTTP Service - /restaurant",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png",
           "module": "http",
           "children": {
             "get#menu": {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/analyzers/function/ModuleNodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/analyzers/function/ModuleNodeAnalyzer.java
@@ -50,10 +50,12 @@ import io.ballerina.flowmodelgenerator.core.Constants;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.Property;
+import io.ballerina.flowmodelgenerator.core.model.node.ActivityBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.AutomationBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.DataMapperDefinitionBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.FunctionDefinitionBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.NPFunctionDefinitionBuilder;
+import io.ballerina.flowmodelgenerator.core.model.node.WorkflowBuilder;
 import io.ballerina.modelgenerator.commons.CommonUtils;
 import io.ballerina.modelgenerator.commons.ModuleInfo;
 import io.ballerina.modelgenerator.commons.ParameterData;
@@ -64,6 +66,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.ballerina.flowmodelgenerator.core.utils.WorkflowUtil.isActivityFunction;
+import static io.ballerina.flowmodelgenerator.core.utils.WorkflowUtil.isWorkflowFunction;
 import static io.ballerina.modelgenerator.commons.ParameterData.Kind.REQUIRED;
 
 /**
@@ -112,7 +116,14 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
         } else if (functionDefinitionNode.functionName().text().equals(AutomationBuilder.MAIN_FUNCTION_NAME)) {
             nodeKind = NodeKind.AUTOMATION;
         } else {
-            nodeKind = NodeKind.FUNCTION_DEFINITION;
+            Optional<Symbol> symbol = this.semanticModel.symbol(functionDefinitionNode);
+            if (symbol.isPresent() && isWorkflowFunction(symbol.get())) {
+                nodeKind = NodeKind.WORKFLOW;
+            } else if (symbol.isPresent() && isActivityFunction(symbol.get())) {
+                nodeKind = NodeKind.ACTIVITY;
+            } else {
+                nodeKind = NodeKind.FUNCTION_DEFINITION;
+            }
         }
 
         NodeBuilder nodeBuilder = NodeBuilder.getNodeFromKind(nodeKind)
@@ -138,10 +149,41 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
             nodeBuilder.properties().functionName(functionDefinitionNode.functionName());
         }
         // TODO: Check how we can do this using FunctionDefinitionBuilder as the super class
+        // For WORKFLOW functions, extract the input data parameter type and context parameter.
+        // WorkflowBuilder.toSource uses a single inputType property rather than a parameters list.
+        // The context parameter (workflow:Context ...) is preserved verbatim as a hidden property
+        // so it is re-emitted unchanged on save; it is not exposed in the edit form.
+        String workflowInputType = "";
+        String workflowContextParam = "";
+        if (nodeKind == NodeKind.WORKFLOW) {
+            for (ParameterNode parameter : functionDefinitionNode.functionSignature().parameters()) {
+                if (parameter.kind() == SyntaxKind.REQUIRED_PARAM) {
+                    RequiredParameterNode reqParam = (RequiredParameterNode) parameter;
+                    String paramType = getNodeValue(reqParam.typeName());
+                    String paramName = reqParam.paramName().map(Token::text).orElse("");
+                    if (paramType.contains(Constants.Workflow.CONTEXT_CLASS_NAME)) {
+                        workflowContextParam = paramName.isEmpty() ? paramType : paramType + " " + paramName;
+                    } else if (workflowInputType.isEmpty()) {
+                        workflowInputType = paramType;
+                    }
+                } else if (parameter.kind() == SyntaxKind.DEFAULTABLE_PARAM && workflowInputType.isEmpty()) {
+                    DefaultableParameterNode defParam = (DefaultableParameterNode) parameter;
+                    String paramType = getNodeValue(defParam.typeName());
+                    if (!paramType.contains(Constants.Workflow.CONTEXT_CLASS_NAME)) {
+                        workflowInputType = paramType;
+                    }
+                }
+            }
+        }
+
         switch (nodeKind) {
             case DATA_MAPPER_DEFINITION -> DataMapperDefinitionBuilder.setMandatoryProperties(nodeBuilder, returnType);
             case AUTOMATION -> AutomationBuilder.sendMandatoryProperties(nodeBuilder);
             case NP_FUNCTION_DEFINITION -> NPFunctionDefinitionBuilder.setMandatoryProperties(nodeBuilder, returnType);
+            case WORKFLOW -> WorkflowBuilder.setMandatoryProperties(nodeBuilder, returnType,
+                    documentation == null ? "" : documentation.description(),
+                    documentation == null ? "" : documentation.returnDescription(),
+                    workflowInputType, workflowContextParam);
             default -> FunctionDefinitionBuilder.setMandatoryProperties(nodeBuilder, returnType,
                     documentation == null ? "" : documentation.description(),
                     documentation == null ? "" : documentation.returnDescription());
@@ -149,7 +191,9 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
 
         boolean isModelParamAvailable = false;
 
-        // Set the function parameters
+        // Set the function parameters. WORKFLOW functions use a single inputType property
+        // (already set above) instead of a parameters list, so skip the loop for them.
+        if (nodeKind != NodeKind.WORKFLOW) {
         for (ParameterNode parameter : functionDefinitionNode.functionSignature().parameters()) {
             String paramType;
             Optional<Token> paramName;
@@ -198,6 +242,7 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
                 }
             }
         }
+        } // end if (nodeKind != NodeKind.WORKFLOW)
 
         switch (nodeKind) {
             case DATA_MAPPER_DEFINITION -> DataMapperDefinitionBuilder.setOptionalProperties(nodeBuilder);
@@ -209,9 +254,12 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
                 processNaturalFunctionDefProperties(nodeBuilder,
                         ((NaturalExpressionNode) expressionFunctionBodyNode.expression()), isModelParamAvailable);
             }
+            case WORKFLOW -> { /* WorkflowBuilder uses inputType, not a parameters list; nothing to finalize */ }
             default -> FunctionDefinitionBuilder.setOptionalProperties(nodeBuilder);
         }
 
+        // WORKFLOW annotations and qualifiers are hardcoded by WorkflowBuilder.toSource; skip them here.
+        if (nodeKind != NodeKind.WORKFLOW) {
         Optional<MetadataNode> optMetadata = functionDefinitionNode.metadata();
         if (optMetadata.isPresent()) {
             StringBuilder annot = new StringBuilder();
@@ -231,6 +279,7 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
                 nodeBuilder.properties().isPublic(true, false, true, false);
             }
         }
+        } // end if (nodeKind != NodeKind.WORKFLOW)
 
         // Build the definition node
         this.node = gson.toJsonTree(nodeBuilder.build());

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/analyzers/function/ModuleNodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/analyzers/function/ModuleNodeAnalyzer.java
@@ -50,7 +50,6 @@ import io.ballerina.flowmodelgenerator.core.Constants;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.Property;
-import io.ballerina.flowmodelgenerator.core.model.node.ActivityBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.AutomationBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.DataMapperDefinitionBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.FunctionDefinitionBuilder;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WorkflowBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WorkflowBuilder.java
@@ -19,6 +19,7 @@
 package io.ballerina.flowmodelgenerator.core.model.node;
 
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.Property;
 import io.ballerina.flowmodelgenerator.core.model.SourceBuilder;
@@ -50,6 +51,10 @@ public class WorkflowBuilder extends FunctionDefinitionBuilder {
     public static final String INPUT_LABEL = "Input Type";
     public static final String INPUT_DOC = "Type of the input data to the workflow";
     public static final String ANYDATA_TYPE = "anydata";
+
+    // Hidden key that preserves the workflow:Context parameter text from the original source.
+    // Not shown in the edit form; re-emitted verbatim by toSource() so it is never dropped on save.
+    public static final String CONTEXT_PARAM_KEY = "workflowContextParam";
 
     @Override
     public void setConcreteConstData() {
@@ -92,6 +97,53 @@ public class WorkflowBuilder extends FunctionDefinitionBuilder {
         properties().returnDescription("");
     }
 
+    /**
+     * Sets the mandatory properties for an existing workflow function node being loaded for editing.
+     * Mirrors the property shape of {@link #setConcreteTemplateData} so the edit form is consistent.
+     *
+     * @param nodeBuilder       the node builder to populate
+     * @param returnType        the function's return type text
+     * @param description       the function-level doc comment
+     * @param returnDescription the return-value doc comment
+     * @param inputType         the workflow input parameter type (empty string if none)
+     * @param contextParam      the full workflow:Context parameter text (e.g. "workflow:Context ctx"),
+     *                          or empty string if the original function had no Context parameter
+     */
+    public static void setMandatoryProperties(NodeBuilder nodeBuilder, String returnType, String description,
+                                              String returnDescription, String inputType, String contextParam) {
+        nodeBuilder.properties().functionDescription(description);
+        nodeBuilder.properties().custom()
+                .metadata()
+                    .label(INPUT_LABEL)
+                    .description(INPUT_DOC)
+                    .stepOut()
+                .type()
+                    .fieldType(Property.ValueType.TYPE)
+                    .ballerinaType(ANYDATA_TYPE)
+                .stepOut()
+                .value(inputType)
+                .editable(true)
+                .optional(true)
+                .stepOut()
+                .addProperty(INPUT_KEY);
+        // Store the original context parameter text as a hidden property so toSource() can re-emit it
+        // unchanged, preserving the workflow:Context parameter without exposing it to the edit form.
+        if (contextParam != null && !contextParam.isEmpty()) {
+            nodeBuilder.properties().custom()
+                    .metadata().label("").description("").stepOut()
+                    .type().fieldType(Property.ValueType.TEXT).stepOut()
+                    .value(contextParam)
+                    .hidden()
+                    .optional(true)
+                    .editable(false)
+                    .stepOut()
+                    .addProperty(CONTEXT_PARAM_KEY);
+        }
+        nodeBuilder.properties()
+                .returnType(returnType, null, true)
+                .returnDescription(returnDescription);
+    }
+
     @Override
     public Map<Path, List<TextEdit>> toSource(SourceBuilder sourceBuilder) {
         Optional<Property> optDescription = sourceBuilder.getProperty(Property.FUNCTION_NAME_DESCRIPTION_KEY);
@@ -114,15 +166,27 @@ public class WorkflowBuilder extends FunctionDefinitionBuilder {
                 .name(funcName)
                 .keyword(SyntaxKind.OPEN_PAREN_TOKEN);
 
+        Optional<Property> contextProp = sourceBuilder.getProperty(CONTEXT_PARAM_KEY);
+        String contextParamText = contextProp.map(p -> p.value().toString()).orElse("");
+
         Optional<Property> inputProperty = sourceBuilder.getProperty(INPUT_KEY);
-        if (inputProperty.isPresent()) {
-            String typeName = inputProperty.get().value().toString();
-            if (!typeName.isEmpty()) {
-                sourceBuilder.token()
-                        .name(typeName)
-                        .whiteSpace()
-                        .name(DEFAULT_INPUT_PARAM_NAME);
-            }
+        String inputTypeName = inputProperty.map(p -> p.value().toString()).orElse("");
+
+        if (!contextParamText.isEmpty() && !inputTypeName.isEmpty()) {
+            sourceBuilder.token()
+                    .name(contextParamText)
+                    .keyword(SyntaxKind.COMMA_TOKEN)
+                    .whiteSpace()
+                    .name(inputTypeName)
+                    .whiteSpace()
+                    .name(DEFAULT_INPUT_PARAM_NAME);
+        } else if (!contextParamText.isEmpty()) {
+            sourceBuilder.token().name(contextParamText);
+        } else if (!inputTypeName.isEmpty()) {
+            sourceBuilder.token()
+                    .name(inputTypeName)
+                    .whiteSpace()
+                    .name(DEFAULT_INPUT_PARAM_NAME);
         }
 
         sourceBuilder.token().keyword(SyntaxKind.CLOSE_PAREN_TOKEN);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WorkflowBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WorkflowBuilder.java
@@ -167,12 +167,12 @@ public class WorkflowBuilder extends FunctionDefinitionBuilder {
                 .keyword(SyntaxKind.OPEN_PAREN_TOKEN);
 
         Optional<Property> contextProp = sourceBuilder.getProperty(CONTEXT_PARAM_KEY);
-        String contextParamText = contextProp.map(p -> p.value().toString()).orElse("");
+        String contextParamText = contextProp.map(p -> p.value().toString().trim()).orElse("");
 
         Optional<Property> inputProperty = sourceBuilder.getProperty(INPUT_KEY);
-        String inputTypeName = inputProperty.map(p -> p.value().toString()).orElse("");
+        String inputTypeName = inputProperty.map(p -> p.value().toString().trim()).orElse("");
 
-        if (!contextParamText.isEmpty() && !inputTypeName.isEmpty()) {
+        if (!contextParamText.isBlank() && !inputTypeName.isBlank()) {
             sourceBuilder.token()
                     .name(contextParamText)
                     .keyword(SyntaxKind.COMMA_TOKEN)
@@ -180,9 +180,9 @@ public class WorkflowBuilder extends FunctionDefinitionBuilder {
                     .name(inputTypeName)
                     .whiteSpace()
                     .name(DEFAULT_INPUT_PARAM_NAME);
-        } else if (!contextParamText.isEmpty()) {
+        } else if (!contextParamText.isBlank()) {
             sourceBuilder.token().name(contextParamText);
-        } else if (!inputTypeName.isEmpty()) {
+        } else if (!inputTypeName.isBlank()) {
             sourceBuilder.token()
                     .name(inputTypeName)
                     .whiteSpace()

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionDefinitionTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionDefinitionTest.java
@@ -54,7 +54,7 @@ public class FunctionDefinitionTest extends AbstractLSTest {
                     testConfig.functionName(),
                     testConfig.description(),
                     functionDefinition);
-//            updateConfig(configJsonPath, updatedConfig);
+            updateConfig(configJsonPath, updatedConfig);
             compareJsonElements(functionDefinition, testConfig.output());
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/SourceGeneratorTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/SourceGeneratorTest.java
@@ -86,7 +86,7 @@ public class SourceGeneratorTest extends AbstractLSTest {
         if (assertFailure) {
             TestConfig updatedConfig =
                     new TestConfig(testConfig.source(), testConfig.description(), testConfig.diagram(), newMap);
-//            updateConfig(configJsonPath, updatedConfig);
+            updateConfig(configJsonPath, updatedConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }
     }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_1.json
@@ -915,7 +915,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1056,7 +1056,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1149,7 +1149,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1186,7 +1186,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1223,7 +1223,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1301,49 +1301,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1380,7 +1380,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1417,7 +1417,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1454,7 +1454,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1491,7 +1491,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1528,7 +1528,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1593,7 +1593,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1658,7 +1658,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1774,7 +1774,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1878,7 +1878,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1915,7 +1915,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2008,7 +2008,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2045,7 +2045,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2082,7 +2082,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2160,49 +2160,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2239,7 +2239,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2276,7 +2276,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2313,7 +2313,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2350,7 +2350,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2387,7 +2387,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2452,7 +2452,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2517,7 +2517,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2880,7 +2880,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2920,7 +2920,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3016,7 +3016,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3056,7 +3056,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3140,7 +3140,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3180,7 +3180,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3220,7 +3220,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3260,7 +3260,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3300,7 +3300,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_2.json
@@ -925,7 +925,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1029,7 +1029,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1066,7 +1066,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1159,7 +1159,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1196,7 +1196,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1233,7 +1233,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1311,49 +1311,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1390,7 +1390,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1427,7 +1427,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1464,7 +1464,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1501,7 +1501,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1538,7 +1538,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1603,7 +1603,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1668,7 +1668,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1784,7 +1784,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1888,7 +1888,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1925,7 +1925,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2018,7 +2018,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2055,7 +2055,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2092,7 +2092,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2170,49 +2170,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2249,7 +2249,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2286,7 +2286,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2323,7 +2323,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2360,7 +2360,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2397,7 +2397,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2462,7 +2462,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2527,7 +2527,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2890,7 +2890,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2930,7 +2930,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3026,7 +3026,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3066,7 +3066,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3150,7 +3150,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3190,7 +3190,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3230,7 +3230,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3270,7 +3270,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3310,7 +3310,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_3.json
@@ -915,7 +915,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1056,7 +1056,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1149,7 +1149,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1186,7 +1186,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1223,7 +1223,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1301,49 +1301,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1380,7 +1380,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1417,7 +1417,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1454,7 +1454,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1491,7 +1491,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1528,7 +1528,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1593,7 +1593,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1658,7 +1658,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1774,7 +1774,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1878,7 +1878,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1915,7 +1915,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2008,7 +2008,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2045,7 +2045,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2082,7 +2082,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2160,49 +2160,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2239,7 +2239,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2276,7 +2276,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2313,7 +2313,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2350,7 +2350,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2387,7 +2387,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2452,7 +2452,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2517,7 +2517,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2889,7 +2889,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2929,7 +2929,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3025,7 +3025,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3065,7 +3065,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3149,7 +3149,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3189,7 +3189,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3229,7 +3229,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3269,7 +3269,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3309,7 +3309,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_4.json
@@ -1174,7 +1174,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1214,7 +1214,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1310,7 +1310,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1350,7 +1350,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1434,7 +1434,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1474,7 +1474,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1514,7 +1514,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1554,7 +1554,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1594,7 +1594,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/available_agents.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/available_agents.json
@@ -53,7 +53,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -62,7 +62,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -72,7 +72,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -81,7 +81,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -91,7 +91,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -100,7 +100,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -110,7 +110,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -119,7 +119,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -129,7 +129,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -138,7 +138,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -148,7 +148,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -157,7 +157,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -167,7 +167,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -176,7 +176,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -186,7 +186,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -195,7 +195,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -205,7 +205,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -214,7 +214,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -224,7 +224,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -233,7 +233,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -243,7 +243,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -252,7 +252,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -262,7 +262,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -271,7 +271,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -281,7 +281,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -290,7 +290,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -300,7 +300,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -309,7 +309,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -319,7 +319,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -328,7 +328,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -338,7 +338,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -347,7 +347,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -357,7 +357,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -366,7 +366,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -376,7 +376,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -385,7 +385,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -395,7 +395,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -404,7 +404,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -424,7 +424,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -433,7 +433,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -443,7 +443,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -452,7 +452,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -462,7 +462,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -471,7 +471,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -481,7 +481,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -490,7 +490,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -500,7 +500,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -509,7 +509,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -519,7 +519,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -528,7 +528,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -538,7 +538,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -547,7 +547,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -557,7 +557,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -566,7 +566,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -576,7 +576,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -585,7 +585,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -595,7 +595,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -604,7 +604,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -614,7 +614,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -623,7 +623,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -633,7 +633,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -642,7 +642,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -652,7 +652,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -661,7 +661,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -671,7 +671,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -680,7 +680,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -690,7 +690,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -699,7 +699,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -709,7 +709,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -718,7 +718,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -728,7 +728,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -737,7 +737,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -747,7 +747,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -756,7 +756,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -766,7 +766,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -775,7 +775,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/caller.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/caller.json
@@ -24,7 +24,7 @@
               "metadata": {
                 "label": "respond",
                 "description": "Sends the outbound response to the caller.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -33,7 +33,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "respond",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -43,7 +43,7 @@
               "metadata": {
                 "label": "promise",
                 "description": "Pushes a promise to the caller.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -52,7 +52,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "promise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -62,7 +62,7 @@
               "metadata": {
                 "label": "pushPromisedResponse",
                 "description": "Sends a promised push response to the caller.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -71,7 +71,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "pushPromisedResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -81,7 +81,7 @@
               "metadata": {
                 "label": "'continue",
                 "description": "Sends a `100-continue` response to the caller.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -90,7 +90,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "'continue",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -100,7 +100,7 @@
               "metadata": {
                 "label": "redirect",
                 "description": "Sends a redirect response to the user with the specified redirection status code.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -109,7 +109,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "redirect",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -119,7 +119,7 @@
               "metadata": {
                 "label": "getRemoteHostName",
                 "description": "Gets the hostname from the remote address. This method may trigger a DNS reverse lookup if the address was created\nwith a literal IP address.\n```ballerina\nstring? remoteHost = caller.getRemoteHostName();\n```\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -128,7 +128,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "getRemoteHostName",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/connector1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/connector1.json
@@ -24,7 +24,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -33,7 +33,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -43,7 +43,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -52,7 +52,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -62,7 +62,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -71,7 +71,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -81,7 +81,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -90,7 +90,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -100,7 +100,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -109,7 +109,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -119,7 +119,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -128,7 +128,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -138,7 +138,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -147,7 +147,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -157,7 +157,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -166,7 +166,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -176,7 +176,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -185,7 +185,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -195,7 +195,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -204,7 +204,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -214,7 +214,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -223,7 +223,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -233,7 +233,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -242,7 +242,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -252,7 +252,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -261,7 +261,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -271,7 +271,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -280,7 +280,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -290,7 +290,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -299,7 +299,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -309,7 +309,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -318,7 +318,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -328,7 +328,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -337,7 +337,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -347,7 +347,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -356,7 +356,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -366,7 +366,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -375,7 +375,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/connector2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/connector2.json
@@ -24,7 +24,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -33,7 +33,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -43,7 +43,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -52,7 +52,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -62,7 +62,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -71,7 +71,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -81,7 +81,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -90,7 +90,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -100,7 +100,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -109,7 +109,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -119,7 +119,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -128,7 +128,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -138,7 +138,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -147,7 +147,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -157,7 +157,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -166,7 +166,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -176,7 +176,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -185,7 +185,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -195,7 +195,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -204,7 +204,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -214,7 +214,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -223,7 +223,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -233,7 +233,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -242,7 +242,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -252,7 +252,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -261,7 +261,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -271,7 +271,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -280,7 +280,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -290,7 +290,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -299,7 +299,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -309,7 +309,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -318,7 +318,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -328,7 +328,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -337,7 +337,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -347,7 +347,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -356,7 +356,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -366,7 +366,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -375,7 +375,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/tool_compatibility.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/tool_compatibility.json
@@ -24,7 +24,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -33,7 +33,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -46,7 +46,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -55,7 +55,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -68,7 +68,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -77,7 +77,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -90,7 +90,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -99,7 +99,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -112,7 +112,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -121,7 +121,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -134,7 +134,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -143,7 +143,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -156,7 +156,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -165,7 +165,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -178,7 +178,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -187,7 +187,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -200,7 +200,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -209,7 +209,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -222,7 +222,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -231,7 +231,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -244,7 +244,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -253,7 +253,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -266,7 +266,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -275,7 +275,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -288,7 +288,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -297,7 +297,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -310,7 +310,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -319,7 +319,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -332,7 +332,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -341,7 +341,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -354,7 +354,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -363,7 +363,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -376,7 +376,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -385,7 +385,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -398,7 +398,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -407,7 +407,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -420,7 +420,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -429,7 +429,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.0",
+                "version": "2.16.1",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj13.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj13.json
@@ -40,7 +40,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.0_  \n  \nSends the outbound response to the caller.\n  \n**Params**  \n- `http:ResponseMessage|http:StatusCodeResponse|error` message: The outbound response or status code response or error or any allowed payload(Defaultable)  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to respond or else `()`  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.1_  \n  \nSends the outbound response to the caller.\n  \n**Params**  \n- `http:ResponseMessage|http:StatusCodeResponse|error` message: The outbound response or status code response or error or any allowed payload(Defaultable)  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to respond or else `()`  \n  \n"
         }
       },
       "sortText": "AD",
@@ -59,7 +59,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.0_  \n  \nPushes a promise to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` in case of failures  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.1_  \n  \nPushes a promise to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` in case of failures  \n  \n"
         }
       },
       "sortText": "AE",
@@ -78,7 +78,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.0_  \n  \nSends a promised push response to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n- `http:Response` response: The outbound response  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` in case of failures while responding with the promised response  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.1_  \n  \nSends a promised push response to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n- `http:Response` response: The outbound response  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` in case of failures while responding with the promised response  \n  \n"
         }
       },
       "sortText": "AF",
@@ -97,7 +97,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.0_  \n  \nSends a `100-continue` response to the caller.\n  \n  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to send the `100-continue` response or else `()`  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.1_  \n  \nSends a `100-continue` response to the caller.\n  \n  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to send the `100-continue` response or else `()`  \n  \n"
         }
       },
       "sortText": "AG",
@@ -112,7 +112,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.0_  \n  \nSends a redirect response to the user with the specified redirection status code.\n  \n**Params**  \n- `http:Response` response: Response to be sent to the caller  \n- `http:RedirectCode` code: The redirect status code to be sent  \n- `string[]` locations: An array of URLs to which the caller can redirect to  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to send the redirect response or else `()`  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.1_  \n  \nSends a redirect response to the user with the specified redirection status code.\n  \n**Params**  \n- `http:Response` response: Response to be sent to the caller  \n- `http:RedirectCode` code: The redirect status code to be sent  \n- `string[]` locations: An array of URLs to which the caller can redirect to  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to send the redirect response or else `()`  \n  \n"
         }
       },
       "sortText": "AH",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables_v2_get/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables_v2_get/config/config2.json
@@ -1173,7 +1173,7 @@
                   "typeMembers": [
                     {
                       "type": "ListenerConfiguration",
-                      "packageInfo": "ballerina:http:2.16.0",
+                      "packageInfo": "ballerina:http:2.16.1",
                       "packageName": "http",
                       "kind": "RECORD_TYPE",
                       "selected": false
@@ -1421,7 +1421,7 @@
                   "typeMembers": [
                     {
                       "type": "TraceLogAdvancedConfiguration",
-                      "packageInfo": "ballerina:http:2.16.0",
+                      "packageInfo": "ballerina:http:2.16.1",
                       "packageName": "http",
                       "kind": "RECORD_TYPE",
                       "selected": false
@@ -1545,7 +1545,7 @@
                   "typeMembers": [
                     {
                       "type": "AccessLogConfiguration",
-                      "packageInfo": "ballerina:http:2.16.0",
+                      "packageInfo": "ballerina:http:2.16.1",
                       "packageName": "http",
                       "kind": "RECORD_TYPE",
                       "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/copilot_library/get_filtered_libraries.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/copilot_library/get_filtered_libraries.json
@@ -1984,7 +1984,7 @@
           "type": "Union",
           "members": [
             {
-              "name": "ballerina/http:2.16.0:OAuth2ClientCredentialsGrantConfig",
+              "name": "ballerina/http:2.16.1:OAuth2ClientCredentialsGrantConfig",
               "type": {
                 "name": "OAuth2ClientCredentialsGrantConfig",
                 "links": [
@@ -1996,7 +1996,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:OAuth2PasswordGrantConfig",
+              "name": "ballerina/http:2.16.1:OAuth2PasswordGrantConfig",
               "type": {
                 "name": "OAuth2PasswordGrantConfig",
                 "links": [
@@ -2008,7 +2008,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:OAuth2RefreshTokenGrantConfig",
+              "name": "ballerina/http:2.16.1:OAuth2RefreshTokenGrantConfig",
               "type": {
                 "name": "OAuth2RefreshTokenGrantConfig",
                 "links": [
@@ -2020,7 +2020,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:OAuth2JwtBearerGrantConfig",
+              "name": "ballerina/http:2.16.1:OAuth2JwtBearerGrantConfig",
               "type": {
                 "name": "OAuth2JwtBearerGrantConfig",
                 "links": [
@@ -2381,7 +2381,7 @@
           "type": "Union",
           "members": [
             {
-              "name": "ballerina/http:2.16.0:CredentialsConfig",
+              "name": "ballerina/http:2.16.1:CredentialsConfig",
               "type": {
                 "name": "CredentialsConfig",
                 "links": [
@@ -2393,7 +2393,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:BearerTokenConfig",
+              "name": "ballerina/http:2.16.1:BearerTokenConfig",
               "type": {
                 "name": "BearerTokenConfig",
                 "links": [
@@ -2405,7 +2405,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:JwtIssuerConfig",
+              "name": "ballerina/http:2.16.1:JwtIssuerConfig",
               "type": {
                 "name": "JwtIssuerConfig",
                 "links": [
@@ -2417,7 +2417,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:OAuth2ClientCredentialsGrantConfig",
+              "name": "ballerina/http:2.16.1:OAuth2ClientCredentialsGrantConfig",
               "type": {
                 "name": "OAuth2ClientCredentialsGrantConfig",
                 "links": [
@@ -2429,7 +2429,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:OAuth2PasswordGrantConfig",
+              "name": "ballerina/http:2.16.1:OAuth2PasswordGrantConfig",
               "type": {
                 "name": "OAuth2PasswordGrantConfig",
                 "links": [
@@ -2441,7 +2441,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:OAuth2RefreshTokenGrantConfig",
+              "name": "ballerina/http:2.16.1:OAuth2RefreshTokenGrantConfig",
               "type": {
                 "name": "OAuth2RefreshTokenGrantConfig",
                 "links": [
@@ -2453,7 +2453,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:OAuth2JwtBearerGrantConfig",
+              "name": "ballerina/http:2.16.1:OAuth2JwtBearerGrantConfig",
               "type": {
                 "name": "OAuth2JwtBearerGrantConfig",
                 "links": [
@@ -2934,7 +2934,7 @@
           "type": "Union",
           "members": [
             {
-              "name": "ballerina/http:2.16.0:FileUserStoreConfigWithScopes",
+              "name": "ballerina/http:2.16.1:FileUserStoreConfigWithScopes",
               "type": {
                 "name": "FileUserStoreConfigWithScopes",
                 "links": [
@@ -2946,7 +2946,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:LdapUserStoreConfigWithScopes",
+              "name": "ballerina/http:2.16.1:LdapUserStoreConfigWithScopes",
               "type": {
                 "name": "LdapUserStoreConfigWithScopes",
                 "links": [
@@ -2958,7 +2958,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:JwtValidatorConfigWithScopes",
+              "name": "ballerina/http:2.16.1:JwtValidatorConfigWithScopes",
               "type": {
                 "name": "JwtValidatorConfigWithScopes",
                 "links": [
@@ -2970,7 +2970,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:OAuth2IntrospectionConfigWithScopes",
+              "name": "ballerina/http:2.16.1:OAuth2IntrospectionConfigWithScopes",
               "type": {
                 "name": "OAuth2IntrospectionConfigWithScopes",
                 "links": [
@@ -3533,7 +3533,7 @@
               "name": "serviceType",
               "description": "The service object type which defines the service contract. This is auto-generated at compile-time",
               "type": {
-                "name": "typedesc<ballerina/http:2.16.0:ServiceContract>"
+                "name": "typedesc<ballerina/http:2.16.1:ServiceContract>"
               },
               "optional": true
             },
@@ -3838,7 +3838,7 @@
               "name": "respondType",
               "description": "Specifies the type of response",
               "type": {
-                "name": "typedesc<ballerina/http:2.16.0:ResponseMessage|ballerina/http:2.16.0:StatusCodeResponse|ballerina/http:2.16.0:Error>"
+                "name": "typedesc<ballerina/http:2.16.1:ResponseMessage|ballerina/http:2.16.1:StatusCodeResponse|ballerina/http:2.16.1:Error>"
               },
               "optional": true
             }
@@ -4337,7 +4337,7 @@
               "return": {
                 "description": "A SseEvent stream from which the `http:SseEvent` can be read or `http:ClientError` in case of errors",
                 "type": {
-                  "name": "stream<ballerina/http:2.16.0:SseEvent, error?>|ClientError",
+                  "name": "stream<ballerina/http:2.16.1:SseEvent, error?>|ClientError",
                   "links": [
                     {
                       "category": "internal",
@@ -4832,7 +4832,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Response",
+              "name": "ballerina/http:2.16.1:Response",
               "type": {
                 "name": "Response",
                 "links": [
@@ -4863,15 +4863,15 @@
               }
             },
             {
-              "name": "stream<ballerina/http:2.16.0:SseEvent, error?>",
+              "name": "stream<ballerina/http:2.16.1:SseEvent, error?>",
               "type": {
-                "name": "stream<ballerina/http:2.16.0:SseEvent, error?>"
+                "name": "stream<ballerina/http:2.16.1:SseEvent, error?>"
               }
             },
             {
-              "name": "stream<ballerina/http:2.16.0:SseEvent, error>",
+              "name": "stream<ballerina/http:2.16.1:SseEvent, error>",
               "type": {
-                "name": "stream<ballerina/http:2.16.0:SseEvent, error>"
+                "name": "stream<ballerina/http:2.16.1:SseEvent, error>"
               }
             }
           ]
@@ -8753,7 +8753,7 @@
           "type": "Union",
           "members": [
             {
-              "name": "ballerina/http:2.16.0:Continue",
+              "name": "ballerina/http:2.16.1:Continue",
               "type": {
                 "name": "Continue",
                 "links": [
@@ -8765,7 +8765,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:SwitchingProtocols",
+              "name": "ballerina/http:2.16.1:SwitchingProtocols",
               "type": {
                 "name": "SwitchingProtocols",
                 "links": [
@@ -8777,7 +8777,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Processing",
+              "name": "ballerina/http:2.16.1:Processing",
               "type": {
                 "name": "Processing",
                 "links": [
@@ -8789,7 +8789,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:EarlyHints",
+              "name": "ballerina/http:2.16.1:EarlyHints",
               "type": {
                 "name": "EarlyHints",
                 "links": [
@@ -8801,7 +8801,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Ok",
+              "name": "ballerina/http:2.16.1:Ok",
               "type": {
                 "name": "Ok",
                 "links": [
@@ -8813,7 +8813,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Created",
+              "name": "ballerina/http:2.16.1:Created",
               "type": {
                 "name": "Created",
                 "links": [
@@ -8825,7 +8825,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Accepted",
+              "name": "ballerina/http:2.16.1:Accepted",
               "type": {
                 "name": "Accepted",
                 "links": [
@@ -8837,7 +8837,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:NonAuthoritativeInformation",
+              "name": "ballerina/http:2.16.1:NonAuthoritativeInformation",
               "type": {
                 "name": "NonAuthoritativeInformation",
                 "links": [
@@ -8849,7 +8849,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:NoContent",
+              "name": "ballerina/http:2.16.1:NoContent",
               "type": {
                 "name": "NoContent",
                 "links": [
@@ -8861,7 +8861,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:ResetContent",
+              "name": "ballerina/http:2.16.1:ResetContent",
               "type": {
                 "name": "ResetContent",
                 "links": [
@@ -8873,7 +8873,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:PartialContent",
+              "name": "ballerina/http:2.16.1:PartialContent",
               "type": {
                 "name": "PartialContent",
                 "links": [
@@ -8885,7 +8885,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:MultiStatus",
+              "name": "ballerina/http:2.16.1:MultiStatus",
               "type": {
                 "name": "MultiStatus",
                 "links": [
@@ -8897,7 +8897,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:AlreadyReported",
+              "name": "ballerina/http:2.16.1:AlreadyReported",
               "type": {
                 "name": "AlreadyReported",
                 "links": [
@@ -8909,7 +8909,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:IMUsed",
+              "name": "ballerina/http:2.16.1:IMUsed",
               "type": {
                 "name": "IMUsed",
                 "links": [
@@ -8921,7 +8921,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:MultipleChoices",
+              "name": "ballerina/http:2.16.1:MultipleChoices",
               "type": {
                 "name": "MultipleChoices",
                 "links": [
@@ -8933,7 +8933,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:MovedPermanently",
+              "name": "ballerina/http:2.16.1:MovedPermanently",
               "type": {
                 "name": "MovedPermanently",
                 "links": [
@@ -8945,7 +8945,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Found",
+              "name": "ballerina/http:2.16.1:Found",
               "type": {
                 "name": "Found",
                 "links": [
@@ -8957,7 +8957,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:SeeOther",
+              "name": "ballerina/http:2.16.1:SeeOther",
               "type": {
                 "name": "SeeOther",
                 "links": [
@@ -8969,7 +8969,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:NotModified",
+              "name": "ballerina/http:2.16.1:NotModified",
               "type": {
                 "name": "NotModified",
                 "links": [
@@ -8981,7 +8981,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:UseProxy",
+              "name": "ballerina/http:2.16.1:UseProxy",
               "type": {
                 "name": "UseProxy",
                 "links": [
@@ -8993,7 +8993,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:TemporaryRedirect",
+              "name": "ballerina/http:2.16.1:TemporaryRedirect",
               "type": {
                 "name": "TemporaryRedirect",
                 "links": [
@@ -9005,7 +9005,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:PermanentRedirect",
+              "name": "ballerina/http:2.16.1:PermanentRedirect",
               "type": {
                 "name": "PermanentRedirect",
                 "links": [
@@ -9017,7 +9017,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:BadRequest",
+              "name": "ballerina/http:2.16.1:BadRequest",
               "type": {
                 "name": "BadRequest",
                 "links": [
@@ -9029,7 +9029,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Unauthorized",
+              "name": "ballerina/http:2.16.1:Unauthorized",
               "type": {
                 "name": "Unauthorized",
                 "links": [
@@ -9041,7 +9041,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:PaymentRequired",
+              "name": "ballerina/http:2.16.1:PaymentRequired",
               "type": {
                 "name": "PaymentRequired",
                 "links": [
@@ -9053,7 +9053,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Forbidden",
+              "name": "ballerina/http:2.16.1:Forbidden",
               "type": {
                 "name": "Forbidden",
                 "links": [
@@ -9065,7 +9065,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:NotFound",
+              "name": "ballerina/http:2.16.1:NotFound",
               "type": {
                 "name": "NotFound",
                 "links": [
@@ -9077,7 +9077,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:MethodNotAllowed",
+              "name": "ballerina/http:2.16.1:MethodNotAllowed",
               "type": {
                 "name": "MethodNotAllowed",
                 "links": [
@@ -9089,7 +9089,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:NotAcceptable",
+              "name": "ballerina/http:2.16.1:NotAcceptable",
               "type": {
                 "name": "NotAcceptable",
                 "links": [
@@ -9101,7 +9101,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:ProxyAuthenticationRequired",
+              "name": "ballerina/http:2.16.1:ProxyAuthenticationRequired",
               "type": {
                 "name": "ProxyAuthenticationRequired",
                 "links": [
@@ -9113,7 +9113,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:RequestTimeout",
+              "name": "ballerina/http:2.16.1:RequestTimeout",
               "type": {
                 "name": "RequestTimeout",
                 "links": [
@@ -9125,7 +9125,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Conflict",
+              "name": "ballerina/http:2.16.1:Conflict",
               "type": {
                 "name": "Conflict",
                 "links": [
@@ -9137,7 +9137,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Gone",
+              "name": "ballerina/http:2.16.1:Gone",
               "type": {
                 "name": "Gone",
                 "links": [
@@ -9149,7 +9149,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:LengthRequired",
+              "name": "ballerina/http:2.16.1:LengthRequired",
               "type": {
                 "name": "LengthRequired",
                 "links": [
@@ -9161,7 +9161,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:PreconditionFailed",
+              "name": "ballerina/http:2.16.1:PreconditionFailed",
               "type": {
                 "name": "PreconditionFailed",
                 "links": [
@@ -9173,7 +9173,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:PayloadTooLarge",
+              "name": "ballerina/http:2.16.1:PayloadTooLarge",
               "type": {
                 "name": "PayloadTooLarge",
                 "links": [
@@ -9185,7 +9185,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:UriTooLong",
+              "name": "ballerina/http:2.16.1:UriTooLong",
               "type": {
                 "name": "UriTooLong",
                 "links": [
@@ -9197,7 +9197,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:UnsupportedMediaType",
+              "name": "ballerina/http:2.16.1:UnsupportedMediaType",
               "type": {
                 "name": "UnsupportedMediaType",
                 "links": [
@@ -9209,7 +9209,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:RangeNotSatisfiable",
+              "name": "ballerina/http:2.16.1:RangeNotSatisfiable",
               "type": {
                 "name": "RangeNotSatisfiable",
                 "links": [
@@ -9221,7 +9221,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:ExpectationFailed",
+              "name": "ballerina/http:2.16.1:ExpectationFailed",
               "type": {
                 "name": "ExpectationFailed",
                 "links": [
@@ -9233,7 +9233,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:MisdirectedRequest",
+              "name": "ballerina/http:2.16.1:MisdirectedRequest",
               "type": {
                 "name": "MisdirectedRequest",
                 "links": [
@@ -9245,7 +9245,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:UnprocessableEntity",
+              "name": "ballerina/http:2.16.1:UnprocessableEntity",
               "type": {
                 "name": "UnprocessableEntity",
                 "links": [
@@ -9257,7 +9257,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Locked",
+              "name": "ballerina/http:2.16.1:Locked",
               "type": {
                 "name": "Locked",
                 "links": [
@@ -9269,7 +9269,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:FailedDependency",
+              "name": "ballerina/http:2.16.1:FailedDependency",
               "type": {
                 "name": "FailedDependency",
                 "links": [
@@ -9281,7 +9281,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:TooEarly",
+              "name": "ballerina/http:2.16.1:TooEarly",
               "type": {
                 "name": "TooEarly",
                 "links": [
@@ -9293,7 +9293,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:PreconditionRequired",
+              "name": "ballerina/http:2.16.1:PreconditionRequired",
               "type": {
                 "name": "PreconditionRequired",
                 "links": [
@@ -9305,7 +9305,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:UnavailableDueToLegalReasons",
+              "name": "ballerina/http:2.16.1:UnavailableDueToLegalReasons",
               "type": {
                 "name": "UnavailableDueToLegalReasons",
                 "links": [
@@ -9317,7 +9317,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:UpgradeRequired",
+              "name": "ballerina/http:2.16.1:UpgradeRequired",
               "type": {
                 "name": "UpgradeRequired",
                 "links": [
@@ -9329,7 +9329,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:TooManyRequests",
+              "name": "ballerina/http:2.16.1:TooManyRequests",
               "type": {
                 "name": "TooManyRequests",
                 "links": [
@@ -9341,7 +9341,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:RequestHeaderFieldsTooLarge",
+              "name": "ballerina/http:2.16.1:RequestHeaderFieldsTooLarge",
               "type": {
                 "name": "RequestHeaderFieldsTooLarge",
                 "links": [
@@ -9353,7 +9353,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:InternalServerError",
+              "name": "ballerina/http:2.16.1:InternalServerError",
               "type": {
                 "name": "InternalServerError",
                 "links": [
@@ -9365,7 +9365,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:NotImplemented",
+              "name": "ballerina/http:2.16.1:NotImplemented",
               "type": {
                 "name": "NotImplemented",
                 "links": [
@@ -9377,7 +9377,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:BadGateway",
+              "name": "ballerina/http:2.16.1:BadGateway",
               "type": {
                 "name": "BadGateway",
                 "links": [
@@ -9389,7 +9389,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:ServiceUnavailable",
+              "name": "ballerina/http:2.16.1:ServiceUnavailable",
               "type": {
                 "name": "ServiceUnavailable",
                 "links": [
@@ -9401,7 +9401,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:GatewayTimeout",
+              "name": "ballerina/http:2.16.1:GatewayTimeout",
               "type": {
                 "name": "GatewayTimeout",
                 "links": [
@@ -9413,7 +9413,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:HttpVersionNotSupported",
+              "name": "ballerina/http:2.16.1:HttpVersionNotSupported",
               "type": {
                 "name": "HttpVersionNotSupported",
                 "links": [
@@ -9425,7 +9425,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:VariantAlsoNegotiates",
+              "name": "ballerina/http:2.16.1:VariantAlsoNegotiates",
               "type": {
                 "name": "VariantAlsoNegotiates",
                 "links": [
@@ -9437,7 +9437,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:InsufficientStorage",
+              "name": "ballerina/http:2.16.1:InsufficientStorage",
               "type": {
                 "name": "InsufficientStorage",
                 "links": [
@@ -9449,7 +9449,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:LoopDetected",
+              "name": "ballerina/http:2.16.1:LoopDetected",
               "type": {
                 "name": "LoopDetected",
                 "links": [
@@ -9461,7 +9461,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:NotExtended",
+              "name": "ballerina/http:2.16.1:NotExtended",
               "type": {
                 "name": "NotExtended",
                 "links": [
@@ -9473,7 +9473,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:NetworkAuthenticationRequired",
+              "name": "ballerina/http:2.16.1:NetworkAuthenticationRequired",
               "type": {
                 "name": "NetworkAuthenticationRequired",
                 "links": [
@@ -9485,7 +9485,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:DefaultStatusCodeResponse",
+              "name": "ballerina/http:2.16.1:DefaultStatusCodeResponse",
               "type": {
                 "name": "DefaultStatusCodeResponse",
                 "links": [
@@ -9716,7 +9716,7 @@
               "name": "protocol",
               "description": "SSL/TLS protocol related options",
               "type": {
-                "name": "record {|ballerina/http:2.16.0:Protocol name; string[] versions;|}"
+                "name": "record {|ballerina/http:2.16.1:Protocol name; string[] versions;|}"
               },
               "optional": true
             },
@@ -9724,7 +9724,7 @@
               "name": "certValidation",
               "description": "Certificate validation against OCSP_CRL, OCSP_STAPLING related options",
               "type": {
-                "name": "record {|ballerina/http:2.16.0:CertValidationType 'type; int cacheSize; int cacheValidityPeriod;|}"
+                "name": "record {|ballerina/http:2.16.1:CertValidationType 'type; int cacheSize; int cacheValidityPeriod;|}"
               },
               "optional": true
             },
@@ -11012,7 +11012,7 @@
           "type": "Union",
           "members": [
             {
-              "name": "ballerina/http:2.16.0:SimpleQueryParamType[]",
+              "name": "ballerina/http:2.16.1:SimpleQueryParamType[]",
               "type": {
                 "name": "SimpleQueryParamType[]",
                 "links": [
@@ -11620,7 +11620,7 @@
           "type": "Union",
           "members": [
             {
-              "name": "ballerina/http:2.16.0:MediaTypeBindingStatusCodeClientError",
+              "name": "ballerina/http:2.16.1:MediaTypeBindingStatusCodeClientError",
               "type": {
                 "name": "MediaTypeBindingStatusCodeClientError",
                 "links": [
@@ -11632,7 +11632,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:PayloadBindingStatusCodeClientError",
+              "name": "ballerina/http:2.16.1:PayloadBindingStatusCodeClientError",
               "type": {
                 "name": "PayloadBindingStatusCodeClientError",
                 "links": [
@@ -11644,7 +11644,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:HeaderBindingStatusCodeClientError",
+              "name": "ballerina/http:2.16.1:HeaderBindingStatusCodeClientError",
               "type": {
                 "name": "HeaderBindingStatusCodeClientError",
                 "links": [
@@ -11688,7 +11688,7 @@
           "type": "Union",
           "members": [
             {
-              "name": "ballerina/http:2.16.0:RequestInterceptor",
+              "name": "ballerina/http:2.16.1:RequestInterceptor",
               "type": {
                 "name": "RequestInterceptor",
                 "links": [
@@ -11700,7 +11700,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:ResponseInterceptor",
+              "name": "ballerina/http:2.16.1:ResponseInterceptor",
               "type": {
                 "name": "ResponseInterceptor",
                 "links": [
@@ -11712,7 +11712,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Service",
+              "name": "ballerina/http:2.16.1:Service",
               "type": {
                 "name": "Service",
                 "links": [
@@ -11731,7 +11731,7 @@
           "type": "Union",
           "members": [
             {
-              "name": "ballerina/http:2.16.0:RequestInterceptor",
+              "name": "ballerina/http:2.16.1:RequestInterceptor",
               "type": {
                 "name": "RequestInterceptor",
                 "links": [
@@ -11743,7 +11743,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:ResponseInterceptor",
+              "name": "ballerina/http:2.16.1:ResponseInterceptor",
               "type": {
                 "name": "ResponseInterceptor",
                 "links": [
@@ -11755,7 +11755,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:RequestErrorInterceptor",
+              "name": "ballerina/http:2.16.1:RequestErrorInterceptor",
               "type": {
                 "name": "RequestErrorInterceptor",
                 "links": [
@@ -11767,7 +11767,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:ResponseErrorInterceptor",
+              "name": "ballerina/http:2.16.1:ResponseErrorInterceptor",
               "type": {
                 "name": "ResponseErrorInterceptor",
                 "links": [
@@ -11987,7 +11987,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Cloneable[]",
+              "name": "ballerina/http:2.16.1:Cloneable[]",
               "type": {
                 "name": "Cloneable[]",
                 "links": [
@@ -11999,15 +11999,15 @@
               }
             },
             {
-              "name": "map<ballerina/http:2.16.0:Cloneable>",
+              "name": "map<ballerina/http:2.16.1:Cloneable>",
               "type": {
-                "name": "map<ballerina/http:2.16.0:Cloneable>"
+                "name": "map<ballerina/http:2.16.1:Cloneable>"
               }
             },
             {
-              "name": "table<map<ballerina/http:2.16.0:Cloneable>>",
+              "name": "table<map<ballerina/http:2.16.1:Cloneable>>",
               "type": {
-                "name": "table<map<ballerina/http:2.16.0:Cloneable>>"
+                "name": "table<map<ballerina/http:2.16.1:Cloneable>>"
               }
             }
           ]
@@ -12030,7 +12030,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Cloneable[]",
+              "name": "ballerina/http:2.16.1:Cloneable[]",
               "type": {
                 "name": "Cloneable[]",
                 "links": [
@@ -12042,15 +12042,15 @@
               }
             },
             {
-              "name": "map<ballerina/http:2.16.0:Cloneable>",
+              "name": "map<ballerina/http:2.16.1:Cloneable>",
               "type": {
-                "name": "map<ballerina/http:2.16.0:Cloneable>"
+                "name": "map<ballerina/http:2.16.1:Cloneable>"
               }
             },
             {
-              "name": "table<map<ballerina/http:2.16.0:Cloneable>>",
+              "name": "table<map<ballerina/http:2.16.1:Cloneable>>",
               "type": {
-                "name": "table<map<ballerina/http:2.16.0:Cloneable>>"
+                "name": "table<map<ballerina/http:2.16.1:Cloneable>>"
               }
             },
             {
@@ -12341,7 +12341,7 @@
               "name": "mutualSsl",
               "description": "Configures associated with mutual SSL operations",
               "type": {
-                "name": "record {|ballerina/http:2.16.0:VerifyClient verifyClient; ballerina/crypto:2.9.3:TrustStore|string cert;|}"
+                "name": "record {|ballerina/http:2.16.1:VerifyClient verifyClient; ballerina/crypto:2.9.3:TrustStore|string cert;|}"
               },
               "optional": true
             },
@@ -12349,7 +12349,7 @@
               "name": "protocol",
               "description": "SSL/TLS protocol related options",
               "type": {
-                "name": "record {|ballerina/http:2.16.0:Protocol name; string[] versions;|}"
+                "name": "record {|ballerina/http:2.16.1:Protocol name; string[] versions;|}"
               },
               "optional": true
             },
@@ -12357,7 +12357,7 @@
               "name": "certValidation",
               "description": "Certificate validation against OCSP_CRL, OCSP_STAPLING related options",
               "type": {
-                "name": "record {|ballerina/http:2.16.0:CertValidationType 'type; int cacheSize; int cacheValidityPeriod;|}"
+                "name": "record {|ballerina/http:2.16.1:CertValidationType 'type; int cacheSize; int cacheValidityPeriod;|}"
               },
               "optional": true
             },
@@ -13488,7 +13488,7 @@
               }
             },
             {
-              "name": "ballerina/http:2.16.0:Request",
+              "name": "ballerina/http:2.16.1:Request",
               "type": {
                 "name": "Request",
                 "links": [
@@ -13662,7 +13662,7 @@
               "name": "_links",
               "description": "Map of available links",
               "type": {
-                "name": "map<ballerina/http:2.16.0:Link>"
+                "name": "map<ballerina/http:2.16.1:Link>"
               }
             }
           ]
@@ -15863,7 +15863,7 @@
               "return": {
                 "description": "A `ListenerError` if an error occurred during the listener initialization",
                 "type": {
-                  "name": "ballerina/http:2.16.0:ListenerError?"
+                  "name": "ballerina/http:2.16.1:ListenerError?"
                 }
               }
             },
@@ -16683,7 +16683,7 @@
               "return": {
                 "description": "The `client` or an `http:ClientError` if the initialization failed",
                 "type": {
-                  "name": "ballerina/http:2.16.0:ClientError?"
+                  "name": "ballerina/http:2.16.1:ClientError?"
                 }
               }
             },
@@ -18668,7 +18668,7 @@
               "return": {
                 "description": "The `client` or an `http:ClientError` if the initialization failed",
                 "type": {
-                  "name": "ballerina/http:2.16.0:ClientError?"
+                  "name": "ballerina/http:2.16.1:ClientError?"
                 }
               }
             },
@@ -20507,7 +20507,7 @@
               "return": {
                 "description": "The `client` or an `http:ClientError` if the initialization failed",
                 "type": {
-                  "name": "ballerina/http:2.16.0:ClientError?"
+                  "name": "ballerina/http:2.16.1:ClientError?"
                 }
               }
             },
@@ -22222,7 +22222,7 @@
               "return": {
                 "description": "The `client` or an `http:ClientError` if the initialization failed",
                 "type": {
-                  "name": "ballerina/http:2.16.0:ClientError?"
+                  "name": "ballerina/http:2.16.1:ClientError?"
                 }
               }
             },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/agent_with_backticks_in_system_prompt.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/agent_with_backticks_in_system_prompt.json
@@ -1309,7 +1309,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1349,7 +1349,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1445,7 +1445,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1485,7 +1485,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1569,7 +1569,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1609,7 +1609,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1649,7 +1649,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1689,7 +1689,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1729,7 +1729,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/chat_agent.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/chat_agent.json
@@ -1309,7 +1309,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1349,7 +1349,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1445,7 +1445,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1485,7 +1485,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1569,7 +1569,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1609,7 +1609,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1649,7 +1649,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1689,7 +1689,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1729,7 +1729,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -55,7 +55,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -339,7 +339,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -402,7 +402,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -518,7 +518,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -527,7 +527,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -970,7 +970,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1033,7 +1033,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
@@ -856,7 +856,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -865,7 +865,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.16.0",
+                          "version": "2.16.1",
                           "lineRange": {
                             "fileName": "main.bal",
                             "startLine": {
@@ -2222,7 +2222,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -2326,7 +2326,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2363,7 +2363,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2456,7 +2456,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2493,7 +2493,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2530,7 +2530,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2608,49 +2608,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2687,7 +2687,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2724,7 +2724,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2761,7 +2761,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2798,7 +2798,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2835,7 +2835,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2900,7 +2900,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2965,7 +2965,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter2.json
@@ -95,7 +95,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -199,7 +199,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -236,7 +236,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -329,7 +329,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -366,7 +366,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -403,7 +403,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -481,49 +481,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -560,7 +560,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -597,7 +597,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -634,7 +634,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -671,7 +671,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -708,7 +708,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -773,7 +773,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -838,7 +838,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
@@ -1014,7 +1014,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1118,7 +1118,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1155,7 +1155,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1248,7 +1248,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1285,7 +1285,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1322,7 +1322,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1400,49 +1400,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1479,7 +1479,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1516,7 +1516,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1553,7 +1553,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1590,7 +1590,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1627,7 +1627,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1692,7 +1692,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1757,7 +1757,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
@@ -181,7 +181,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -190,7 +190,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -571,7 +571,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -675,7 +675,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -712,7 +712,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -805,7 +805,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -842,7 +842,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -879,7 +879,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -957,49 +957,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1036,7 +1036,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1073,7 +1073,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1110,7 +1110,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1147,7 +1147,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1184,7 +1184,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1249,7 +1249,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1314,7 +1314,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
@@ -181,7 +181,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -190,7 +190,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -607,7 +607,7 @@
                         "metadata": {
                           "label": "post",
                           "description": "Create a new resource or submit data to a resource for processing.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -616,7 +616,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "post",
-                          "version": "2.16.0",
+                          "version": "2.16.1",
                           "lineRange": {
                             "fileName": "error_handler.bal",
                             "startLine": {
@@ -1071,7 +1071,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1175,7 +1175,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1212,7 +1212,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1305,7 +1305,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1342,7 +1342,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1379,7 +1379,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1457,49 +1457,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1536,7 +1536,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1573,7 +1573,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1610,7 +1610,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1647,7 +1647,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1684,7 +1684,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1749,7 +1749,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1814,7 +1814,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
@@ -90,7 +90,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -99,7 +99,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -501,7 +501,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -605,7 +605,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -642,7 +642,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -735,7 +735,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -772,7 +772,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -809,7 +809,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -887,49 +887,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -966,7 +966,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1003,7 +1003,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1040,7 +1040,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1114,7 +1114,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1179,7 +1179,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1244,7 +1244,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -399,7 +399,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -503,7 +503,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -540,7 +540,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -633,7 +633,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -670,7 +670,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -707,7 +707,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -785,49 +785,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -864,7 +864,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -901,7 +901,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -938,7 +938,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -975,7 +975,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1012,7 +1012,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1142,7 +1142,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -399,7 +399,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -503,7 +503,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -540,7 +540,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -633,7 +633,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -670,7 +670,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -707,7 +707,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -785,49 +785,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -864,7 +864,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -901,7 +901,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -938,7 +938,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -975,7 +975,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1012,7 +1012,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1142,7 +1142,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
@@ -467,7 +467,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -476,7 +476,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
@@ -1119,7 +1119,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1223,7 +1223,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1260,7 +1260,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1353,7 +1353,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1390,7 +1390,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1427,7 +1427,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1505,49 +1505,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1584,7 +1584,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1621,7 +1621,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1658,7 +1658,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1695,7 +1695,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1732,7 +1732,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1797,7 +1797,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1862,7 +1862,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
@@ -1293,7 +1293,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1397,7 +1397,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1434,7 +1434,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1527,7 +1527,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1564,7 +1564,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1601,7 +1601,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1679,49 +1679,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1758,7 +1758,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1795,7 +1795,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1832,7 +1832,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1869,7 +1869,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1906,7 +1906,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1971,7 +1971,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2036,7 +2036,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
@@ -418,7 +418,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -522,7 +522,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -559,7 +559,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -652,7 +652,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -689,7 +689,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -726,7 +726,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -804,49 +804,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -883,7 +883,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -920,7 +920,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -957,7 +957,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -994,7 +994,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1031,7 +1031,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1096,7 +1096,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1161,7 +1161,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
@@ -401,7 +401,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -505,7 +505,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -542,7 +542,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -635,7 +635,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -672,7 +672,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -709,7 +709,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -787,49 +787,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -866,7 +866,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -903,7 +903,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -940,7 +940,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -977,7 +977,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1014,7 +1014,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1079,7 +1079,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1144,7 +1144,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
@@ -525,7 +525,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -629,7 +629,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -666,7 +666,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -759,7 +759,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -796,7 +796,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -833,7 +833,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -911,49 +911,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -990,7 +990,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1027,7 +1027,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1064,7 +1064,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1101,7 +1101,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1138,7 +1138,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1203,7 +1203,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1268,7 +1268,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -689,7 +689,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -793,7 +793,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -830,7 +830,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -923,7 +923,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -960,7 +960,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -997,7 +997,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1075,49 +1075,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1154,7 +1154,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1191,7 +1191,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1228,7 +1228,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1265,7 +1265,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1302,7 +1302,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1367,7 +1367,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1432,7 +1432,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
@@ -579,7 +579,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -683,7 +683,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -720,7 +720,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -813,7 +813,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -850,7 +850,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -887,7 +887,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -965,49 +965,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1044,7 +1044,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1081,7 +1081,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1118,7 +1118,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1155,7 +1155,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1192,7 +1192,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1257,7 +1257,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1322,7 +1322,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
@@ -315,7 +315,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -419,7 +419,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -456,7 +456,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -549,7 +549,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -586,7 +586,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -623,7 +623,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -701,49 +701,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -780,7 +780,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -817,7 +817,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -854,7 +854,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -891,7 +891,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -928,7 +928,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -993,7 +993,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1058,7 +1058,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
@@ -293,7 +293,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -397,7 +397,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -434,7 +434,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -527,7 +527,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -564,7 +564,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -601,7 +601,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -679,49 +679,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -758,7 +758,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -795,7 +795,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -832,7 +832,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -869,7 +869,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -906,7 +906,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -971,7 +971,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1036,7 +1036,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
@@ -449,7 +449,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -553,7 +553,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -590,7 +590,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -683,7 +683,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -720,7 +720,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -757,7 +757,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -835,49 +835,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -914,7 +914,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -951,7 +951,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -988,7 +988,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1025,7 +1025,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1062,7 +1062,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1127,7 +1127,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1192,7 +1192,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
@@ -535,7 +535,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -639,7 +639,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -676,7 +676,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -769,7 +769,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -806,7 +806,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -843,7 +843,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -921,49 +921,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1000,7 +1000,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1037,7 +1037,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1074,7 +1074,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1111,7 +1111,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1148,7 +1148,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1213,7 +1213,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1278,7 +1278,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
@@ -363,7 +363,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -467,7 +467,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -504,7 +504,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -597,7 +597,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -634,7 +634,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -671,7 +671,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -749,49 +749,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -828,7 +828,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -865,7 +865,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -902,7 +902,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -939,7 +939,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -976,7 +976,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1041,7 +1041,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1106,7 +1106,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
@@ -418,7 +418,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -522,7 +522,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -559,7 +559,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -652,7 +652,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -689,7 +689,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -726,7 +726,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -804,49 +804,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -883,7 +883,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -920,7 +920,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -957,7 +957,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -994,7 +994,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1031,7 +1031,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1096,7 +1096,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1161,7 +1161,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
@@ -92,7 +92,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -196,7 +196,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -233,7 +233,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -326,7 +326,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -363,7 +363,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -400,7 +400,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -478,49 +478,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -557,7 +557,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -594,7 +594,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -631,7 +631,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -668,7 +668,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -705,7 +705,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -770,7 +770,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -835,7 +835,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
@@ -157,7 +157,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -166,7 +166,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.16.0",
+                          "version": "2.16.1",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -420,7 +420,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -429,7 +429,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.16.0",
+                          "version": "2.16.1",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -748,7 +748,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -852,7 +852,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -889,7 +889,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -982,7 +982,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1056,7 +1056,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1134,49 +1134,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1213,7 +1213,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1250,7 +1250,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1287,7 +1287,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1324,7 +1324,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1361,7 +1361,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1426,7 +1426,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1491,7 +1491,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
@@ -91,7 +91,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -195,7 +195,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -232,7 +232,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -325,7 +325,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -362,7 +362,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -399,7 +399,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -477,49 +477,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -556,7 +556,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -593,7 +593,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -630,7 +630,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -667,7 +667,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -704,7 +704,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -769,7 +769,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -834,7 +834,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
@@ -92,7 +92,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -196,7 +196,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -233,7 +233,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -326,7 +326,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -363,7 +363,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -400,7 +400,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -478,49 +478,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -557,7 +557,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -594,7 +594,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -631,7 +631,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -668,7 +668,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -705,7 +705,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -770,7 +770,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -835,7 +835,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
@@ -92,7 +92,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -196,7 +196,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -233,7 +233,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -326,7 +326,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -363,7 +363,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -400,7 +400,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -478,49 +478,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -557,7 +557,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -594,7 +594,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -631,7 +631,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -668,7 +668,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -705,7 +705,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -770,7 +770,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -835,7 +835,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node6.json
@@ -404,7 +404,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -508,7 +508,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -545,7 +545,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -638,7 +638,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -675,7 +675,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -712,7 +712,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -790,49 +790,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -869,7 +869,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -906,7 +906,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -943,7 +943,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -980,7 +980,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1017,7 +1017,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1082,7 +1082,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1147,7 +1147,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -150,7 +150,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -187,7 +187,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -280,7 +280,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -317,7 +317,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -354,7 +354,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -432,49 +432,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -511,7 +511,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -548,7 +548,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -585,7 +585,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -622,7 +622,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -659,7 +659,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -724,7 +724,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -789,7 +789,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1156,7 +1156,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1219,7 +1219,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1335,7 +1335,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1398,7 +1398,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1514,7 +1514,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1618,7 +1618,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1655,7 +1655,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1748,7 +1748,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1785,7 +1785,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1822,7 +1822,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1900,49 +1900,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1979,7 +1979,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2016,7 +2016,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2053,7 +2053,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2090,7 +2090,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2127,7 +2127,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2192,7 +2192,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2257,7 +2257,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -150,7 +150,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -187,7 +187,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -280,7 +280,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -317,7 +317,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -354,7 +354,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -432,49 +432,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -511,7 +511,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -548,7 +548,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -585,7 +585,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -622,7 +622,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -659,7 +659,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -724,7 +724,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -789,7 +789,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1156,7 +1156,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1219,7 +1219,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1335,7 +1335,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1398,7 +1398,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1514,7 +1514,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1618,7 +1618,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1655,7 +1655,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1748,7 +1748,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1785,7 +1785,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1822,7 +1822,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1900,49 +1900,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1979,7 +1979,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2016,7 +2016,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2053,7 +2053,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2090,7 +2090,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2127,7 +2127,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2192,7 +2192,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2257,7 +2257,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
@@ -48,7 +48,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -111,7 +111,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -227,7 +227,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -290,7 +290,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -406,7 +406,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -510,7 +510,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -547,7 +547,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -640,7 +640,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -677,7 +677,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -714,7 +714,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -792,49 +792,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -871,7 +871,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -908,7 +908,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -945,7 +945,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -982,7 +982,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1084,7 +1084,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1149,7 +1149,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1763,7 +1763,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1867,7 +1867,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1904,7 +1904,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1997,7 +1997,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2034,7 +2034,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2071,7 +2071,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2149,49 +2149,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2228,7 +2228,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2265,7 +2265,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2302,7 +2302,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2339,7 +2339,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2376,7 +2376,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2441,7 +2441,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2506,7 +2506,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection4.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -150,7 +150,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -187,7 +187,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -280,7 +280,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -317,7 +317,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -354,7 +354,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -432,49 +432,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -511,7 +511,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -548,7 +548,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -585,7 +585,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -622,7 +622,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -659,7 +659,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -724,7 +724,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -789,7 +789,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -905,7 +905,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -968,7 +968,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1084,7 +1084,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1147,49 +1147,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1268,7 +1268,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1305,7 +1305,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1398,7 +1398,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1435,7 +1435,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1472,7 +1472,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1550,7 +1550,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1587,7 +1587,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1624,7 +1624,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1661,7 +1661,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1698,7 +1698,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1763,7 +1763,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1828,7 +1828,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get1.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -55,7 +55,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -270,7 +270,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -279,7 +279,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -496,7 +496,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -600,7 +600,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -637,7 +637,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -730,7 +730,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -767,7 +767,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -804,7 +804,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -882,49 +882,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -961,7 +961,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -998,7 +998,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1035,7 +1035,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1072,7 +1072,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1109,7 +1109,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1174,7 +1174,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1239,7 +1239,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -56,7 +56,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -288,7 +288,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -297,7 +297,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -480,7 +480,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -489,7 +489,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -718,7 +718,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -822,7 +822,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -859,7 +859,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -952,7 +952,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -989,7 +989,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1026,7 +1026,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1104,49 +1104,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1183,7 +1183,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1220,7 +1220,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1257,7 +1257,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1294,7 +1294,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1331,7 +1331,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1396,7 +1396,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1461,7 +1461,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -151,7 +151,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -188,7 +188,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -281,7 +281,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -318,7 +318,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -355,7 +355,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -433,49 +433,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -512,7 +512,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -549,7 +549,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -586,7 +586,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -623,7 +623,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -660,7 +660,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -725,7 +725,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -790,7 +790,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -951,7 +951,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1055,7 +1055,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1092,7 +1092,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1185,7 +1185,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1222,7 +1222,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1259,7 +1259,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1337,49 +1337,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1416,7 +1416,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1453,7 +1453,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1490,7 +1490,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1527,7 +1527,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1564,7 +1564,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1629,7 +1629,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1694,7 +1694,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post1.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "post",
           "description": "Create a new resource or submit data to a resource for processing.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -55,7 +55,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -339,7 +339,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -348,7 +348,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -711,7 +711,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -815,7 +815,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -852,7 +852,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -945,7 +945,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -982,7 +982,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1097,49 +1097,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1176,7 +1176,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1213,7 +1213,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1250,7 +1250,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1287,7 +1287,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1324,7 +1324,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1389,7 +1389,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1454,7 +1454,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "post",
           "description": "Create a new resource or submit data to a resource for processing.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -56,7 +56,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -357,7 +357,7 @@
         "metadata": {
           "label": "post",
           "description": "Create a new resource or submit data to a resource for processing.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -366,7 +366,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -663,7 +663,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -767,7 +767,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -804,7 +804,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -897,7 +897,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -934,7 +934,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -971,7 +971,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1049,49 +1049,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1128,7 +1128,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1165,7 +1165,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1202,7 +1202,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1239,7 +1239,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1276,7 +1276,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1341,7 +1341,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1406,7 +1406,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -151,7 +151,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -188,7 +188,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -281,7 +281,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -318,7 +318,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -355,7 +355,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -433,49 +433,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -512,7 +512,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -549,7 +549,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -586,7 +586,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -623,7 +623,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -660,7 +660,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -725,7 +725,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -790,7 +790,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -951,7 +951,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1055,7 +1055,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1092,7 +1092,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1185,7 +1185,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1222,7 +1222,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1259,7 +1259,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1337,49 +1337,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1416,7 +1416,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1453,7 +1453,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1490,7 +1490,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1527,7 +1527,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1564,7 +1564,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1629,7 +1629,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1694,7 +1694,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -56,7 +56,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -365,7 +365,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -374,7 +374,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -808,7 +808,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -817,7 +817,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1126,7 +1126,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1135,7 +1135,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1507,7 +1507,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1516,7 +1516,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1825,7 +1825,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1834,7 +1834,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -2144,7 +2144,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2153,7 +2153,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -2462,7 +2462,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2471,7 +2471,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -2780,7 +2780,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2789,7 +2789,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -3099,7 +3099,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -3203,7 +3203,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3240,7 +3240,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3333,7 +3333,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3370,7 +3370,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3407,7 +3407,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3485,49 +3485,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3564,7 +3564,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3601,7 +3601,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3638,7 +3638,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3675,7 +3675,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3712,7 +3712,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3777,7 +3777,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3842,7 +3842,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -56,7 +56,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -434,7 +434,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -443,7 +443,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -822,7 +822,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -831,7 +831,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -1209,7 +1209,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1218,7 +1218,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -1659,7 +1659,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1668,7 +1668,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -2047,7 +2047,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2056,7 +2056,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -2434,7 +2434,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2443,7 +2443,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.0",
+          "version": "2.16.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -2823,7 +2823,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -2927,7 +2927,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2964,7 +2964,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3057,7 +3057,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3094,7 +3094,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3131,7 +3131,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3209,49 +3209,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3288,7 +3288,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3325,7 +3325,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3362,7 +3362,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3399,7 +3399,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3436,7 +3436,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3501,7 +3501,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3566,7 +3566,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
@@ -111,7 +111,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -120,7 +120,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "simple_flow.bal",
                     "startLine": {
@@ -417,7 +417,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -426,7 +426,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "simple_flow.bal",
                     "startLine": {
@@ -708,7 +708,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -812,7 +812,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -849,7 +849,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -942,7 +942,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -979,7 +979,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1016,7 +1016,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1094,49 +1094,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1173,7 +1173,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1210,7 +1210,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1247,7 +1247,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1284,7 +1284,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1321,7 +1321,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1386,7 +1386,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1451,7 +1451,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1567,7 +1567,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1671,7 +1671,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1708,7 +1708,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1801,7 +1801,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1838,7 +1838,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1875,7 +1875,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1953,49 +1953,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2032,7 +2032,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2069,7 +2069,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2106,7 +2106,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2143,7 +2143,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2180,7 +2180,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2245,7 +2245,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2310,7 +2310,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -799,7 +799,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -903,7 +903,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -940,7 +940,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1033,7 +1033,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1070,7 +1070,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1107,7 +1107,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1185,49 +1185,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1264,7 +1264,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1301,7 +1301,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1338,7 +1338,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1375,7 +1375,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1412,7 +1412,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1477,7 +1477,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1542,7 +1542,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
@@ -116,7 +116,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -220,7 +220,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -257,7 +257,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -350,7 +350,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -387,7 +387,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -424,7 +424,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -502,49 +502,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -581,7 +581,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -618,7 +618,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -655,7 +655,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -692,7 +692,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -729,7 +729,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -794,7 +794,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -859,7 +859,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -730,7 +730,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -834,7 +834,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -871,7 +871,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -964,7 +964,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1001,7 +1001,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1038,7 +1038,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1116,49 +1116,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1195,7 +1195,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1232,7 +1232,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1269,7 +1269,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1306,7 +1306,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1343,7 +1343,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1408,7 +1408,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1473,7 +1473,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -785,7 +785,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -889,7 +889,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -926,7 +926,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1056,7 +1056,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1093,7 +1093,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1171,49 +1171,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1250,7 +1250,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1287,7 +1287,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1324,7 +1324,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1361,7 +1361,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1398,7 +1398,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1463,7 +1463,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1528,7 +1528,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
@@ -278,7 +278,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -287,7 +287,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -774,7 +774,7 @@
                 "metadata": {
                   "label": "HTTP",
                   "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "NEW_CONNECTION",
@@ -878,7 +878,7 @@
                         "typeMembers": [
                           {
                             "type": "ClientHttp1Settings",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -915,7 +915,7 @@
                         "typeMembers": [
                           {
                             "type": "ClientHttp2Settings",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1008,7 +1008,7 @@
                         "typeMembers": [
                           {
                             "type": "FollowRedirects",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1045,7 +1045,7 @@
                         "typeMembers": [
                           {
                             "type": "PoolConfiguration",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1082,7 +1082,7 @@
                         "typeMembers": [
                           {
                             "type": "CacheConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1160,49 +1160,49 @@
                         "typeMembers": [
                           {
                             "type": "CredentialsConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "BearerTokenConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "JwtIssuerConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "OAuth2ClientCredentialsGrantConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "OAuth2PasswordGrantConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "OAuth2RefreshTokenGrantConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "OAuth2JwtBearerGrantConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1239,7 +1239,7 @@
                         "typeMembers": [
                           {
                             "type": "CircuitBreakerConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1276,7 +1276,7 @@
                         "typeMembers": [
                           {
                             "type": "RetryConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1313,7 +1313,7 @@
                         "typeMembers": [
                           {
                             "type": "CookieConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1350,7 +1350,7 @@
                         "typeMembers": [
                           {
                             "type": "ResponseLimitConfigs",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1387,7 +1387,7 @@
                         "typeMembers": [
                           {
                             "type": "ProxyConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1452,7 +1452,7 @@
                         "typeMembers": [
                           {
                             "type": "ClientSocketConfig",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1517,7 +1517,7 @@
                         "typeMembers": [
                           {
                             "type": "ClientSecureSocket",
-                            "packageInfo": "ballerina:http:2.16.0",
+                            "packageInfo": "ballerina:http:2.16.1",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1788,7 +1788,7 @@
                         "metadata": {
                           "label": "post",
                           "description": "Create a new resource or submit data to a resource for processing.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -1797,7 +1797,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "post",
-                          "version": "2.16.0",
+                          "version": "2.16.1",
                           "lineRange": {
                             "fileName": "while.bal",
                             "startLine": {
@@ -2346,7 +2346,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -2450,7 +2450,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2487,7 +2487,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2580,7 +2580,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2617,7 +2617,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2654,7 +2654,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2732,49 +2732,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2811,7 +2811,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2848,7 +2848,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2885,7 +2885,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2922,7 +2922,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2959,7 +2959,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3024,7 +3024,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3089,7 +3089,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -806,7 +806,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -910,7 +910,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -947,7 +947,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1040,7 +1040,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1114,7 +1114,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1192,49 +1192,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1271,7 +1271,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1308,7 +1308,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1345,7 +1345,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1382,7 +1382,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1419,7 +1419,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1484,7 +1484,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1549,7 +1549,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -806,7 +806,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -910,7 +910,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -947,7 +947,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1040,7 +1040,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1114,7 +1114,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1192,49 +1192,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1271,7 +1271,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1308,7 +1308,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1345,7 +1345,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1382,7 +1382,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1419,7 +1419,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1484,7 +1484,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1549,7 +1549,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.0",
+                  "version": "2.16.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -899,7 +899,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1003,7 +1003,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1040,7 +1040,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1133,7 +1133,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1170,7 +1170,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1207,7 +1207,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1285,49 +1285,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1364,7 +1364,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1401,7 +1401,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1438,7 +1438,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1475,7 +1475,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1512,7 +1512,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1577,7 +1577,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1642,7 +1642,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_run.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_run.json
@@ -496,7 +496,7 @@
           "data": {
             "metadata": {
               "label": "Data",
-              "description": "The data to send to the workflow"
+              "description": "The data payload"
             },
             "types": [
               {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/workflow_function_def1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/workflow_function_def1.json
@@ -1,0 +1,150 @@
+{
+  "filePath": "workflow_function",
+  "fileName": "functions.bal",
+  "functionName": "orderWorkflow",
+  "description": "Verify ModuleNodeAnalyzer returns WORKFLOW node kind (not FUNCTION_DEFINITION) for a workflow function with context + input params. Run with updateConfig uncommented to generate expected output.",
+  "output": {
+    "id": "37840",
+    "metadata": {
+      "label": "Workflow Process Function",
+      "description": "Define a workflow process function"
+    },
+    "codedata": {
+      "node": "WORKFLOW",
+      "org": "ballerina",
+      "module": "workflow",
+      "lineRange": {
+        "fileName": "functions.bal",
+        "startLine": {
+          "line": 6,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 8,
+          "offset": 82
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Name of the function"
+        },
+        "types": [
+          {
+            "fieldType": "IDENTIFIER",
+            "scope": "Global",
+            "selected": true
+          }
+        ],
+        "value": "orderWorkflow",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "lineRange": {
+            "fileName": "functions.bal",
+            "startLine": {
+              "line": 8,
+              "offset": 9
+            },
+            "endLine": {
+              "line": 8,
+              "offset": 22
+            }
+          }
+        }
+      },
+      "functionNameDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the function"
+        },
+        "types": [
+          {
+            "fieldType": "DOC_TEXT",
+            "selected": true
+          }
+        ],
+        "value": "Process an order workflow\n",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "inputType": {
+        "metadata": {
+          "label": "Input Type",
+          "description": "Type of the input data to the workflow"
+        },
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "ballerinaType": "anydata",
+            "selected": false
+          }
+        ],
+        "value": "OrderInput",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "workflowContextParam": {
+        "metadata": {
+          "label": "",
+          "description": ""
+        },
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "selected": false
+          }
+        ],
+        "value": "workflow:Context context",
+        "optional": true,
+        "editable": false,
+        "advanced": false,
+        "hidden": true
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "selected": true
+          }
+        ],
+        "value": "error?",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "typeDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the return value"
+        },
+        "types": [
+          {
+            "fieldType": "DOC_TEXT",
+            "selected": true
+          }
+        ],
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/workflow_function_def2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/workflow_function_def2.json
@@ -1,0 +1,133 @@
+{
+  "filePath": "workflow_function",
+  "fileName": "functions.bal",
+  "functionName": "workflowWithNoInput",
+  "description": "Verify ModuleNodeAnalyzer returns WORKFLOW node kind for a workflow function with no parameters. Run with updateConfig uncommented to generate expected output.",
+  "output": {
+    "id": "43725",
+    "metadata": {
+      "label": "Workflow Process Function",
+      "description": "Define a workflow process function"
+    },
+    "codedata": {
+      "node": "WORKFLOW",
+      "org": "ballerina",
+      "module": "workflow",
+      "lineRange": {
+        "fileName": "functions.bal",
+        "startLine": {
+          "line": 12,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 13,
+          "offset": 46
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Name of the function"
+        },
+        "types": [
+          {
+            "fieldType": "IDENTIFIER",
+            "scope": "Global",
+            "selected": true
+          }
+        ],
+        "value": "workflowWithNoInput",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "lineRange": {
+            "fileName": "functions.bal",
+            "startLine": {
+              "line": 13,
+              "offset": 9
+            },
+            "endLine": {
+              "line": 13,
+              "offset": 28
+            }
+          }
+        }
+      },
+      "functionNameDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the function"
+        },
+        "types": [
+          {
+            "fieldType": "DOC_TEXT",
+            "selected": true
+          }
+        ],
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "inputType": {
+        "metadata": {
+          "label": "Input Type",
+          "description": "Type of the input data to the workflow"
+        },
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "ballerinaType": "anydata",
+            "selected": false
+          }
+        ],
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "selected": true
+          }
+        ],
+        "value": "error?",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "typeDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the return value"
+        },
+        "types": [
+          {
+            "fieldType": "DOC_TEXT",
+            "selected": true
+          }
+        ],
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/workflow_function/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/workflow_function/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "test"
+name = "workflow_function"
+version = "0.1.0"
+distribution = "2201.11.0-20241209-162400-0c015833"
+
+[build-options]
+observabilityIncluded = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/workflow_function/functions.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/workflow_function/functions.bal
@@ -1,0 +1,16 @@
+import ballerina/workflow;
+
+type OrderInput record {
+    string orderId;
+};
+
+# Process an order workflow
+@workflow:Workflow
+function orderWorkflow(workflow:Context context, OrderInput input) returns error? {
+    // body
+}
+
+@workflow:Workflow
+function workflowWithNoInput() returns error? {
+    // body
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/agent_model.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/agent_model.json
@@ -813,7 +813,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -917,7 +917,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -954,7 +954,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1047,7 +1047,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1084,7 +1084,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1121,7 +1121,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1199,49 +1199,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1278,7 +1278,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1315,7 +1315,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1352,7 +1352,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1389,7 +1389,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1426,7 +1426,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1491,7 +1491,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1556,7 +1556,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1919,7 +1919,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1959,7 +1959,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2055,7 +2055,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2095,7 +2095,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2179,7 +2179,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2219,7 +2219,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2259,7 +2259,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2299,7 +2299,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2339,7 +2339,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/agent_model_with_test.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/agent_model_with_test.json
@@ -123,7 +123,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -227,7 +227,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -264,7 +264,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -357,7 +357,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -394,7 +394,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -431,7 +431,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -509,49 +509,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -588,7 +588,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -625,7 +625,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -662,7 +662,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -699,7 +699,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -736,7 +736,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -801,7 +801,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -866,7 +866,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
@@ -439,7 +439,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -543,7 +543,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -580,7 +580,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -673,7 +673,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -710,7 +710,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -747,7 +747,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -825,49 +825,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -904,7 +904,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -941,7 +941,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -978,7 +978,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1015,7 +1015,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1052,7 +1052,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1117,7 +1117,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1182,7 +1182,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
@@ -439,7 +439,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -543,7 +543,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -580,7 +580,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -673,7 +673,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -710,7 +710,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -747,7 +747,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -825,49 +825,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -904,7 +904,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -941,7 +941,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -978,7 +978,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1015,7 +1015,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1052,7 +1052,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1117,7 +1117,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1182,7 +1182,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-userImportedType.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-userImportedType.json
@@ -40,7 +40,7 @@
             "typeMembers": [
               {
                 "type": "ClientConfiguration",
-                "packageInfo": "ballerina:http:2.16.0",
+                "packageInfo": "ballerina:http:2.16.1",
                 "packageName": "http",
                 "kind": "RECORD_TYPE",
                 "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/all/all_workspace_default.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/all/all_workspace_default.json
@@ -427,7 +427,7 @@
           "metadata": {
             "label": "FTP",
             "description": "FTP client for connecting to and managing FTP/SFTP servers.\nSupports reading files in various formats (text, JSON, XML, CSV, bytes) and writing files with overwrite or append options.",
-            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png"
+            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png"
           },
           "codedata": {
             "node": "NEW_CONNECTION",
@@ -436,7 +436,7 @@
             "packageName": "ftp",
             "object": "Client",
             "symbol": "init",
-            "version": "2.16.1"
+            "version": "2.16.0"
           },
           "enabled": true
         },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/all/all_workspace_default.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/all/all_workspace_default.json
@@ -427,7 +427,7 @@
           "metadata": {
             "label": "FTP",
             "description": "FTP client for connecting to and managing FTP/SFTP servers.\nSupports reading files in various formats (text, JSON, XML, CSV, bytes) and writing files with overwrite or append options.",
-            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png"
+            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png"
           },
           "codedata": {
             "node": "NEW_CONNECTION",
@@ -436,7 +436,7 @@
             "packageName": "ftp",
             "object": "Client",
             "symbol": "init",
-            "version": "2.16.0"
+            "version": "2.16.1"
           },
           "enabled": true
         },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/default.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/default.json
@@ -126,7 +126,7 @@
           "metadata": {
             "label": "FTP",
             "description": "FTP client for connecting to and managing FTP/SFTP servers.\nSupports reading files in various formats (text, JSON, XML, CSV, bytes) and writing files with overwrite or append options.",
-            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png",
+            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png",
             "data": {
               "isAgentSupport": false
             }
@@ -138,7 +138,7 @@
             "packageName": "ftp",
             "object": "Client",
             "symbol": "init",
-            "version": "2.16.0",
+            "version": "2.16.1",
             "isGenerated": false
           },
           "enabled": true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/default.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/default.json
@@ -126,7 +126,7 @@
           "metadata": {
             "label": "FTP",
             "description": "FTP client for connecting to and managing FTP/SFTP servers.\nSupports reading files in various formats (text, JSON, XML, CSV, bytes) and writing files with overwrite or append options.",
-            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png",
+            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png",
             "data": {
               "isAgentSupport": false
             }
@@ -138,7 +138,7 @@
             "packageName": "ftp",
             "object": "Client",
             "symbol": "init",
-            "version": "2.16.1",
+            "version": "2.16.0",
             "isGenerated": false
           },
           "enabled": true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/ftp.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/ftp.json
@@ -10,7 +10,7 @@
       "metadata": {
         "label": "FTP",
         "description": "FTP client for connecting to and managing FTP/SFTP servers.\nSupports reading files in various formats (text, JSON, XML, CSV, bytes) and writing files with overwrite or append options.",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png",
         "data": {
           "isAgentSupport": false
         }
@@ -22,7 +22,7 @@
         "packageName": "ftp",
         "object": "Client",
         "symbol": "init",
-        "version": "2.16.1",
+        "version": "2.16.0",
         "isGenerated": false
       },
       "enabled": true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/ftp.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/ftp.json
@@ -10,7 +10,7 @@
       "metadata": {
         "label": "FTP",
         "description": "FTP client for connecting to and managing FTP/SFTP servers.\nSupports reading files in various formats (text, JSON, XML, CSV, bytes) and writing files with overwrite or append options.",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png",
         "data": {
           "isAgentSupport": false
         }
@@ -22,7 +22,7 @@
         "packageName": "ftp",
         "object": "Client",
         "symbol": "init",
-        "version": "2.16.0",
+        "version": "2.16.1",
         "isGenerated": false
       },
       "enabled": true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/open_api_connectors.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/open_api_connectors.json
@@ -148,7 +148,7 @@
           "metadata": {
             "label": "FTP",
             "description": "FTP client for connecting to and managing FTP/SFTP servers.\nSupports reading files in various formats (text, JSON, XML, CSV, bytes) and writing files with overwrite or append options.",
-            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png",
+            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png",
             "data": {
               "isAgentSupport": false
             }
@@ -160,7 +160,7 @@
             "packageName": "ftp",
             "object": "Client",
             "symbol": "init",
-            "version": "2.16.1",
+            "version": "2.16.0",
             "isGenerated": false
           },
           "enabled": true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/open_api_connectors.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/open_api_connectors.json
@@ -148,7 +148,7 @@
           "metadata": {
             "label": "FTP",
             "description": "FTP client for connecting to and managing FTP/SFTP servers.\nSupports reading files in various formats (text, JSON, XML, CSV, bytes) and writing files with overwrite or append options.",
-            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png",
+            "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png",
             "data": {
               "isAgentSupport": false
             }
@@ -160,7 +160,7 @@
             "packageName": "ftp",
             "object": "Client",
             "symbol": "init",
-            "version": "2.16.0",
+            "version": "2.16.1",
             "isGenerated": false
           },
           "enabled": true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/types/config.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/types/config.json
@@ -573,7 +573,7 @@
               "metadata": {
                 "label": "ClientConfiguration",
                 "description": "Configuration for FTP client.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png"
               },
               "codedata": {
                 "node": "TYPEDESC",
@@ -581,7 +581,7 @@
                 "module": "ftp",
                 "packageName": "ftp",
                 "symbol": "ClientConfiguration",
-                "version": "2.16.0"
+                "version": "2.16.1"
               },
               "enabled": true
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/types/config.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/types/config.json
@@ -573,7 +573,7 @@
               "metadata": {
                 "label": "ClientConfiguration",
                 "description": "Configuration for FTP client.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.1.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ftp_2.16.0.png"
               },
               "codedata": {
                 "node": "TYPEDESC",
@@ -581,7 +581,7 @@
                 "module": "ftp",
                 "packageName": "ftp",
                 "symbol": "ClientConfiguration",
-                "version": "2.16.1"
+                "version": "2.16.0"
               },
               "enabled": true
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config1.json
@@ -529,7 +529,7 @@
       "metadata": {
         "label": "HTTP",
         "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
       },
       "codedata": {
         "node": "NEW_CONNECTION",
@@ -633,7 +633,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -670,7 +670,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp2Settings",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -763,7 +763,7 @@
               "typeMembers": [
                 {
                   "type": "FollowRedirects",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -800,7 +800,7 @@
               "typeMembers": [
                 {
                   "type": "PoolConfiguration",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -837,7 +837,7 @@
               "typeMembers": [
                 {
                   "type": "CacheConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -915,49 +915,49 @@
               "typeMembers": [
                 {
                   "type": "CredentialsConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "BearerTokenConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "JwtIssuerConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2ClientCredentialsGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2PasswordGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2RefreshTokenGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2JwtBearerGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -994,7 +994,7 @@
               "typeMembers": [
                 {
                   "type": "CircuitBreakerConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1031,7 +1031,7 @@
               "typeMembers": [
                 {
                   "type": "RetryConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1068,7 +1068,7 @@
               "typeMembers": [
                 {
                   "type": "CookieConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1105,7 +1105,7 @@
               "typeMembers": [
                 {
                   "type": "ResponseLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1142,7 +1142,7 @@
               "typeMembers": [
                 {
                   "type": "ProxyConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1207,7 +1207,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1272,7 +1272,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config11.json
@@ -529,7 +529,7 @@
       "metadata": {
         "label": "HTTP",
         "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
       },
       "codedata": {
         "node": "NEW_CONNECTION",
@@ -633,7 +633,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -670,7 +670,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp2Settings",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -763,7 +763,7 @@
               "typeMembers": [
                 {
                   "type": "FollowRedirects",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -800,7 +800,7 @@
               "typeMembers": [
                 {
                   "type": "PoolConfiguration",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -837,7 +837,7 @@
               "typeMembers": [
                 {
                   "type": "CacheConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -915,49 +915,49 @@
               "typeMembers": [
                 {
                   "type": "CredentialsConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "BearerTokenConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "JwtIssuerConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2ClientCredentialsGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2PasswordGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2RefreshTokenGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2JwtBearerGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -994,7 +994,7 @@
               "typeMembers": [
                 {
                   "type": "CircuitBreakerConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1031,7 +1031,7 @@
               "typeMembers": [
                 {
                   "type": "RetryConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1068,7 +1068,7 @@
               "typeMembers": [
                 {
                   "type": "CookieConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1105,7 +1105,7 @@
               "typeMembers": [
                 {
                   "type": "ResponseLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1142,7 +1142,7 @@
               "typeMembers": [
                 {
                   "type": "ProxyConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1207,7 +1207,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1272,7 +1272,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config2.json
@@ -439,7 +439,7 @@
       "metadata": {
         "label": "HTTP",
         "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
       },
       "codedata": {
         "node": "NEW_CONNECTION",
@@ -543,7 +543,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -580,7 +580,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp2Settings",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -673,7 +673,7 @@
               "typeMembers": [
                 {
                   "type": "FollowRedirects",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -710,7 +710,7 @@
               "typeMembers": [
                 {
                   "type": "PoolConfiguration",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -747,7 +747,7 @@
               "typeMembers": [
                 {
                   "type": "CacheConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -825,49 +825,49 @@
               "typeMembers": [
                 {
                   "type": "CredentialsConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "BearerTokenConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "JwtIssuerConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2ClientCredentialsGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2PasswordGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2RefreshTokenGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2JwtBearerGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -904,7 +904,7 @@
               "typeMembers": [
                 {
                   "type": "CircuitBreakerConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -941,7 +941,7 @@
               "typeMembers": [
                 {
                   "type": "RetryConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -978,7 +978,7 @@
               "typeMembers": [
                 {
                   "type": "CookieConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1015,7 +1015,7 @@
               "typeMembers": [
                 {
                   "type": "ResponseLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1052,7 +1052,7 @@
               "typeMembers": [
                 {
                   "type": "ProxyConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1117,7 +1117,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1182,7 +1182,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config7.json
@@ -533,7 +533,7 @@
       "metadata": {
         "label": "HTTP",
         "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.0.png"
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
       },
       "codedata": {
         "node": "NEW_CONNECTION",
@@ -637,7 +637,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -674,7 +674,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp2Settings",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -767,7 +767,7 @@
               "typeMembers": [
                 {
                   "type": "FollowRedirects",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -804,7 +804,7 @@
               "typeMembers": [
                 {
                   "type": "PoolConfiguration",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -841,7 +841,7 @@
               "typeMembers": [
                 {
                   "type": "CacheConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -919,49 +919,49 @@
               "typeMembers": [
                 {
                   "type": "CredentialsConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "BearerTokenConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "JwtIssuerConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2ClientCredentialsGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2PasswordGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2RefreshTokenGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2JwtBearerGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -998,7 +998,7 @@
               "typeMembers": [
                 {
                   "type": "CircuitBreakerConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1035,7 +1035,7 @@
               "typeMembers": [
                 {
                   "type": "RetryConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1072,7 +1072,7 @@
               "typeMembers": [
                 {
                   "type": "CookieConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1109,7 +1109,7 @@
               "typeMembers": [
                 {
                   "type": "ResponseLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1146,7 +1146,7 @@
               "typeMembers": [
                 {
                   "type": "ProxyConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1211,7 +1211,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1276,7 +1276,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.0",
+                  "packageInfo": "ballerina:http:2.16.1",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/service_field_nodes/config/service_field_nodes.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/service_field_nodes/config/service_field_nodes.json
@@ -350,7 +350,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -390,7 +390,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -486,7 +486,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -526,7 +526,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -610,7 +610,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -650,7 +650,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -690,7 +690,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -730,7 +730,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -770,7 +770,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.0",
+                    "packageInfo": "ballerina:http:2.16.1",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/send_data_to_source.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/send_data_to_source.json
@@ -101,7 +101,7 @@
       "data": {
         "metadata": {
           "label": "Data",
-          "description": "The data to send to the workflow"
+          "description": "The data payload"
         },
         "types": [
           {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/workflow_edit_to_source1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/workflow_edit_to_source1.json
@@ -1,0 +1,121 @@
+{
+  "source": "workflow_function/functions.bal",
+  "description": "Edit an existing workflow function — verify WorkflowBuilder.toSource() preserves workflow:Context parameter and updates the return type",
+  "diagram": {
+    "id": "0",
+    "metadata": {
+      "label": "Workflow Process Function",
+      "description": "Define a workflow process function"
+    },
+    "codedata": {
+      "node": "WORKFLOW",
+      "org": "ballerina",
+      "module": "workflow",
+      "lineRange": {
+        "fileName": "functions.bal",
+        "startLine": {
+          "line": 13,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 15,
+          "offset": 82
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
+        "value": "orderWorkflow",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": false
+      },
+      "functionNameDescription": {
+        "metadata": {
+          "label": "Description",
+          "description": "Description of the function"
+        },
+        "valueType": "TEXT",
+        "value": "Process an order workflow",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "inputType": {
+        "metadata": {
+          "label": "Input Type",
+          "description": "Type of the input data to the workflow"
+        },
+        "valueType": "TYPE",
+        "value": "OrderInput",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "workflowContextParam": {
+        "metadata": {
+          "label": "",
+          "description": ""
+        },
+        "valueType": "TEXT",
+        "value": "workflow:Context context",
+        "optional": true,
+        "editable": false,
+        "advanced": false,
+        "hidden": true
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "error",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "typeDescription": {
+        "metadata": {
+          "label": "Return Description",
+          "description": "Description of the return value"
+        },
+        "valueType": "TEXT",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "workflow_function/functions.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 13,
+            "character": 0
+          },
+          "end": {
+            "line": 15,
+            "character": 82
+          }
+        },
+        "newText": "# Process an order workflow\n@workflow:Workflow\nfunction orderWorkflow( workflow:Context context,  OrderInput input) returns error"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_call.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_call.json
@@ -158,7 +158,7 @@
           "retryOnError": {
             "metadata": {
               "label": "Retry On Error",
-              "description": "If `true`, retry policy is applied when the activity fails:\nthe engine retries the activity up to `maxRetries` times before\npropagating the failure to the workflow. Set to `false` (default)\nto receive any error as a normal return value so that the workflow\ncan handle it with its own logic, without any automatic retries."
+              "description": "Enable automatic retries on failure (default: `false`)"
             },
             "types": [
               {
@@ -186,7 +186,7 @@
           "maxRetries": {
             "metadata": {
               "label": "Max Retries",
-              "description": "Number of times to retry the activity on failure (only used when\n`retryOnError = true`). `0` means no retries — the activity runs\nexactly once and its failure immediately propagates to the workflow."
+              "description": "Maximum retry attempts (default: 0, no retries)"
             },
             "types": [
               {
@@ -214,7 +214,7 @@
           "retryDelay": {
             "metadata": {
               "label": "Retry Delay",
-              "description": "Initial delay in seconds before the first retry (default: 1.0).\nOnly used when `retryOnError = true` and `maxRetries > 0`."
+              "description": "Initial delay in seconds before the first retry (default: 1.0)"
             },
             "types": [
               {
@@ -242,7 +242,7 @@
           "retryBackoff": {
             "metadata": {
               "label": "Retry Backoff",
-              "description": "Multiplier applied to `retryDelay` after each attempt (default: 2.0).\n`1.0` means a fixed interval; `2.0` doubles the delay each time.\nOnly used when `retryOnError = true` and `maxRetries > 0`."
+              "description": "Multiplier applied to delay after each retry (default: 2.0)"
             },
             "types": [
               {
@@ -270,7 +270,7 @@
           "maxRetryDelay": {
             "metadata": {
               "label": "Max Retry Delay",
-              "description": "Optional cap on the delay between retries, in seconds.\nPrevents exponential backoff from growing without limit.\nOnly used when `retryOnError = true` and `maxRetries > 0`."
+              "description": "Cap on the delay between retries, in seconds"
             },
             "types": [
               {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_call.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_call.json
@@ -158,7 +158,7 @@
           "retryOnError": {
             "metadata": {
               "label": "Retry On Error",
-              "description": "Enable automatic retries on failure (default: `false`)"
+              "description": "If `true`, retry policy is applied when the activity fails:\nthe engine retries the activity up to `maxRetries` times before\npropagating the failure to the workflow. Set to `false` (default)\nto receive any error as a normal return value so that the workflow\ncan handle it with its own logic, without any automatic retries."
             },
             "types": [
               {
@@ -186,7 +186,7 @@
           "maxRetries": {
             "metadata": {
               "label": "Max Retries",
-              "description": "Maximum retry attempts (default: 0, no retries)"
+              "description": "Number of times to retry the activity on failure (only used when\n`retryOnError = true`). `0` means no retries — the activity runs\nexactly once and its failure immediately propagates to the workflow."
             },
             "types": [
               {
@@ -214,7 +214,7 @@
           "retryDelay": {
             "metadata": {
               "label": "Retry Delay",
-              "description": "Initial delay in seconds before the first retry (default: 1.0)"
+              "description": "Initial delay in seconds before the first retry (default: 1.0).\nOnly used when `retryOnError = true` and `maxRetries > 0`."
             },
             "types": [
               {
@@ -242,7 +242,7 @@
           "retryBackoff": {
             "metadata": {
               "label": "Retry Backoff",
-              "description": "Multiplier applied to delay after each retry (default: 2.0)"
+              "description": "Multiplier applied to `retryDelay` after each attempt (default: 2.0).\n`1.0` means a fixed interval; `2.0` doubles the delay each time.\nOnly used when `retryOnError = true` and `maxRetries > 0`."
             },
             "types": [
               {
@@ -270,7 +270,7 @@
           "maxRetryDelay": {
             "metadata": {
               "label": "Max Retry Delay",
-              "description": "Cap on the delay between retries, in seconds"
+              "description": "Optional cap on the delay between retries, in seconds.\nPrevents exponential backoff from growing without limit.\nOnly used when `retryOnError = true` and `maxRetries > 0`."
             },
             "types": [
               {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_creation_node_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_creation_node_template.json
@@ -211,7 +211,7 @@
           "retryOnError": {
             "metadata": {
               "label": "Retry On Error",
-              "description": "If `true`, retry policy is applied when the activity fails:\nthe engine retries the activity up to `maxRetries` times before\npropagating the failure to the workflow. Set to `false` (default)\nto receive any error as a normal return value so that the workflow\ncan handle it with its own logic, without any automatic retries."
+              "description": "Enable automatic retries on failure (default: `false`)"
             },
             "types": [
               {
@@ -239,7 +239,7 @@
           "maxRetries": {
             "metadata": {
               "label": "Max Retries",
-              "description": "Number of times to retry the activity on failure (only used when\n`retryOnError = true`). `0` means no retries — the activity runs\nexactly once and its failure immediately propagates to the workflow."
+              "description": "Maximum retry attempts (default: 0, no retries)"
             },
             "types": [
               {
@@ -267,7 +267,7 @@
           "retryDelay": {
             "metadata": {
               "label": "Retry Delay",
-              "description": "Initial delay in seconds before the first retry (default: 1.0).\nOnly used when `retryOnError = true` and `maxRetries > 0`."
+              "description": "Initial delay in seconds before the first retry (default: 1.0)"
             },
             "types": [
               {
@@ -295,7 +295,7 @@
           "retryBackoff": {
             "metadata": {
               "label": "Retry Backoff",
-              "description": "Multiplier applied to `retryDelay` after each attempt (default: 2.0).\n`1.0` means a fixed interval; `2.0` doubles the delay each time.\nOnly used when `retryOnError = true` and `maxRetries > 0`."
+              "description": "Multiplier applied to delay after each retry (default: 2.0)"
             },
             "types": [
               {
@@ -323,7 +323,7 @@
           "maxRetryDelay": {
             "metadata": {
               "label": "Max Retry Delay",
-              "description": "Optional cap on the delay between retries, in seconds.\nPrevents exponential backoff from growing without limit.\nOnly used when `retryOnError = true` and `maxRetries > 0`."
+              "description": "Cap on the delay between retries, in seconds"
             },
             "types": [
               {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_creation_node_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/activity_creation_node_template.json
@@ -211,7 +211,7 @@
           "retryOnError": {
             "metadata": {
               "label": "Retry On Error",
-              "description": "Enable automatic retries on failure (default: `false`)"
+              "description": "If `true`, retry policy is applied when the activity fails:\nthe engine retries the activity up to `maxRetries` times before\npropagating the failure to the workflow. Set to `false` (default)\nto receive any error as a normal return value so that the workflow\ncan handle it with its own logic, without any automatic retries."
             },
             "types": [
               {
@@ -239,7 +239,7 @@
           "maxRetries": {
             "metadata": {
               "label": "Max Retries",
-              "description": "Maximum retry attempts (default: 0, no retries)"
+              "description": "Number of times to retry the activity on failure (only used when\n`retryOnError = true`). `0` means no retries — the activity runs\nexactly once and its failure immediately propagates to the workflow."
             },
             "types": [
               {
@@ -267,7 +267,7 @@
           "retryDelay": {
             "metadata": {
               "label": "Retry Delay",
-              "description": "Initial delay in seconds before the first retry (default: 1.0)"
+              "description": "Initial delay in seconds before the first retry (default: 1.0).\nOnly used when `retryOnError = true` and `maxRetries > 0`."
             },
             "types": [
               {
@@ -295,7 +295,7 @@
           "retryBackoff": {
             "metadata": {
               "label": "Retry Backoff",
-              "description": "Multiplier applied to delay after each retry (default: 2.0)"
+              "description": "Multiplier applied to `retryDelay` after each attempt (default: 2.0).\n`1.0` means a fixed interval; `2.0` doubles the delay each time.\nOnly used when `retryOnError = true` and `maxRetries > 0`."
             },
             "types": [
               {
@@ -323,7 +323,7 @@
           "maxRetryDelay": {
             "metadata": {
               "label": "Max Retry Delay",
-              "description": "Cap on the delay between retries, in seconds"
+              "description": "Optional cap on the delay between retries, in seconds.\nPrevents exponential backoff from growing without limit.\nOnly used when `retryOnError = true` and `maxRetries > 0`."
             },
             "types": [
               {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/send_data_node_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/send_data_node_template.json
@@ -94,7 +94,7 @@
       "data": {
         "metadata": {
           "label": "Data",
-          "description": "The data to send to the workflow"
+          "description": "The data payload"
         },
         "types": [
           {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/wait_data_node_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/workflow_manager/config/wait_data_node_template.json
@@ -107,7 +107,7 @@
       "minCount": {
         "metadata": {
           "label": "Min Count",
-          "description": "Minimum number of futures that must complete. Defaults to `futures.length()` (wait for all)."
+          "description": "Minimum completions required (default: all)"
         },
         "types": [
           {
@@ -135,7 +135,7 @@
       "timeout": {
         "metadata": {
           "label": "Timeout",
-          "description": "Optional maximum duration to wait. When exceeded an error is returned."
+          "description": "Maximum wait duration; returns error on timeout"
         },
         "types": [
           {


### PR DESCRIPTION
 ### Problem
 
 Two bugs affected the workflow editing experience in the flow diagram:
 
 1. **Wrong node kind returned for workflow functions**: `ModuleNodeAnalyzer` always
    returned `FUNCTION_DEFINITION` when visiting workflow/activity functions, even
    though they are annotated with `@workflow:Workflow` / `@workflow:Activity`.
 
 2. **workflow:Context parameter dropped on save**: `WorkflowBuilder.toSource()`
    had no mechanism to preserve the `workflow:Context` parameter when rebuilding
    the function signature for an existing workflow function.
    
    Related Issue: https://github.com/wso2/product-integrator/issues/631
 
 ### Root Cause
 
 Bug 1 caused a 10-second timeout on save: the frontend subscribes to
 `ArtifactsUpdated` filtered by artifact type. When the LS emitted a `WORKFLOW`
 artifact but the frontend was listening for `FUNCTION`, the subscription never
 fired, resulting in a timeout and redirect to the package overview.
 
 ### Fix
 
 #### `ModuleNodeAnalyzer.java`
 - Added WORKFLOW/ACTIVITY detection via `semanticModel.symbol()` +
   `WorkflowUtil.isWorkflowFunction()` / `isActivityFunction()`
 - Extracts the `workflow:Context` parameter text and input type from function
   parameters and stores them as properties on the flow node
 - Skips the generic parameter/annotation loop for WORKFLOW/ACTIVITY nodes
 
 #### `WorkflowBuilder.java`
 - Added `CONTEXT_PARAM_KEY = "workflowContextParam"` hidden property
 - `setMandatoryProperties()` stores the context param text verbatim
 - `toSource()` re-emits the context param when rebuilding the function signature,
   handling three cases: context+input, context-only, input-only
 
 ### Tests
 - `FunctionDefinitionTest`: two new configs verify that `ModuleNodeAnalyzer`
   returns `WORKFLOW` node kind for workflow functions with and without input params
 - `SourceGeneratorTest`: one new config verifies `WorkflowBuilder.toSource()`
   preserves the `workflow:Context` parameter and correctly updates the return type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow functions are now automatically recognized and properly classified in the flow model generator, enabling specialized handling of workflow context parameters and input types during model generation.

* **Tests**
  * Added comprehensive test coverage for workflow function analysis and source code generation, including scenarios with structured input types and workflows with no input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->