### PR TITLE
Implement project eviction on last close in workspace manager

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -113,6 +113,12 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         return this.client;
     }
 
+    public void setEvictProjectOnLastClose(boolean enabled) {
+        if (workspaceManagerProxy instanceof BallerinaWorkspaceManagerProxyImpl ballerinaWorkspaceManagerProxy) {
+            ballerinaWorkspaceManagerProxy.setEvictProjectOnLastClose(enabled);
+        }
+    }
+
     @Override
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
         final InitializeResult res = new InitializeResult(new ServerCapabilities());

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -141,9 +141,11 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
      */
     private BuildOptions buildOptions;
 
+    private boolean evictProjectOnLastClose;
+
     protected final LSClientLogger clientLogger;
     private final LanguageServerContext serverContext;
-    private final Set<Path> openedDocuments = new HashSet<>();
+    private final Set<Path> openedDocuments = ConcurrentHashMap.newKeySet();
 
     public BallerinaWorkspaceManager(LanguageServerContext serverContext) {
         this.serverContext = serverContext;
@@ -846,6 +848,10 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         this.buildOptions = buildOptions;
     }
 
+    void setEvictProjectOnLastClose(boolean evictProjectOnLastClose) {
+        this.evictProjectOnLastClose = evictProjectOnLastClose;
+    }
+
     private Optional<ProjectContext> projectOfWatchedFileChange(Path filePath, FileEvent fileEvent,
                                                                 boolean isBallerinaSourceChange,
                                                                 boolean isBallerinaTomlChange,
@@ -1489,9 +1495,9 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         if (project.isEmpty()) {
             return;
         }
-        // If it is a single file project, remove project from mapping
-        if (project.get().kind() == ProjectKind.SINGLE_FILE_PROJECT) {
-            Path projectRoot = project.get().sourceRoot();
+        Path projectRoot = project.get().sourceRoot();
+        if (project.get().kind() == ProjectKind.SINGLE_FILE_PROJECT
+                || (this.evictProjectOnLastClose && !hasOpenDocuments(projectRoot))) {
             sourceRootToProject.remove(projectRoot);
             clientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CLOSE.getName() +
                     "' {project: '" + projectRoot.toUri().toString() +
@@ -1521,6 +1527,12 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         }
 
         return ProjectPaths.packageRoot(path);
+    }
+
+    private boolean hasOpenDocuments(Path projectRoot) {
+        return this.openedDocuments.stream()
+                .map(this::projectRoot)
+                .anyMatch(projectRoot::equals);
     }
 
     private Optional<ProjectContext> projectContext(Path projectRoot) {

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
@@ -194,6 +194,10 @@ public class BallerinaWorkspaceManagerProxyImpl implements BallerinaWorkspaceMan
         this.clonedWorkspaceManager.setBuildOptions(buildOptions);
     }
 
+    public void setEvictProjectOnLastClose(boolean enabled) {
+        ((BallerinaWorkspaceManager) this.baseWorkspaceManager).setEvictProjectOnLastClose(enabled);
+    }
+
     private boolean isExprScheme(String uri) {
         return PathUtil.getEncodedURIPath(uri).getScheme().equals(CommonUtil.EXPR_SCHEME);
     }

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestWorkspaceManager.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestWorkspaceManager.java
@@ -917,6 +917,38 @@ public class TestWorkspaceManager {
                 "Package B project should still exist");
     }
 
+    @Test(description = "Test last-close eviction removes only the matching workspace package")
+    public void testDocumentLifecycleWithLastCloseEviction() throws WorkspaceDocumentException {
+        Path workspaceProjectsPath = RESOURCE_DIRECTORY.resolve("workspace-projects");
+        Path packageAFile = workspaceProjectsPath.resolve("simple-workspace")
+                .resolve("package-a").resolve("main.bal").toAbsolutePath();
+        Path packageAUtilsFile = workspaceProjectsPath.resolve("simple-workspace")
+                .resolve("package-a").resolve("modules").resolve("utils").resolve("utils.bal").toAbsolutePath();
+        Path packageBFile = workspaceProjectsPath.resolve("simple-workspace")
+                .resolve("package-b").resolve("main.bal").toAbsolutePath();
+        workspaceManager.setEvictProjectOnLastClose(true);
+
+        openFile(packageAFile);
+        openFile(packageAUtilsFile);
+        openFile(packageBFile);
+
+        DidCloseTextDocumentParams closePackageAMainParams = new DidCloseTextDocumentParams();
+        closePackageAMainParams.setTextDocument(new TextDocumentIdentifier(packageAFile.toUri().toString()));
+        workspaceManager.didClose(packageAFile, closePackageAMainParams);
+
+        Assert.assertTrue(workspaceManager.project(packageAFile).isPresent(),
+                "Package A project should remain while another package A document is open");
+
+        DidCloseTextDocumentParams closePackageAUtilsParams = new DidCloseTextDocumentParams();
+        closePackageAUtilsParams.setTextDocument(new TextDocumentIdentifier(packageAUtilsFile.toUri().toString()));
+        workspaceManager.didClose(packageAUtilsFile, closePackageAUtilsParams);
+
+        Assert.assertTrue(workspaceManager.project(packageAFile).isEmpty(),
+                "Package A project should be evicted after its last open document closes");
+        Assert.assertTrue(workspaceManager.project(packageBFile).isPresent(),
+                "Package B project should remain loaded after evicting package A");
+    }
+
     /**
      * Test module access within workspace project.
      */

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/AbstractLSTest.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/AbstractLSTest.java
@@ -82,6 +82,7 @@ public abstract class AbstractLSTest {
         }
         log = LoggerFactory.getLogger(clazz());
         this.languageServer = new BallerinaLanguageServer();
+        this.languageServer.setEvictProjectOnLastClose(true);
         TestUtil.LanguageServerBuilder builder = TestUtil.newLanguageServer().withLanguageServer(languageServer);
         this.serviceEndpoint = builder.build();
     }
@@ -431,6 +432,7 @@ public abstract class AbstractLSTest {
             return;
         }
         this.languageServer = new BallerinaLanguageServer();
+        this.languageServer.setEvictProjectOnLastClose(true);
         TestUtil.LanguageServerBuilder builder = TestUtil.newLanguageServer().withLanguageServer(languageServer);
         this.serviceEndpoint = builder.build();
     }


### PR DESCRIPTION
## Purpose

$title to reduce the likelihood of OOM when running tests. This change only affects the test environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Purpose: reduce test OOMs by evicting projects when they are closed for the last time (change scoped to the test environment).
- API/config:
  - Added public method BallerinaLanguageServer.setEvictProjectOnLastClose(boolean) to allow enabling the behavior.
  - Added package-private flag and setter in BallerinaWorkspaceManager: evictProjectOnLastClose.
  - Added forwarding method in BallerinaWorkspaceManagerProxyImpl that forwards the flag to the base workspace manager.
  - Tests and test harness enable the flag (AbstractLSTest and a new TestWorkspaceManager test).
- Implementation:
  - When enabled, didClose(...) will evict non-single-file projects if the closed document was the last open document for that project; single-file projects are still always removed.
  - Replaced the non-thread-safe openedDocuments set with a concurrent set (ConcurrentHashMap.newKeySet()) and added hasOpenDocuments(Path) to check remaining open documents for a project.
- Tests:
  - Added testDocumentLifecycleWithLastCloseEviction() asserting correct eviction behavior across multiple documents and packages.
- Scope and impact:
  - Change is intended to improve stability of test runs by lowering memory usage; confined to test-related initialization and wiring. No other runtime request/response logic or lifecycle initialization was altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->