### PR TITLE
Handle union types with map and nil members in properties

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -965,21 +965,24 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
             // Find the matching type symbol that is a subtype of the parameter type.
             // When the inferred type is unavailable or a compilation error, skip the subtype check
             // and use the declared type directly.
+            TypeSymbol matchedMapType;
             if (paramType.isPresent()
                     && paramType.get().typeKind() != TypeDescKind.COMPILATION_ERROR) {
                 TypeSymbol actualParamType = paramType.get();
-                TypeSymbol matchingType = candidateMapTypes.stream()
+                matchedMapType = candidateMapTypes.stream()
                         .filter(candidate -> candidate.subtypeOf(actualParamType))
                         .findFirst()
                         .orElse(null);
-                if (matchingType == null) {
+                if (matchedMapType == null) {
                     return;
                 }
             } else if (candidateMapTypes.isEmpty()) {
                 return;
+            } else {
+                matchedMapType = candidateMapTypes.getFirst();
             }
 
-            String ballerinaType = CommonUtils.getTypeSignature(typeSymbol, moduleInfo);
+            String ballerinaType = CommonUtils.getTypeSignature(matchedMapType, moduleInfo);
 
             // Find and update the matching property type
             builder.types.stream()

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -965,7 +965,7 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
             // Find the matching type symbol that is a subtype of the parameter type.
             // When the inferred type is unavailable or a compilation error, skip the subtype check
             // and use the declared type directly.
-            TypeSymbol matchedMapType;
+            TypeSymbol matchedMapType = null;
             if (paramType.isPresent()
                     && paramType.get().typeKind() != TypeDescKind.COMPILATION_ERROR) {
                 TypeSymbol actualParamType = paramType.get();
@@ -978,11 +978,10 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
                 }
             } else if (candidateMapTypes.isEmpty()) {
                 return;
-            } else {
-                matchedMapType = candidateMapTypes.getFirst();
             }
 
-            String ballerinaType = CommonUtils.getTypeSignature(matchedMapType, moduleInfo);
+            String ballerinaType = CommonUtils.getTypeSignature(matchedMapType != null ? matchedMapType : typeSymbol
+                    , moduleInfo);
 
             // Find and update the matching property type
             builder.types.stream()

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
@@ -1972,7 +1972,7 @@
                   "advanced": false,
                   "hidden": false
                 },
-                "selected": false
+                "selected": true
               },
               {
                 "fieldType": "EXPRESSION",
@@ -1980,7 +1980,92 @@
                 "selected": false
               }
             ],
-            "value": "{\n            \"first-header\": \"first\",\n            \"second-header\": \"second\"\n        }",
+            "value": {
+              "\"first-header\"": {
+                "types": [
+                  {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                  },
+                  {
+                    "fieldType": "REPEATABLE_LIST",
+                    "ballerinaType": "string[]",
+                    "template": {
+                      "types": [
+                        {
+                          "fieldType": "TEXT",
+                          "ballerinaType": "string",
+                          "selected": false
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "string",
+                          "selected": false
+                        }
+                      ],
+                      "optional": false,
+                      "editable": false,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "selected": false
+                  },
+                  {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string|string[]",
+                    "selected": true
+                  }
+                ],
+                "value": "\"first\"",
+                "optional": false,
+                "editable": false,
+                "advanced": false,
+                "hidden": false
+              },
+              "\"second-header\"": {
+                "types": [
+                  {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                  },
+                  {
+                    "fieldType": "REPEATABLE_LIST",
+                    "ballerinaType": "string[]",
+                    "template": {
+                      "types": [
+                        {
+                          "fieldType": "TEXT",
+                          "ballerinaType": "string",
+                          "selected": false
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "string",
+                          "selected": false
+                        }
+                      ],
+                      "optional": false,
+                      "editable": false,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "selected": false
+                  },
+                  {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string|string[]",
+                    "selected": true
+                  }
+                ],
+                "value": "\"second\"",
+                "optional": false,
+                "editable": false,
+                "advanced": false,
+                "hidden": false
+              }
+            },
             "placeholder": "()",
             "optional": true,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
@@ -1847,7 +1847,7 @@
                   "advanced": false,
                   "hidden": false
                 },
-                "selected": false
+                "selected": true
               },
               {
                 "fieldType": "EXPRESSION",
@@ -1855,7 +1855,92 @@
                 "selected": false
               }
             ],
-            "value": "{\n            \"first-header\": \"first\",\n            \"second-header\": \"second\"\n        }",
+            "value": {
+              "\"first-header\"": {
+                "types": [
+                  {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                  },
+                  {
+                    "fieldType": "REPEATABLE_LIST",
+                    "ballerinaType": "string[]",
+                    "template": {
+                      "types": [
+                        {
+                          "fieldType": "TEXT",
+                          "ballerinaType": "string",
+                          "selected": false
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "string",
+                          "selected": false
+                        }
+                      ],
+                      "optional": false,
+                      "editable": false,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "selected": false
+                  },
+                  {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string|string[]",
+                    "selected": true
+                  }
+                ],
+                "value": "\"first\"",
+                "optional": false,
+                "editable": false,
+                "advanced": false,
+                "hidden": false
+              },
+              "\"second-header\"": {
+                "types": [
+                  {
+                    "fieldType": "TEXT",
+                    "ballerinaType": "string",
+                    "selected": false
+                  },
+                  {
+                    "fieldType": "REPEATABLE_LIST",
+                    "ballerinaType": "string[]",
+                    "template": {
+                      "types": [
+                        {
+                          "fieldType": "TEXT",
+                          "ballerinaType": "string",
+                          "selected": false
+                        },
+                        {
+                          "fieldType": "EXPRESSION",
+                          "ballerinaType": "string",
+                          "selected": false
+                        }
+                      ],
+                      "optional": false,
+                      "editable": false,
+                      "advanced": false,
+                      "hidden": false
+                    },
+                    "selected": false
+                  },
+                  {
+                    "fieldType": "EXPRESSION",
+                    "ballerinaType": "string|string[]",
+                    "selected": true
+                  }
+                ],
+                "value": "\"second\"",
+                "optional": false,
+                "editable": false,
+                "advanced": false,
+                "hidden": false
+              }
+            },
             "placeholder": "()",
             "optional": true,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/remote_action_call-http-get9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/remote_action_call-http-get9.json
@@ -1,0 +1,358 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "31",
+    "metadata": {
+      "label": "get",
+      "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.1.png"
+    },
+    "codedata": {
+      "node": "REMOTE_ACTION_CALL",
+      "org": "ballerina",
+      "module": "http",
+      "packageName": "http",
+      "object": "Client",
+      "symbol": "get",
+      "version": "2.16.1",
+      "isNew": true,
+      "inferredReturnType": "targetType",
+      "lineRange": {
+        "startLine": {
+          "line": 3,
+          "offset": 8
+        },
+        "endLine": {
+          "line": 3,
+          "offset": 8
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "connection": {
+        "metadata": {
+          "label": "Connection",
+          "description": "Connection to use"
+        },
+        "types": [
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:Client",
+            "selected": false
+          }
+        ],
+        "value": "httpClient",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": true,
+        "modified": false
+      },
+      "path": {
+        "metadata": {
+          "label": "Path",
+          "description": "Request path"
+        },
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": true
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "string",
+            "selected": false
+          }
+        ],
+        "placeholder": "\"\"",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "kind": "REQUIRED",
+          "originalName": "path"
+        },
+        "modified": false,
+        "value": "string `foo`"
+      },
+      "headers": {
+        "metadata": {
+          "label": "Headers",
+          "description": "The entity headers"
+        },
+        "types": [
+          {
+            "fieldType": "REPEATABLE_MAP",
+            "ballerinaType": "map<string|string[]>",
+            "template": {
+              "types": [
+                {
+                  "fieldType": "TEXT",
+                  "ballerinaType": "string",
+                  "selected": false
+                },
+                {
+                  "fieldType": "REPEATABLE_LIST",
+                  "ballerinaType": "string[]",
+                  "template": {
+                    "types": [
+                      {
+                        "fieldType": "TEXT",
+                        "ballerinaType": "string",
+                        "selected": false
+                      },
+                      {
+                        "fieldType": "EXPRESSION",
+                        "ballerinaType": "string",
+                        "selected": false
+                      }
+                    ],
+                    "optional": false,
+                    "editable": false,
+                    "advanced": false,
+                    "hidden": false
+                  },
+                  "selected": false
+                },
+                {
+                  "fieldType": "EXPRESSION",
+                  "ballerinaType": "string|string[]",
+                  "selected": false
+                }
+              ],
+              "optional": false,
+              "editable": false,
+              "advanced": false,
+              "hidden": false
+            },
+            "selected": true
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "map<string|string[]>?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "DEFAULTABLE",
+          "originalName": "headers"
+        },
+        "defaultValue": "()",
+        "modified": true,
+        "value": {
+          "Header1": {
+            "key": "mp-val-64edeebd-e900-4327-b170-2147d82329a9",
+            "label": "Value",
+            "type": "TEXT",
+            "optional": false,
+            "editable": true,
+            "documentation": "",
+            "value": "string `Header1Value`",
+            "types": [
+              {
+                "fieldType": "TEXT",
+                "ballerinaType": "string",
+                "selected": true
+              },
+              {
+                "fieldType": "REPEATABLE_LIST",
+                "ballerinaType": "string[]",
+                "template": {
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "ballerinaType": "string",
+                      "selected": false
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "string",
+                      "selected": false
+                    }
+                  ],
+                  "optional": false,
+                  "editable": false,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "selected": false
+              },
+              {
+                "fieldType": "EXPRESSION",
+                "ballerinaType": "string|string[]",
+                "selected": false
+              }
+            ],
+            "enabled": true
+          },
+          "Header2": {
+            "key": "mp-val-b35080d4-8c11-4fe5-a397-ca6d87b1e92f",
+            "label": "Value",
+            "type": "TEXT",
+            "optional": false,
+            "editable": true,
+            "documentation": "",
+            "value": "string `Header2Value`",
+            "types": [
+              {
+                "fieldType": "TEXT",
+                "ballerinaType": "string",
+                "selected": true
+              },
+              {
+                "fieldType": "REPEATABLE_LIST",
+                "ballerinaType": "string[]",
+                "template": {
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "ballerinaType": "string",
+                      "selected": false
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "string",
+                      "selected": false
+                    }
+                  ],
+                  "optional": false,
+                  "editable": false,
+                  "advanced": false,
+                  "hidden": false
+                },
+                "selected": false
+              },
+              {
+                "fieldType": "EXPRESSION",
+                "ballerinaType": "string|string[]",
+                "selected": false
+              }
+            ],
+            "enabled": true
+          }
+        }
+      },
+      "targetType": {
+        "metadata": {
+          "label": "Target Type",
+          "description": "Expected return type (to be used for automatic data binding).\nSupported types:\n- Built-in subtypes of `anydata` (`string`, `byte[]`, `json|xml`, etc.)\n- Custom types (e.g., `User`, `Student?`, `Person[]`, etc.)\n- Full HTTP response with headers and status (`http:Response`)\n- Stream of Server-Sent Events (`stream<http:SseEvent, error?>`)"
+        },
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "ballerinaType": "http:Response|anydata|stream<http:SseEvent, error?>",
+            "selected": false
+          }
+        ],
+        "placeholder": "http:Response|anydata|stream<http:SseEvent, error?>",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "kind": "PARAM_FOR_TYPE_INFER",
+          "originalName": "targetType"
+        },
+        "defaultValue": "http:Response|anydata|stream<http:SseEvent, error?>",
+        "modified": false,
+        "value": "anydata"
+      },
+      "type": {
+        "metadata": {
+          "label": "Result Type",
+          "description": "Type of the variable"
+        },
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "selected": true
+          }
+        ],
+        "value": "targetType",
+        "placeholder": "var",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {},
+        "modified": false
+      },
+      "variable": {
+        "metadata": {
+          "label": "Result",
+          "description": "Name of the result variable"
+        },
+        "types": [
+          {
+            "fieldType": "IDENTIFIER",
+            "selected": false
+          }
+        ],
+        "value": "var1",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "modified": false
+      },
+      "checkError": {
+        "metadata": {
+          "label": "Check Error",
+          "description": "Trigger error flow"
+        },
+        "types": [
+          {
+            "fieldType": "FLAG",
+            "selected": true
+          }
+        ],
+        "value": true,
+        "optional": false,
+        "editable": true,
+        "advanced": true,
+        "hidden": true,
+        "modified": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "import ballerina/http;"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 8
+          },
+          "end": {
+            "line": 3,
+            "character": 8
+          }
+        },
+        "newText": "\nanydata var1 = check httpClient->get(\"foo\", {Header1: \"Header1Value\", Header2: \"Header2Value\"});"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Purpose
Fixes : Adds back end support for https://github.com/wso2/product-integrator/issues/735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request addresses handling of union types that include map and nil members in property configurations.

### Changes

**Core Logic Update (`Property.java`)**
- Modified the `handleMapValue` method to improve type resolution for map-based properties
- Introduced a `matchedMapType` variable that more robustly selects the appropriate map type subtype
- When subtype matching is available, the logic uses the first matching candidate; when subtype matching is unavailable (due to missing or compilation-error inference), it defaults to the first candidate map type instead of leaving it unset
- This change prevents incomplete type handling and ensures consistent property type resolution

**Test Configuration Updates**
- Updated test resources (`resource_action_call-http-get1.json` and `resource_action_call-http-post1.json`) to reflect the improved map type handling
- Changed map property selection state from disabled to enabled (`"selected": false` → `"selected": true`)
- Restructured map value representations from stringified formats to properly typed object structures with explicit type metadata for each map entry
- These updates ensure test configurations align with the corrected type handling behavior

### Impact
The changes improve the reliability of property type resolution when dealing with union types containing map and nil members, enabling more accurate code generation and diagram representation in the flow model generator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->