### PR TITLE
Fix log and http imports not getting added when generating MCP toolkit

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/McpToolKitBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/McpToolKitBuilder.java
@@ -287,24 +287,28 @@ public class McpToolKitBuilder extends NodeBuilder {
 
             // Check if class definition data exists in codedata
             Map<String, Object> data = sourceBuilder.flowNode.codedata().data();
+            Map<Path, List<TextEdit>> classTextEdits = null;
             if (data != null && data.containsKey(MCP_CLASS_DEFINITION)) {
                 Object classDefinitionCodedata = data.get(MCP_CLASS_DEFINITION);
                 Codedata codedata = gson.fromJson(gson.toJsonTree(classDefinitionCodedata),
                         Codedata.class);
                 LineRange lineRange = codedata.lineRange();
 
-                // Use the class definition location for the text edit
+                // Use a separate SourceBuilder for the class file so imports target the correct file
                 Path classFilePath = sourceBuilder.workspaceManager.projectRoot(sourceBuilder.filePath)
                         .resolve(lineRange.fileName());
                 Range classRange = CommonUtils.toRange(lineRange);
+                SourceBuilder classSourceBuilder = new SourceBuilder(sourceBuilder.flowNode,
+                        sourceBuilder.workspaceManager, classFilePath);
 
                 // OAuth scopes require log (error logging) and http (auth config) in generated code
                 if (!toolScopesMap.isEmpty()) {
-                    sourceBuilder.acceptImport(Ai.BALLERINA_ORG, Ai.LOG_PACKAGE);
-                    sourceBuilder.acceptImport(Ai.BALLERINA_ORG, Ai.HTTP_PACKAGE);
+                    classSourceBuilder.acceptImport(Ai.BALLERINA_ORG, Ai.LOG_PACKAGE);
+                    classSourceBuilder.acceptImport(Ai.BALLERINA_ORG, Ai.HTTP_PACKAGE);
                 }
-                sourceBuilder.token().source(sourceCode).skipFormatting().stepOut()
+                classSourceBuilder.token().source(sourceCode).skipFormatting().stepOut()
                         .textEdit(SourceBuilder.SourceKind.STATEMENT, classFilePath, classRange);
+                classTextEdits = classSourceBuilder.build();
             } else {
                 // Use default agents.bal location
                 sourceBuilder.acceptImport(Ai.BALLERINA_ORG, Ai.MCP_PACKAGE);
@@ -327,8 +331,15 @@ public class McpToolKitBuilder extends NodeBuilder {
             sourceBuilder.token().keyword(SyntaxKind.FINAL_KEYWORD).stepOut().newVariable()
                     .token().keyword(SyntaxKind.CHECK_KEYWORD).keyword(SyntaxKind.NEW_KEYWORD).stepOut()
                     .functionParameters(sourceBuilder.flowNode, ignoredProperties);
+
+            Map<Path, List<TextEdit>> result =
+                    sourceBuilder.textEdit(SourceBuilder.SourceKind.STATEMENT, connectionsFilePath,
+                            defaultRange).build();
+            if (classTextEdits != null) {
+                combineTextEdits(classTextEdits, result);
+            }
+            return result;
         }
-        return sourceBuilder.textEdit(SourceBuilder.SourceKind.STATEMENT, connectionsFilePath, defaultRange).build();
     }
 
     private static Range getDefaultLineRange(SourceBuilder sourceBuilder, Path connectionsFilePath) {
@@ -592,6 +603,19 @@ public class McpToolKitBuilder extends NodeBuilder {
             return result;
         } catch (JsonSyntaxException | IllegalStateException e) {
             return Collections.emptyMap();
+        }
+    }
+
+    private static void combineTextEdits(Map<Path, List<TextEdit>> source,
+                                          Map<Path, List<TextEdit>> target) {
+        for (Map.Entry<Path, List<TextEdit>> sourceEntry : source.entrySet()) {
+            Path path = sourceEntry.getKey();
+            List<TextEdit> targetTextEdits = target.get(path);
+            if (targetTextEdits == null) {
+                target.put(path, sourceEntry.getValue());
+            } else {
+                targetTextEdits.addAll(sourceEntry.getValue());
+            }
         }
     }
 

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/McpToolKitBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/McpToolKitBuilder.java
@@ -301,6 +301,8 @@ public class McpToolKitBuilder extends NodeBuilder {
                 SourceBuilder classSourceBuilder = new SourceBuilder(sourceBuilder.flowNode,
                         sourceBuilder.workspaceManager, classFilePath);
 
+                classSourceBuilder.acceptImport(Ai.BALLERINA_ORG, Ai.MCP_PACKAGE);
+                classSourceBuilder.acceptImport(Ai.BALLERINA_ORG, Ai.AI_PACKAGE);
                 // OAuth scopes require log (error logging) and http (auth config) in generated code
                 if (!toolScopesMap.isEmpty()) {
                     classSourceBuilder.acceptImport(Ai.BALLERINA_ORG, Ai.LOG_PACKAGE);

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/toolkitmanager/McpToolKitGenerationTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/toolkitmanager/McpToolKitGenerationTest.java
@@ -50,6 +50,7 @@ public class McpToolKitGenerationTest extends AbstractLSTest {
                 {Path.of("mcp_toolkit_generation_with_class.json")},
                 {Path.of("mcp_toolkit_generation_without_class.json")},
                 {Path.of("mcp_toolkit_generation_edit.json")},
+                {Path.of("mcp_toolkit_generation_edit_with_scopes.json")},
                 {Path.of("mcp_toolkit_generation_edit_without_class.json")},
                 {Path.of("mcp_toolkit_generation_empty_permitted_tools.json")},
                 {Path.of("mcp_toolkit_generation_with_special_tool_names.json")}
@@ -65,7 +66,7 @@ public class McpToolKitGenerationTest extends AbstractLSTest {
         JsonObject response = getSourceGenerationResponse(filePath, testConfig);
         if (!response.equals(testConfig.expectedResponse())) {
             TestConfig updatedConfig = new TestConfig(testConfig.source(), testConfig.flowNode(), response);
-            // updateConfig(configJsonPath, updatedConfig);
+            updateConfig(configJsonPath, updatedConfig);
             compareJsonElements(response, testConfig.expectedResponse());
             Assert.fail(String.format("Failed test: '%s'", configJsonPath));
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/toolkitmanager/McpToolKitGenerationTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/toolkitmanager/McpToolKitGenerationTest.java
@@ -66,7 +66,7 @@ public class McpToolKitGenerationTest extends AbstractLSTest {
         JsonObject response = getSourceGenerationResponse(filePath, testConfig);
         if (!response.equals(testConfig.expectedResponse())) {
             TestConfig updatedConfig = new TestConfig(testConfig.source(), testConfig.flowNode(), response);
-            updateConfig(configJsonPath, updatedConfig);
+//            updateConfig(configJsonPath, updatedConfig);
             compareJsonElements(response, testConfig.expectedResponse());
             Assert.fail(String.format("Failed test: '%s'", configJsonPath));
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/toolkit_manager/config/mcp_toolkit_generation_edit.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/toolkit_manager/config/mcp_toolkit_generation_edit.json
@@ -966,6 +966,32 @@
         {
           "range": {
             "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/ai;"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/mcp;"
+        },
+        {
+          "range": {
+            "start": {
               "line": 7,
               "character": 0
             },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/toolkit_manager/config/mcp_toolkit_generation_edit_with_scopes.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/toolkit_manager/config/mcp_toolkit_generation_edit_with_scopes.json
@@ -1,0 +1,1025 @@
+{
+  "source": "ai_with_version",
+  "flowNode": {
+    "id": "34799",
+    "metadata": {
+      "label": "ai",
+      "description": "",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_0.1.0.png"
+    },
+    "codedata": {
+      "node": "MCP_TOOL_KIT",
+      "org": "ballerina",
+      "module": "ai",
+      "object": "McpToolKit",
+      "symbol": "init",
+      "lineRange": {
+        "fileName": "connections.bal",
+        "startLine": {
+          "line": 3,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 3,
+          "offset": 79
+        }
+      },
+      "sourceCode": "final McpToolKit aiMcpbasetoolkit = check new (\"https://mcp.deepwiki.com/mcp\");",
+      "data": {
+        "mcpClassDefinition": {
+          "lineRange": {
+            "fileName": "agents.bal",
+            "startLine": {
+              "line": 7,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 43,
+              "offset": 1
+            }
+          }
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "serverUrl": {
+        "metadata": {
+          "label": "Server Url"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "string",
+        "value": "\"https://mcp.deepwiki.com/mcp\"",
+        "placeholder": "\"\"",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "kind": "REQUIRED",
+          "originalName": "serverUrl"
+        },
+        "typeMembers": [
+          {
+            "type": "string",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": true
+          }
+        ],
+        "modified": false
+      },
+      "info": {
+        "metadata": {
+          "label": "Info"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "mcp:Implementation",
+        "placeholder": "{name: \"\", version: \"\"}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "DEFAULTABLE",
+          "originalName": "info"
+        },
+        "typeMembers": [
+          {
+            "type": "Implementation",
+            "packageInfo": "ballerina:mcp:1.0.0",
+            "packageName": "mcp",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "mcp": "ballerina/mcp"
+        },
+        "defaultValue": "{name: \"\", version: \"\"}",
+        "value": "{\n    name: \"MCP Server\",\n    version: \"1.0.0\"\n}",
+        "modified": false
+      },
+      "httpVersion": {
+        "metadata": {
+          "label": "HTTP Version",
+          "description": "HTTP protocol version supported by the client"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:HttpVersion",
+        "placeholder": "\"2.0\"",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "httpVersion"
+        },
+        "typeMembers": [
+          {
+            "type": "HttpVersion",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "\"2.0\"",
+        "value": "",
+        "modified": false
+      },
+      "http1Settings": {
+        "metadata": {
+          "label": "HTTP1 Settings",
+          "description": "HTTP/1.x specific settings"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:ClientHttp1Settings",
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "http1Settings"
+        },
+        "typeMembers": [
+          {
+            "type": "ClientHttp1Settings",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "{}",
+        "value": "",
+        "modified": false
+      },
+      "http2Settings": {
+        "metadata": {
+          "label": "HTTP2 Settings",
+          "description": "HTTP/2 specific settings"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:ClientHttp2Settings",
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "http2Settings"
+        },
+        "typeMembers": [
+          {
+            "type": "ClientHttp2Settings",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "{}",
+        "value": "",
+        "modified": false
+      },
+      "timeout": {
+        "metadata": {
+          "label": "Timeout",
+          "description": "Maximum time(in seconds) to wait for a response before the request times out"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "decimal",
+        "placeholder": "0.0d",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "timeout"
+        },
+        "typeMembers": [
+          {
+            "type": "decimal",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "defaultValue": "0.0d",
+        "value": "",
+        "modified": false
+      },
+      "forwarded": {
+        "metadata": {
+          "label": "Forwarded",
+          "description": "The choice of setting `Forwarded`/`X-Forwarded-For` header, when acting as a proxy"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "string",
+        "placeholder": "\"\"",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "forwarded"
+        },
+        "typeMembers": [
+          {
+            "type": "string",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "defaultValue": "\"\"",
+        "value": "",
+        "modified": false
+      },
+      "followRedirects": {
+        "metadata": {
+          "label": "Follow Redirects",
+          "description": "HTTP redirect handling configurations (with 3xx status codes)"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:FollowRedirects|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "followRedirects"
+        },
+        "typeMembers": [
+          {
+            "type": "FollowRedirects",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "poolConfig": {
+        "metadata": {
+          "label": "Pool Config",
+          "description": "Configurations associated with the request connection pool"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:PoolConfiguration|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "poolConfig"
+        },
+        "typeMembers": [
+          {
+            "type": "PoolConfiguration",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "cache": {
+        "metadata": {
+          "label": "Cache",
+          "description": "HTTP response caching related configurations"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:CacheConfig",
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "cache"
+        },
+        "typeMembers": [
+          {
+            "type": "CacheConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "{}",
+        "value": "",
+        "modified": false
+      },
+      "compression": {
+        "metadata": {
+          "label": "Compression",
+          "description": "Enable request/response compression (using `accept-encoding` header)"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:Compression",
+        "placeholder": "\"AUTO\"",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "compression"
+        },
+        "typeMembers": [
+          {
+            "type": "Compression",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "\"AUTO\"",
+        "value": "",
+        "modified": false
+      },
+      "auth": {
+        "metadata": {
+          "label": "Auth",
+          "description": "Client authentication options (Basic, Bearer token, OAuth, etc.)"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:CredentialsConfig|http:BearerTokenConfig|http:JwtIssuerConfig|http:OAuth2ClientCredentialsGrantConfig|http:OAuth2PasswordGrantConfig|http:OAuth2RefreshTokenGrantConfig|http:OAuth2JwtBearerGrantConfig|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "auth"
+        },
+        "typeMembers": [
+          {
+            "type": "CredentialsConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "BearerTokenConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "JwtIssuerConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "OAuth2ClientCredentialsGrantConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "OAuth2PasswordGrantConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "OAuth2RefreshTokenGrantConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "OAuth2JwtBearerGrantConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "circuitBreaker": {
+        "metadata": {
+          "label": "Circuit Breaker",
+          "description": "Circuit breaker configurations to prevent cascading failures"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:CircuitBreakerConfig|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "circuitBreaker"
+        },
+        "typeMembers": [
+          {
+            "type": "CircuitBreakerConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "retryConfig": {
+        "metadata": {
+          "label": "Retry Config",
+          "description": "Automatic retry settings for failed requests"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:RetryConfig|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "retryConfig"
+        },
+        "typeMembers": [
+          {
+            "type": "RetryConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "cookieConfig": {
+        "metadata": {
+          "label": "Cookie Config",
+          "description": "Cookie handling settings for session management"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:CookieConfig|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "cookieConfig"
+        },
+        "typeMembers": [
+          {
+            "type": "CookieConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "responseLimits": {
+        "metadata": {
+          "label": "Response Limits",
+          "description": "Limits for response size and headers (to prevent memory issues)"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:ResponseLimitConfigs",
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "responseLimits"
+        },
+        "typeMembers": [
+          {
+            "type": "ResponseLimitConfigs",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "{}",
+        "value": "",
+        "modified": false
+      },
+      "proxy": {
+        "metadata": {
+          "label": "Proxy",
+          "description": "Proxy server settings if requests need to go through a proxy"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:ProxyConfig|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "proxy"
+        },
+        "typeMembers": [
+          {
+            "type": "ProxyConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "validation": {
+        "metadata": {
+          "label": "Validation",
+          "description": "Enable automatic payload validation for request/response data against constraints"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "boolean",
+        "placeholder": "false",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "validation"
+        },
+        "typeMembers": [
+          {
+            "type": "boolean",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "defaultValue": "false",
+        "value": "",
+        "modified": false
+      },
+      "socketConfig": {
+        "metadata": {
+          "label": "Socket Config",
+          "description": "Low-level socket settings (timeouts, buffer sizes, etc.)"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:ClientSocketConfig",
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "socketConfig"
+        },
+        "typeMembers": [
+          {
+            "type": "ClientSocketConfig",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "{}",
+        "value": "",
+        "modified": false
+      },
+      "laxDataBinding": {
+        "metadata": {
+          "label": "Lax Data Binding",
+          "description": "Enable relaxed data binding on the client side.\nWhen enabled:\n- `null` values in JSON are allowed to be mapped to optional fields\n- missing fields in JSON are allowed to be mapped as `null` values"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "boolean",
+        "placeholder": "false",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "laxDataBinding"
+        },
+        "typeMembers": [
+          {
+            "type": "boolean",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "defaultValue": "false",
+        "value": "",
+        "modified": false
+      },
+      "secureSocket": {
+        "metadata": {
+          "label": "Secure Socket",
+          "description": "SSL/TLS-related options"
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "http:ClientSecureSocket|()",
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "secureSocket"
+        },
+        "typeMembers": [
+          {
+            "type": "ClientSecureSocket",
+            "packageInfo": "ballerina:http:2.15.0",
+            "packageName": "http",
+            "kind": "RECORD_TYPE",
+            "selected": false
+          },
+          {
+            "type": "()",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "imports": {
+          "http": "ballerina/http"
+        },
+        "defaultValue": "()",
+        "value": "",
+        "modified": false
+      },
+      "sessionId": {
+        "metadata": {
+          "label": "Session Id",
+          "description": "Optional session identifier for continued interactions."
+        },
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "string",
+        "placeholder": "\"\"",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "sessionId"
+        },
+        "typeMembers": [
+          {
+            "type": "string",
+            "packageInfo": "",
+            "packageName": "",
+            "kind": "BASIC_TYPE",
+            "selected": false
+          }
+        ],
+        "defaultValue": "\"\"",
+        "value": "",
+        "modified": false
+      },
+      "checkError": {
+        "metadata": {
+          "label": "Check Error",
+          "description": "Terminate on error"
+        },
+        "valueType": "FLAG",
+        "value": true,
+        "optional": false,
+        "editable": false,
+        "advanced": true,
+        "hidden": true
+      },
+      "toolKitName": {
+        "metadata": {
+          "label": "MCP Toolkit Name",
+          "description": "Name of the MCP toolkit"
+        },
+        "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
+        "value": "McpToolKit2",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "modified": true
+      },
+      "permittedTools": {
+        "value": "[\"get_teams\", \"create_pull_request_with_copilot\"]",
+        "placeholder": "()",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": true,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "permittedTools"
+        },
+        "modified": false
+      },
+      "toolScopes": {
+        "metadata": {
+          "label": "Tool Scopes",
+          "description": "OAuth scopes for each tool"
+        },
+        "value": "{\"get_teams\":[\"scope-1\",\"scope-2\"]}",
+        "placeholder": "()",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": true,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "toolScopes"
+        },
+        "modified": false
+      },
+      "scope": {
+        "metadata": {
+          "label": "Connection Scope",
+          "description": "Scope of the connection, Global or Local"
+        },
+        "valueType": "ENUM",
+        "value": "Global",
+        "optional": false,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      },
+      "variable": {
+        "metadata": {
+          "label": "Variable Name",
+          "description": "Name of the variable"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "aiMcpbasetoolkit",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "lineRange": {
+            "fileName": "connections.bal",
+            "startLine": {
+              "line": 3,
+              "offset": 17
+            },
+            "endLine": {
+              "line": 3,
+              "offset": 33
+            }
+          }
+        },
+        "modified": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Variable Type",
+          "description": "Type of the variable"
+        },
+        "valueType": "TYPE",
+        "value": "McpToolKit",
+        "placeholder": "var",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {},
+        "modified": false
+      }
+    },
+    "flags": 1
+  },
+  "expectedResponse": {
+    "textEdits": {
+      "connections.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/mcp;"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/http;"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 0
+            },
+            "end": {
+              "line": 3,
+              "character": 79
+            }
+          },
+          "newText": "final McpToolKit2 aiMcpbasetoolkit = check new (\"https://mcp.deepwiki.com/mcp\", {\n    name: \"MCP Server\",\n    version: \"1.0.0\"\n});"
+        }
+      ],
+      "agents.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/http;"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/log;"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 0
+            },
+            "end": {
+              "line": 43,
+              "character": 1
+            }
+          },
+          "newText": "isolated class McpToolKit2 {\n    *ai:McpBaseToolKit;\n    private final mcp:StreamableHttpClient mcpClient;\n    private final readonly & ai:ToolConfig[] tools;\n\n    public isolated function init(string serverUrl, mcp:Implementation info = {name: \"MCP\", version: \"1.0.0\"},\n            *ai:StreamableHttpClientTransportConfig config) returns ai:Error? {\n        final map<ai:FunctionTool> permittedTools = {\n                \"get_teams\" : self.get_teams,\n                \"create_pull_request_with_copilot\" : self.create_pull_request_with_copilot\n        };\n\n        do {\n            ai:StreamableHttpClientTransportConfig{auth, ...configs} = config;\n            mcp:StreamableHttpClientTransportConfig mcpConfig = {...configs};\n            ai:AgentIdAuthConfig? agentIdAuth = ();\n            if auth is http:ClientAuthConfig {\n                mcpConfig.auth = auth;\n                auth = ();\n            } else {\n                agentIdAuth = auth;\n            }\n            self.mcpClient = check new mcp:StreamableHttpClient(serverUrl, mcpConfig);\n            self.tools = check ai:getPermittedMcpToolConfigs(self.mcpClient, info, permittedTools, agentIdAuth).cloneReadOnly();\n        } on fail error e {\n            log:printError(\"Error initializing MCP toolkit\", e);\n            return error ai:Error(\"Failed to initialize MCP toolkit\", e);\n        }\n    }\n\n    public isolated function getTools() returns ai:ToolConfig[] => self.tools;\n\n    @ai:AgentTool {\n        auth: {\n            scopes: [\"scope-1\", \"scope-2\"]\n        }\n    }\n    public isolated function get_teams(ai:Context ctx, mcp:CallToolParams params) returns mcp:CallToolResult|error {\n        return self.mcpClient->callTool(params, headers = {\"Authorization\": string `Bearer ${check ctx.getAccessToken(params.name)}`});\n    }\n\n    @ai:AgentTool\n    public isolated function create_pull_request_with_copilot(mcp:CallToolParams params) returns mcp:CallToolResult|error {\n        return self.mcpClient->callTool(params);\n    }\n}\n"
+        }
+      ]
+    }
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/toolkit_manager/config/mcp_toolkit_generation_edit_with_scopes.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/toolkit_manager/config/mcp_toolkit_generation_edit_with_scopes.json
@@ -991,6 +991,32 @@
               "character": 0
             }
           },
+          "newText": "import ballerina/ai;"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/mcp;"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
           "newText": "import ballerina/http;"
         },
         {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/686

This PR fixes imports for `log` and `http` not being added when generating MCP toolkit with scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes generation of MCP toolkit code so required imports for the log and http modules are included when tool scopes (Agent ID scopes) are configured. The change restores correct import handling and merges edits across the generated toolkit class file and the connections file.

### Changes

- Core fix (McpToolKitBuilder.java)
  - Updated import-generation and source-building logic: the MCP toolkit class is now generated via a dedicated SourceBuilder bound to its resolved file path, with base imports added there.
  - Conditionally includes log and http imports when toolScopes are present.
  - Produces class-specific text edits separately and merges them with the connections.bal edits using a new combineTextEdits helper, replacing the prior single-step edit flow.

- Tests and fixtures
  - Added a new test scenario (mcp_toolkit_generation_edit_with_scopes.json) to validate generation and import insertion when scopes are configured.
  - Updated test data selection to include the new fixture and adjusted test failure handling to capture output for debugging.
  - The new fixture encodes expected imports (including ballerina/http and ballerina/log where appropriate), the generated isolated class, and the updated connections.bal initialization.

Outcome: ensures MCP toolkit generation includes required log and http imports when Agent ID scopes are used, addressing the behavior reported in wso2/product-integrator#686.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->