### PR TITLE
Update the failing test cases

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -100,6 +100,7 @@ public class ConnectionActionProvider {
                 .create();
         this.cache = Caffeine.newBuilder()
                 .maximumSize(MAX_CACHE_SIZE)
+                .executor(Runnable::run)
                 .removalListener((String key, List<Item> value, RemovalCause cause) -> {
                     if (cause == RemovalCause.EXPLICIT && key != null) {
                         deleteFromDisk(key);
@@ -117,6 +118,7 @@ public class ConnectionActionProvider {
                 .create();
         this.cache = Caffeine.newBuilder()
                 .maximumSize(maxCacheSize)
+                .executor(Runnable::run)
                 .removalListener((String key, List<Item> value, RemovalCause cause) -> {
                     if (cause == RemovalCause.EXPLICIT && key != null) {
                         deleteFromDisk(key);

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/chunker_manager/config/chunkers.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/chunker_manager/config/chunkers.json
@@ -54,22 +54,6 @@
               "symbol": "init"
             },
             "enabled": true
-          },
-          {
-            "metadata": {
-              "label": "Devant Chunker",
-              "description": "Splits documents loaded by the `devant:BinaryDataLoader` into smaller chunks \nusing the Devant AI service.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.devant_1.0.2.png"
-            },
-            "codedata": {
-              "node": "CHUNKER",
-              "org": "ballerinax",
-              "module": "ai.devant",
-              "packageName": "ai.devant",
-              "object": "Chunker",
-              "symbol": "init"
-            },
-            "enabled": true
           }
         ]
       }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_loader_manager/config/data_loaders.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_loader_manager/config/data_loaders.json
@@ -22,22 +22,6 @@
               "symbol": "init"
             },
             "enabled": true
-          },
-          {
-            "metadata": {
-              "label": "Devant Binary Data Loader",
-              "description": "Loads documents as `ai:BinaryDocument` instances from a specified file or directory path.\nThis loader can handle either a single file or a directory containing multiple files.\nTypically used in conjunction with `devant:Chunker` to split documents into chunks for processing.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.devant_1.0.2.png"
-            },
-            "codedata": {
-              "node": "DATA_LOADER",
-              "org": "ballerinax",
-              "module": "ai.devant",
-              "packageName": "ai.devant",
-              "object": "BinaryDataLoader",
-              "symbol": "init"
-            },
-            "enabled": true
           }
         ]
       }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/embedding_providers.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/embedding_providers.json
@@ -58,7 +58,7 @@
             "metadata": {
               "label": "OpenAI Embedding Provider",
               "description": "EmbeddingProvider provides an interface for interacting with OpenAI Embedding Models.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.openai_1.3.1.png"
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.openai_1.3.2.png"
             },
             "codedata": {
               "node": "EMBEDDING_PROVIDER",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/embedding_providers_search_openai.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/embedding_providers_search_openai.json
@@ -12,7 +12,7 @@
             "metadata": {
               "label": "OpenAI Embedding Provider",
               "description": "EmbeddingProvider provides an interface for interacting with OpenAI Embedding Models.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.openai_1.3.1.png"
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.openai_1.3.2.png"
             },
             "codedata": {
               "node": "EMBEDDING_PROVIDER",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/model_provider_manager/config/model_providers.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/model_provider_manager/config/model_providers.json
@@ -26,7 +26,7 @@
             "metadata": {
               "label": "Anthropic Model Provider",
               "description": "Provider is a client class that provides an interface for interacting with Anthropic Large Language Models.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.anthropic_1.3.1.png"
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.anthropic_1.3.2.png"
             },
             "codedata": {
               "node": "MODEL_PROVIDER",
@@ -106,7 +106,7 @@
             "metadata": {
               "label": "Ollama Model Provider",
               "description": "Provider represents a client for interacting with an Ollama language models.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.ollama_1.2.1.png"
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.ollama_1.2.2.png"
             },
             "codedata": {
               "node": "MODEL_PROVIDER",
@@ -122,7 +122,7 @@
             "metadata": {
               "label": "OpenAI Model Provider",
               "description": "ModelProvider is a client class that provides an interface for interacting with OpenAI Large Language Models.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.openai_1.3.1.png"
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.openai_1.3.2.png"
             },
             "codedata": {
               "node": "MODEL_PROVIDER",


### PR DESCRIPTION
## Purpose
$title. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Update test fixtures to fix failing tests:
  - Removed deprecated entries from test configs:
    - chunkers.json: removed the “Devant Chunker” item.
    - data_loaders.json: removed the “Devant Binary Data Loader” item.
  - Updated provider icon references in test configs:
    - embedding_providers.json and embedding_providers_search_openai.json: bumped OpenAI icon from 1.3.1 → 1.3.2.
    - model_providers.json: bumped icons for Anthropic (1.3.1 → 1.3.2), Ollama (1.2.1 → 1.2.2), and OpenAI (1.3.1 → 1.3.2).

- Internal runtime/config change:
  - flow-model-generator-core: ConnectionActionProvider — set Caffeine cache executor to Runnable::run for two caches to run cache tasks/removal listeners on the calling thread (adjusts execution context for cache operations).

Intent: tidy test resources and adjust cache execution behavior to improve test stability and predictability; no public API or exported signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->