### PR TITLE
Add secure socket (SSL/TLS) configuration support for MCP tool discovery

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/McpClient.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/McpClient.java
@@ -35,6 +35,7 @@ import java.security.KeyStore;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManagerFactory;
@@ -127,7 +128,7 @@ public class McpClient {
     }
 
     private static KeyStore loadTrustStore(String path, String password) throws Exception {
-        String lowerPath = path.toLowerCase();
+        String lowerPath = path.toLowerCase(Locale.ROOT);
         char[] passwordChars = password != null ? password.toCharArray() : new char[0];
 
         if (lowerPath.endsWith(".p12") || lowerPath.endsWith(".pfx") || lowerPath.endsWith(".jks")) {
@@ -167,7 +168,7 @@ public class McpClient {
     }
 
     private static KeyStore loadKeyStore(String path, String password) throws Exception {
-        String lowerPath = path.toLowerCase();
+        String lowerPath = path.toLowerCase(Locale.ROOT);
         char[] passwordChars = password != null ? password.toCharArray() : new char[0];
 
         String type;
@@ -176,7 +177,9 @@ public class McpClient {
         } else if (lowerPath.endsWith(".jks")) {
             type = "JKS";
         } else {
-            type = "PKCS12"; // default for key files
+            throw new IllegalArgumentException(
+                    "Unsupported key file format: " + path +
+                            ". Client key must be a keystore file (.p12, .pfx, or .jks)");
         }
 
         KeyStore keyStore = KeyStore.getInstance(type);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/McpClient.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/McpClient.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 import java.io.BufferedReader;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -30,8 +31,17 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Client for sending requests to the MCP service.
@@ -43,11 +53,150 @@ public class McpClient {
     private static final Integer CONNECTION_TIMEOUT_MS = 10000; // 10 seconds
     private static final Integer READ_TIMEOUT_MS = 10000; // 10 seconds
 
+    /**
+     * Secure socket configuration for SSL/TLS connections.
+     *
+     * @param certPath     Path to the CA certificate or truststore file
+     * @param certPassword Password for the truststore (if .p12/.jks)
+     * @param keyPath      Path to the client certificate/key file (for mTLS)
+     * @param keyPassword  Password for the client key/keystore
+     * @param insecure     If true, skip all certificate verification
+     */
+    public record SslConfig(String certPath, String certPassword, String keyPath, String keyPassword,
+                            boolean insecure) {
+    }
+
+    private static void applySslConfig(HttpURLConnection conn, SslConfig sslConfig) throws IOException {
+        if (sslConfig == null || !(conn instanceof HttpsURLConnection httpsConn)) {
+            return;
+        }
+
+        try {
+            if (sslConfig.insecure()) {
+                TrustManager[] trustAllCerts = new TrustManager[]{
+                        new X509TrustManager() {
+                            public X509Certificate[] getAcceptedIssuers() {
+                                return new X509Certificate[0];
+                            }
+
+                            public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                            }
+
+                            public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                            }
+                        }
+                };
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+                httpsConn.setSSLSocketFactory(sslContext.getSocketFactory());
+                httpsConn.setHostnameVerifier((hostname, session) -> true);
+                return;
+            }
+
+            javax.net.ssl.KeyManager[] keyManagers = null;
+            javax.net.ssl.TrustManager[] trustManagers = null;
+
+            // Load client key for mTLS
+            if (sslConfig.keyPath() != null && !sslConfig.keyPath().trim().isEmpty()) {
+                KeyStore keyStore = loadKeyStore(sslConfig.keyPath(), sslConfig.keyPassword());
+                KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                kmf.init(keyStore, sslConfig.keyPassword() != null
+                        ? sslConfig.keyPassword().toCharArray() : new char[0]);
+                keyManagers = kmf.getKeyManagers();
+            }
+
+            // Load CA certificate / truststore
+            if (sslConfig.certPath() != null && !sslConfig.certPath().trim().isEmpty()) {
+                KeyStore trustStore = loadTrustStore(sslConfig.certPath(), sslConfig.certPassword());
+                TrustManagerFactory tmf =
+                        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                tmf.init(trustStore);
+                trustManagers = tmf.getTrustManagers();
+            }
+
+            if (keyManagers != null || trustManagers != null) {
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(keyManagers, trustManagers, new java.security.SecureRandom());
+                httpsConn.setSSLSocketFactory(sslContext.getSocketFactory());
+            }
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to configure SSL: " + e.getMessage(), e);
+        }
+    }
+
+    private static KeyStore loadTrustStore(String path, String password) throws Exception {
+        String lowerPath = path.toLowerCase();
+        char[] passwordChars = password != null ? password.toCharArray() : new char[0];
+
+        if (lowerPath.endsWith(".p12") || lowerPath.endsWith(".pfx") || lowerPath.endsWith(".jks")) {
+            // Load the keystore, then extract all certificates into a new truststore
+            // so they are recognized as trustedCertEntry by TrustManagerFactory
+            String type = lowerPath.endsWith(".jks") ? "JKS" : "PKCS12";
+            KeyStore source = KeyStore.getInstance(type);
+            try (FileInputStream fis = new FileInputStream(path)) {
+                source.load(fis, passwordChars);
+            }
+
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+            java.util.Enumeration<String> aliases = source.aliases();
+            int index = 0;
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                java.security.cert.Certificate cert = source.getCertificate(alias);
+                if (cert != null) {
+                    trustStore.setCertificateEntry("trust-" + index++, cert);
+                }
+            }
+            return trustStore;
+        } else {
+            // PEM/CRT format — load certificates directly
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+            try (FileInputStream fis = new FileInputStream(path)) {
+                int index = 0;
+                for (java.security.cert.Certificate cert : cf.generateCertificates(fis)) {
+                    trustStore.setCertificateEntry("cert-" + index++, cert);
+                }
+            }
+            return trustStore;
+        }
+    }
+
+    private static KeyStore loadKeyStore(String path, String password) throws Exception {
+        String lowerPath = path.toLowerCase();
+        char[] passwordChars = password != null ? password.toCharArray() : new char[0];
+
+        String type;
+        if (lowerPath.endsWith(".p12") || lowerPath.endsWith(".pfx")) {
+            type = "PKCS12";
+        } else if (lowerPath.endsWith(".jks")) {
+            type = "JKS";
+        } else {
+            type = "PKCS12"; // default for key files
+        }
+
+        KeyStore keyStore = KeyStore.getInstance(type);
+        try (FileInputStream fis = new FileInputStream(path)) {
+            keyStore.load(fis, passwordChars);
+        }
+        return keyStore;
+    }
+
     public static String sendInitializeRequest(String serviceUrl, String accessToken) throws IOException {
+        return sendInitializeRequest(serviceUrl, accessToken, null);
+    }
+
+    public static String sendInitializeRequest(String serviceUrl, String accessToken, SslConfig sslConfig)
+            throws IOException {
         HttpURLConnection conn = null;
         try {
             URL url = URI.create(serviceUrl).toURL();
             conn = (HttpURLConnection) url.openConnection();
+            applySslConfig(conn, sslConfig);
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("Accept", "application/json, text/event-stream");
@@ -118,10 +267,16 @@ public class McpClient {
 
     public static void sendInitializedNotification(String serviceUrl, String sessionId, String accessToken)
             throws IOException {
+        sendInitializedNotification(serviceUrl, sessionId, accessToken, null);
+    }
+
+    public static void sendInitializedNotification(String serviceUrl, String sessionId, String accessToken,
+                                                    SslConfig sslConfig) throws IOException {
         HttpURLConnection conn = null;
         try {
             URL url = URI.create(serviceUrl).toURL();
             conn = (HttpURLConnection) url.openConnection();
+            applySslConfig(conn, sslConfig);
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("Accept", "application/json, text/event-stream");
@@ -182,10 +337,16 @@ public class McpClient {
 
     public static JsonArray sendToolsListRequest(String serviceUrl, String sessionId, String accessToken)
             throws IOException {
+        return sendToolsListRequest(serviceUrl, sessionId, accessToken, null);
+    }
+
+    public static JsonArray sendToolsListRequest(String serviceUrl, String sessionId, String accessToken,
+                                                  SslConfig sslConfig) throws IOException {
         HttpURLConnection conn = null;
         try {
             URL url = URI.create(serviceUrl).toURL();
             conn = (HttpURLConnection) url.openConnection();
+            applySslConfig(conn, sslConfig);
             // Configure request
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/McpClient.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/McpClient.java
@@ -37,6 +37,7 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/McpClient.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/McpClient.java
@@ -271,7 +271,7 @@ public class McpClient {
     }
 
     public static void sendInitializedNotification(String serviceUrl, String sessionId, String accessToken,
-                                                    SslConfig sslConfig) throws IOException {
+                                                   SslConfig sslConfig) throws IOException {
         HttpURLConnection conn = null;
         try {
             URL url = URI.create(serviceUrl).toURL();
@@ -341,7 +341,7 @@ public class McpClient {
     }
 
     public static JsonArray sendToolsListRequest(String serviceUrl, String sessionId, String accessToken,
-                                                  SslConfig sslConfig) throws IOException {
+                                                 SslConfig sslConfig) throws IOException {
         HttpURLConnection conn = null;
         try {
             URL url = URI.create(serviceUrl).toURL();

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/AgentsManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/AgentsManagerService.java
@@ -36,6 +36,7 @@ import io.ballerina.flowmodelgenerator.extension.request.GetPackageVersionReques
 import io.ballerina.flowmodelgenerator.extension.request.GetToolRequest;
 import io.ballerina.flowmodelgenerator.extension.request.GetToolsRequest;
 import io.ballerina.flowmodelgenerator.extension.request.McpToolsRequest;
+import io.ballerina.flowmodelgenerator.extension.request.SecureSocketConfig;
 import io.ballerina.flowmodelgenerator.extension.response.AddAgentChatServiceResponse;
 import io.ballerina.flowmodelgenerator.extension.response.GenToolResponse;
 import io.ballerina.flowmodelgenerator.extension.response.GetAgentsResponse;
@@ -240,14 +241,28 @@ public class AgentsManagerService implements ExtendedLanguageServerService {
                 // Get the access token from the request (if provided)
                 String accessToken = request.accessToken();
 
+                // Build SSL config if provided
+                McpClient.SslConfig sslConfig = null;
+                if (request.secureSocket() != null) {
+                    SecureSocketConfig sc = request.secureSocket();
+                    sslConfig = new McpClient.SslConfig(
+                            sc.cert() != null ? sc.cert().path() : null,
+                            sc.cert() != null ? sc.cert().password() : null,
+                            sc.key() != null ? sc.key().path() : null,
+                            sc.key() != null ? sc.key().password() : null,
+                            sc.insecure()
+                    );
+                }
+
                 // Send initialize request with optional authentication
-                String sessionId = McpClient.sendInitializeRequest(serviceUrl, accessToken);
+                String sessionId = McpClient.sendInitializeRequest(serviceUrl, accessToken, sslConfig);
 
                 // Send initialized notification to complete the handshake
-                McpClient.sendInitializedNotification(serviceUrl, sessionId, accessToken);
+                McpClient.sendInitializedNotification(serviceUrl, sessionId, accessToken, sslConfig);
 
                 // Now we can send operational requests
-                JsonArray toolsJsonArray = McpClient.sendToolsListRequest(serviceUrl, sessionId, accessToken);
+                JsonArray toolsJsonArray = McpClient.sendToolsListRequest(serviceUrl, sessionId, accessToken,
+                        sslConfig);
 
                 response.setTools(toolsJsonArray);
                 return response;

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/AgentsManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/AgentsManagerService.java
@@ -241,6 +241,13 @@ public class AgentsManagerService implements ExtendedLanguageServerService {
                 // Get the access token from the request (if provided)
                 String accessToken = request.accessToken();
 
+                // Validate: SSL config should only be used with HTTPS URLs
+                if (request.secureSocket() != null && "http".equals(new java.net.URI(serviceUrl).getScheme())) {
+                    response.setError(new IllegalArgumentException(
+                            "Secure socket configuration is only applicable for HTTPS URLs"));
+                    return response;
+                }
+
                 // Build SSL config if provided
                 McpClient.SslConfig sslConfig = null;
                 if (request.secureSocket() != null) {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/SecureSocketConfig.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/SecureSocketConfig.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -21,19 +21,22 @@ package io.ballerina.flowmodelgenerator.extension.request;
 /**
  * Configuration for secure socket (SSL/TLS) connections.
  *
- * @param cert     Truststore/CA certificate configuration for verifying the server
- * @param key      Client certificate/key configuration for mutual TLS (mTLS)
+ * @param cert     Truststore/CA certificate configuration for verifying the server.
+ *                 Supports .pem, .crt, .p12, .pfx, and .jks formats.
+ * @param key      Client keystore configuration for mutual TLS (mTLS).
+ *                 Supports .p12, .pfx, and .jks formats only.
  * @param insecure If true, skip all certificate verification (development/testing only)
  *
- * @since 1.1.0
+ * @since 1.7.0
  */
 public record SecureSocketConfig(CertConfig cert, CertConfig key, boolean insecure) {
 
     /**
-     * Certificate/key file configuration.
+     * Certificate or keystore file configuration.
      *
-     * @param path     Path to the certificate or key file (.pem, .crt, .p12, .jks)
-     * @param password Password for the keystore (required for .p12/.jks, optional for .pem/.crt)
+     * @param path     Path to the file. For cert: .pem, .crt, .p12, .pfx, .jks.
+     *                 For key (mTLS): .p12, .pfx, .jks only.
+     * @param password Password for the keystore (required for .p12/.pfx/.jks, not needed for .pem/.crt)
      */
     public record CertConfig(String path, String password) {
     }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/SecureSocketConfig.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/SecureSocketConfig.java
@@ -19,14 +19,22 @@
 package io.ballerina.flowmodelgenerator.extension.request;
 
 /**
- * Request to initialize MCP tools with a service URL and optional authentication.
+ * Configuration for secure socket (SSL/TLS) connections.
  *
- * @param serviceUrl   The URL of the MCP service
- * @param accessToken  Optional OAuth 2.0 bearer token for authentication
- * @param secureSocket Optional secure socket (SSL/TLS) configuration
+ * @param cert     Truststore/CA certificate configuration for verifying the server
+ * @param key      Client certificate/key configuration for mutual TLS (mTLS)
+ * @param insecure If true, skip all certificate verification (development/testing only)
  *
  * @since 1.1.0
  */
-public record McpToolsRequest(String serviceUrl, String accessToken, SecureSocketConfig secureSocket) {
-}
+public record SecureSocketConfig(CertConfig cert, CertConfig key, boolean insecure) {
 
+    /**
+     * Certificate/key file configuration.
+     *
+     * @param path     Path to the certificate or key file (.pem, .crt, .p12, .jks)
+     * @param password Password for the keystore (required for .p12/.jks, optional for .pem/.crt)
+     */
+    public record CertConfig(String path, String password) {
+    }
+}


### PR DESCRIPTION
## Purpose

Related to https://github.com/wso2/product-integrator/issues/491

- Add SSL/TLS (secure socket) support for MCP tool discovery, enabling connections to HTTPS-protected MCP    
servers with custom certificates                                                                             
- Support three modes: custom CA certificate (truststore), mutual TLS (client certificate), and insecure mode
 (skip verification)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request adds secure socket (SSL/TLS) configuration support for MCP tool discovery, enabling secure connections to HTTPS-protected MCP servers.

## Changes

**New Data Structures:**
- Introduced `SecureSocketConfig` record in the request module to encapsulate SSL/TLS configuration with three options:
  - Custom CA certificate (truststore) for server certificate validation
  - Client certificate for mutual TLS authentication
  - Insecure mode to bypass certificate verification
- Added nested `CertConfig` record to represent certificate/keystore file paths and passwords

**Core MCP Client Updates:**
- Introduced `SslConfig` record in `McpClient` to parameterize TLS behavior
- Added SSL/TLS support methods:
  - `applySslConfig`: Configures `HttpsURLConnection` with appropriate SSL context
  - `loadTrustStore`: Loads CA certificates for server validation
  - `loadKeyStore`: Loads client certificates for mutual TLS
- Extended three primary request methods with new overloads that accept `SslConfig`:
  - `sendInitializeRequest`
  - `sendInitializedNotification`
  - `sendToolsListRequest`
- Retained existing method overloads for backward compatibility

**Integration Updates:**
- Updated `AgentsManagerService` to construct `SslConfig` from request parameters and pass it through the MCP connection lifecycle
- Extended `McpToolsRequest` record to include optional `secureSocket` parameter

## Impact

These changes enable users to securely connect to MCP servers using custom certificates while maintaining backward compatibility with existing callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->