### PR TITLE
Escape reserved keywords in name arguments

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/SourceBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/SourceBuilder.java
@@ -618,8 +618,7 @@ public class SourceBuilder {
                     tokenBuilder.keyword(SyntaxKind.COMMA_TOKEN);
                 }
                 if (missedDefaultValue) {
-                    tokenBuilder.name(prop.codedata().originalName()).whiteSpace()
-                            .keyword(SyntaxKind.EQUAL_TOKEN).expression(prop);
+                    tokenBuilder.namedArg(prop);
                 } else {
                     tokenBuilder.param(prop);
                 }
@@ -630,8 +629,7 @@ public class SourceBuilder {
                 if (firstParamAdded) {
                     tokenBuilder.keyword(SyntaxKind.COMMA_TOKEN);
                 }
-                tokenBuilder.name(prop.codedata().originalName())
-                        .whiteSpace().keyword(SyntaxKind.EQUAL_TOKEN).expression(prop);
+                tokenBuilder.namedArg(prop);
             } else if (kind.equals(ParameterData.Kind.REST_PARAMETER.name())) {
                 if (isPropValueEmpty(prop) || ((List<?>) prop.value()).isEmpty()) {
                     continue;
@@ -876,11 +874,14 @@ public class SourceBuilder {
         }
 
         public TokenBuilder param(Property property) {
-            String source = property.toSourceCode();
-            if (source.startsWith("$")) {
-                source = "'" + source.substring(1);
-            }
-            sb.append(source);
+            sb.append(CommonUtils.escapeIdentifierFromFormField(property.toSourceCode()));
+            return this;
+        }
+
+        public TokenBuilder namedArg(Property property) {
+            sb.append(CommonUtils.escapeIdentifierFromFormField(property.codedata().originalName())).append(WHITE_SPACE)
+                    .append(SyntaxKind.EQUAL_TOKEN.stringValue()).append(WHITE_SPACE)
+                    .append(property.toSourceCode());
             return this;
         }
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_call-order.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_call-order.json
@@ -1,0 +1,107 @@
+{
+  "source": "process_order.bal",
+  "description": "Function call with 'order parameter",
+  "diagram": {
+    "id": "103329",
+    "metadata": {
+      "label": "processOrder"
+    },
+    "codedata": {
+      "node": "FUNCTION_CALL",
+      "org": "$anon",
+      "module": ".",
+      "symbol": "processOrder",
+      "version": "0.0.0",
+      "lineRange": {
+        "fileName": "process_order.bal",
+        "startLine": {
+          "line": 0,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 2,
+          "offset": 1
+        }
+      },
+      "sourceCode": "processOrder();"
+    },
+    "returning": false,
+    "properties": {
+      "firstVal": {
+        "metadata": {
+          "label": "First Val"
+        },
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": true
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "string",
+            "selected": false
+          }
+        ],
+        "placeholder": "\"\"",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "DEFAULTABLE",
+          "originalName": "firstVal"
+        },
+        "defaultValue": "\"first\"",
+        "modified": false
+      },
+      "$type": {
+        "metadata": {
+          "label": "Type"
+        },
+        "types": [
+          {
+            "fieldType": "NUMBER",
+            "ballerinaType": "int",
+            "selected": true
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "int",
+            "selected": false
+          }
+        ],
+        "placeholder": "0",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "DEFAULTABLE",
+          "originalName": "'type"
+        },
+        "defaultValue": "\"second\"",
+        "modified": true,
+        "value": "10"
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "process_order.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 1
+          }
+        },
+        "newText": "processOrder('type = 10);"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/process_order.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/process_order.bal
@@ -1,0 +1,3 @@
+function processOrder(string firstVal = "first", int 'type = 2) {
+
+}

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/CommonUtils.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/CommonUtils.java
@@ -88,6 +88,7 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
 import java.net.URI;
@@ -1681,7 +1682,7 @@ public class CommonUtils {
      * @param name the form field name to escape
      * @return the escaped identifier
      */
-    public static String escapeIdentifierFromFormField(String name) {
+    public static String escapeIdentifierFromFormField(@NonNull String name) {
         return name.startsWith("$") ? "'" + name.substring(1) : name;
     }
 

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/CommonUtils.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/CommonUtils.java
@@ -1674,4 +1674,16 @@ public class CommonUtils {
         return valueExpression.toSourceCode().trim();
     }
 
+    /**
+     * Escapes a form field name to a valid Ballerina identifier by replacing the leading {@code $} with a
+     * single quote prefix.
+     *
+     * @param name the form field name to escape
+     * @return the escaped identifier
+     */
+    public static String escapeIdentifierFromFormField(String name) {
+        return name.startsWith("$") ? "'" + name.substring(1) : name;
+    }
+
 }
+

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/FunctionDataBuilder.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/FunctionDataBuilder.java
@@ -268,7 +268,6 @@ public class FunctionDataBuilder {
         return this;
     }
 
-
     private void setParentSymbol(Stream<Symbol> symbolStream, String parentSymbolName) {
         this.parentSymbol = symbolStream
                 .filter(symbol -> symbol.kind() == SymbolKind.VARIABLE && symbol.nameEquals(parentSymbolName))


### PR DESCRIPTION
## Purpose

Fix identifier escaping for reserved-keyword parameters in generated Ballerina source code.

Fixes https://github.com/wso2/product-integrator/issues/665

## Approach

Extracted `$`-prefix escaping into a shared utility (`CommonUtils.escapeIdentifierFromFormField`) and introduced a `namedArg()` builder method to eliminate duplicated named-argument construction logic in `SourceBuilder`.

## Affected Components

- `flow-model-generator/modules/flow-model-generator-core/`
- `flow-model-generator/modules/flow-model-generator-ls-extension/`
- `model-generator-commons/`

## Testing

New test case covering function calls with reserved-keyword named parameters (e.g., `'type`). Existing source generation tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes identifier handling in generated Ballerina source code to properly escape reserved keyword parameter names, ensuring generated code remains syntactically valid.

## Problem

The code generator was producing invalid Ballerina syntax when named parameters used reserved keywords (e.g., `type`). For instance, when generating code for the Twitter client's "List Compliance Jobs" action, it would emit `type = "tweets"` instead of the properly escaped `'type = "tweets"`, causing syntax errors.

## Solution

The PR introduces a shared utility method and refactors parameter handling across the code generation pipeline:

- **New utility method**: `CommonUtils.escapeIdentifierFromFormField()` handles the transformation of form field names starting with `$` into properly escaped Ballerina identifiers by prefixing with a single quote and removing the leading `$`.

- **Centralized named argument construction**: Added `TokenBuilder.namedArg(Property)` method in `SourceBuilder` to standardize how named arguments are built, ensuring all parameter names are escaped via the shared utility before code generation.

- **Updated parameter handling**: Modified `TokenBuilder.param(Property)` to consistently apply identifier escaping derived from form fields.

## Testing

The PR includes new test resources demonstrating the fix:
- Added test configuration for a function call scenario with reserved keyword parameters
- Included test source file showing proper declaration syntax with escaped reserved keyword parameter (`'type`)
- Existing source generation tests continue to pass

## Files Modified

- `SourceBuilder.java`: Added `namedArg()` builder method and updated parameter construction logic
- `CommonUtils.java`: Added `escapeIdentifierFromFormField()` utility method
- Test resources: Added configuration and source files validating the fix with reserved keyword parameters
- Minor cleanup in `FunctionDataBuilder.java`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->