### PR TITLE
Restrict connection action caching to ballerina/ballerinax organizations

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -78,6 +78,8 @@ public class ConnectionActionProvider {
 
     private static final int MAX_CACHE_SIZE = 25;
     private static final String CACHE_DIR_NAME = "ballerina-ls-connector-cache";
+    private static final String BALLERINA_ORG = "ballerina";
+    private static final String BALLERINAX_ORG = "ballerinax";
     private static final String HTTP_MODULE = "http";
     private static final List<String> HTTP_REMOTE_METHOD_SKIP_LIST = List.of("get", "put", "post", "head",
             "delete", "patch", "options");
@@ -200,6 +202,9 @@ public class ConnectionActionProvider {
     }
 
     private List<Item> getOrBuildTemplates(ConnectorContext context) {
+        if (!context.cacheable()) {
+            return buildTemplates(context, context.project());
+        }
         return getOrBuild(context.cacheKey(), () -> buildTemplates(context, context.project()));
     }
 
@@ -210,9 +215,11 @@ public class ConnectionActionProvider {
                 .orElseThrow();
         Package resolvedPackage = resolvePackage(moduleInfo, project).orElse(null);
         boolean persistClient = isPersistClient(classSymbol, semanticModel);
+        String cacheKey = generateKey(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.moduleName(), className,
+                moduleInfo.version());
+        boolean cacheable = BALLERINA_ORG.equals(moduleInfo.org()) || BALLERINAX_ORG.equals(moduleInfo.org());
         return new ConnectorContext(
-                generateKey(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.moduleName(), className,
-                        moduleInfo.version()),
+                cacheKey,
                 classSymbol,
                 className,
                 moduleInfo,
@@ -220,7 +227,8 @@ public class ConnectionActionProvider {
                 isAiKnowledgeBase(classSymbol),
                 isAgentClass(classSymbol),
                 persistClient ? getPersistDatabaseIcon(classSymbol).orElse(null) : null,
-                project
+                project,
+                cacheable
         );
     }
 
@@ -234,10 +242,7 @@ public class ConnectionActionProvider {
             return null;
         }
         Optional<ClassSymbol> classSymbol = resolveClassSymbol(semanticModel, codedata.object());
-        if (classSymbol.isEmpty()) {
-            return null;
-        }
-        return createContext(classSymbol.get(), project, semanticModel);
+        return classSymbol.map(symbol -> createContext(symbol, project, semanticModel)).orElse(null);
     }
 
     private List<Item> buildTemplates(ConnectorContext context, Project project) {
@@ -302,7 +307,7 @@ public class ConnectionActionProvider {
                     .buildAvailableNode();
             methods.add(node);
         }
-        return methods;
+        return List.copyOf(methods);
     }
 
     private List<Item> bindParentSymbol(List<Item> cachedMethods, String parentSymbolName,
@@ -472,7 +477,7 @@ public class ConnectionActionProvider {
 
     private record ConnectorContext(String cacheKey, ClassSymbol classSymbol, String className, ModuleInfo moduleInfo,
                                     Package resolvedPackage, boolean knowledgeBase, boolean agentClass,
-                                    String iconOverride, Project project) {
+                                    String iconOverride, Project project, boolean cacheable) {
     }
 
     // Exposed for core tests: getOrBuild using Caffeine atomic loading

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -252,7 +252,6 @@ public class ConnectionActionProvider {
                 .project(project)
                 .moduleInfo(context.moduleInfo())
                 .resolvedPackage(context.resolvedPackage())
-                .enableIndex()
                 .buildChildNodes();
 
         List<Item> methods = new ArrayList<>();

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -64,6 +64,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.ballerina.flowmodelgenerator.core.Constants.BALLERINA;
+import static io.ballerina.flowmodelgenerator.core.Constants.BALLERINAX;
 import static io.ballerina.modelgenerator.commons.CommonUtils.getPersistDatabaseIcon;
 import static io.ballerina.modelgenerator.commons.CommonUtils.isAgentClass;
 import static io.ballerina.modelgenerator.commons.CommonUtils.isAiKnowledgeBase;
@@ -78,8 +79,6 @@ public class ConnectionActionProvider {
 
     private static final int MAX_CACHE_SIZE = 25;
     private static final String CACHE_DIR_NAME = "ballerina-ls-connector-cache";
-    private static final String BALLERINA_ORG = "ballerina";
-    private static final String BALLERINAX_ORG = "ballerinax";
     private static final String HTTP_MODULE = "http";
     private static final List<String> HTTP_REMOTE_METHOD_SKIP_LIST = List.of("get", "put", "post", "head",
             "delete", "patch", "options");
@@ -201,11 +200,15 @@ public class ConnectionActionProvider {
                 sanitizeSegment(version));
     }
 
-    private List<Item> getOrBuildTemplates(ConnectorContext context) {
+    List<Item> getOrBuildTemplates(ConnectorContext context) {
+        return getOrBuildTemplates(context, () -> buildTemplates(context, context.project()));
+    }
+
+    List<Item> getOrBuildTemplates(ConnectorContext context, SupplierFn<List<Item>> supplier) {
         if (!context.cacheable()) {
-            return buildTemplates(context, context.project());
+            return supplier.get();
         }
-        return getOrBuild(context.cacheKey(), () -> buildTemplates(context, context.project()));
+        return getOrBuild(context.cacheKey(), supplier);
     }
 
     private ConnectorContext createContext(ClassSymbol classSymbol, Project project, SemanticModel semanticModel) {
@@ -217,7 +220,7 @@ public class ConnectionActionProvider {
         boolean persistClient = isPersistClient(classSymbol, semanticModel);
         String cacheKey = generateKey(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.moduleName(), className,
                 moduleInfo.version());
-        boolean cacheable = BALLERINA_ORG.equals(moduleInfo.org()) || BALLERINAX_ORG.equals(moduleInfo.org());
+        boolean cacheable = BALLERINA.equals(moduleInfo.org()) || BALLERINAX.equals(moduleInfo.org());
         return new ConnectorContext(
                 cacheKey,
                 classSymbol,
@@ -474,9 +477,9 @@ public class ConnectionActionProvider {
         private static final ConnectionActionProvider INSTANCE = new ConnectionActionProvider();
     }
 
-    private record ConnectorContext(String cacheKey, ClassSymbol classSymbol, String className, ModuleInfo moduleInfo,
-                                    Package resolvedPackage, boolean knowledgeBase, boolean agentClass,
-                                    String iconOverride, Project project, boolean cacheable) {
+    record ConnectorContext(String cacheKey, ClassSymbol classSymbol, String className, ModuleInfo moduleInfo,
+                            Package resolvedPackage, boolean knowledgeBase, boolean agentClass,
+                            String iconOverride, Project project, boolean cacheable) {
     }
 
     // Exposed for core tests: getOrBuild using Caffeine atomic loading

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
@@ -73,7 +73,7 @@ public class ConnectionActionProviderTest {
 
     @Test(description = "Verifies a built entry is reused from memory without rebuilding on a second lookup.")
     public void testBuildCachesInMemory() {
-        String key = "cache-hit";
+        String key = "ballerina:http:http:Client:cache-hit";
         AtomicInteger buildCount = new AtomicInteger();
         List<Item> expected = List.of(availableNode("listPets", null, null));
 
@@ -91,9 +91,29 @@ public class ConnectionActionProviderTest {
         Assert.assertEquals(second, expected);
     }
 
+    @Test(description = "Verifies non-ballerina connector entries bypass memory and disk cache.")
+    public void testNonBallerinaPackagesBypassMemoryAndDiskCache() {
+        String key = "acme:local_cache_test:local_cache_test:LocalClient:0.1.0";
+        AtomicInteger buildCount = new AtomicInteger();
+
+        List<Item> first = provider.getOrBuild(key, () -> {
+            buildCount.incrementAndGet();
+            return List.of(availableNode("ping", null, null));
+        });
+        List<Item> second = provider.getOrBuild(key, () -> {
+            buildCount.incrementAndGet();
+            return List.of(availableNode("pong", null, null));
+        });
+
+        Assert.assertEquals(buildCount.get(), 2);
+        Assert.assertEquals(first, List.of(availableNode("ping", null, null)));
+        Assert.assertEquals(second, List.of(availableNode("pong", null, null)));
+        Assert.assertFalse(Files.exists(provider.cacheFilePath(key)));
+    }
+
     @Test(description = "Verifies a persisted cache entry is reloaded from disk by a fresh provider instance.")
     public void testCachePersistsToDiskAndLoadsFromFreshProvider() {
-        String key = "disk-hit";
+        String key = "ballerina:http:http:Client:disk-hit";
         AtomicInteger buildCount = new AtomicInteger();
         List<Item> expected = List.of(availableNode("createOrder", null, null));
 
@@ -119,7 +139,7 @@ public class ConnectionActionProviderTest {
 
     @Test(description = "Verifies an unreadable cache file is treated as a miss and rebuilt successfully.")
     public void testCorruptDiskFileTriggersRebuild() throws IOException {
-        String key = "corrupt-entry";
+        String key = "ballerina:http:http:Client:corrupt-entry";
         Files.createDirectories(tempDir);
         Files.writeString(provider.cacheFilePath(key), "{ not-json");
 
@@ -138,7 +158,7 @@ public class ConnectionActionProviderTest {
 
     @Test(description = "Verifies explicit invalidation removes the corresponding persisted cache file.")
     public void testInvalidateDeletesDiskFile() {
-        String key = "invalidate";
+        String key = "ballerina:http:http:Client:invalidate";
         provider.getOrBuild(key, () -> List.of(availableNode("deleteCache", null, null)));
         Path cacheFile = provider.cacheFilePath(key);
 
@@ -154,19 +174,21 @@ public class ConnectionActionProviderTest {
         ConnectionActionProvider sizeBoundProvider = new ConnectionActionProvider(tempDir, 1);
         try {
             AtomicInteger buildCount = new AtomicInteger();
-            sizeBoundProvider.getOrBuild("one", () -> {
+            String firstKey = "ballerina:http:http:Client:one";
+            String secondKey = "ballerina:http:http:Client:two";
+            sizeBoundProvider.getOrBuild(firstKey, () -> {
                 buildCount.incrementAndGet();
                 return List.of(availableNode("one", null, null));
             });
-            sizeBoundProvider.getOrBuild("two", () -> {
+            sizeBoundProvider.getOrBuild(secondKey, () -> {
                 buildCount.incrementAndGet();
                 return List.of(availableNode("two", null, null));
             });
             sizeBoundProvider.cleanUp();
 
-            Assert.assertTrue(Files.exists(sizeBoundProvider.cacheFilePath("one")));
+            Assert.assertTrue(Files.exists(sizeBoundProvider.cacheFilePath(firstKey)));
 
-            List<Item> reloaded = sizeBoundProvider.getOrBuild("one", () -> {
+            List<Item> reloaded = sizeBoundProvider.getOrBuild(firstKey, () -> {
                 buildCount.incrementAndGet();
                 return List.of(availableNode("should-not-build", null, null));
             });
@@ -180,7 +202,7 @@ public class ConnectionActionProviderTest {
 
     @Test(description = "Verifies nested Item implementations serialize and deserialize correctly through Gson.")
     public void testPolymorphicSerializationRoundTrip() {
-        String key = "polymorphic";
+        String key = "ballerina:http:http:Client:polymorphic";
         List<Item> expected = List.of(new Category(
                 new Metadata("Connections", "Connector actions", null, null, null, null),
                 List.of(availableNode("query", null, null), availableNode("close", null, null))));
@@ -201,7 +223,7 @@ public class ConnectionActionProviderTest {
 
     @Test(description = "Verifies parent-symbol rebinding returns caller-specific nodes without mutating templates.")
     public void testBindForParentSymbolDoesNotMutateCachedTemplates() {
-        String key = "binding";
+        String key = "ballerina:http:http:Client:binding";
         List<Item> templates = provider.getOrBuild(key, () -> List.of(availableNode("invoke", null, null)));
 
         List<Item> firstBound = provider.bindForParentSymbol(templates, "clientA", Map.of("invoke", true));
@@ -225,7 +247,7 @@ public class ConnectionActionProviderTest {
         try {
             List<Item> expected = List.of(availableNode("memoryOnly", null, null));
 
-            List<Item> actual = invalidProvider.getOrBuild("memory-only", () -> expected);
+            List<Item> actual = invalidProvider.getOrBuild("ballerina:http:http:Client:memory-only", () -> expected);
 
             Assert.assertEquals(actual, expected);
             Assert.assertFalse(Files.isDirectory(invalidCacheRoot));
@@ -237,7 +259,7 @@ public class ConnectionActionProviderTest {
 
     @Test(description = "Verifies concurrent requests for the same missing key trigger only one build.")
     public void testConcurrentMissBuildsOnce() throws InterruptedException, ExecutionException {
-        String key = "concurrent";
+        String key = "ballerina:http:http:Client:concurrent";
         ExecutorService executor = Executors.newFixedThreadPool(4);
         CountDownLatch ready = new CountDownLatch(4);
         CountDownLatch start = new CountDownLatch(1);

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
@@ -24,6 +24,7 @@ import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.flowmodelgenerator.core.model.Item;
 import io.ballerina.flowmodelgenerator.core.model.Metadata;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+import io.ballerina.modelgenerator.commons.ModuleInfo;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -91,16 +92,27 @@ public class ConnectionActionProviderTest {
         Assert.assertEquals(second, expected);
     }
 
-    @Test(description = "Verifies non-ballerina connector entries bypass memory and disk cache.")
-    public void testNonBallerinaPackagesBypassMemoryAndDiskCache() {
+    @Test(description = "Verifies non-cacheable connector contexts bypass memory and disk cache.")
+    public void testGetOrBuildCachesRegardlessOfOrg() {
         String key = "acme:local_cache_test:local_cache_test:LocalClient:0.1.0";
         AtomicInteger buildCount = new AtomicInteger();
+        ConnectionActionProvider.ConnectorContext context = new ConnectionActionProvider.ConnectorContext(
+                key,
+                null,
+                "LocalClient",
+                new ModuleInfo("acme", "local_cache_test", "local_cache_test", "0.1.0"),
+                null,
+                false,
+                false,
+                null,
+                null,
+                false);
 
-        List<Item> first = provider.getOrBuild(key, () -> {
+        List<Item> first = provider.getOrBuildTemplates(context, () -> {
             buildCount.incrementAndGet();
             return List.of(availableNode("ping", null, null));
         });
-        List<Item> second = provider.getOrBuild(key, () -> {
+        List<Item> second = provider.getOrBuildTemplates(context, () -> {
             buildCount.incrementAndGet();
             return List.of(availableNode("pong", null, null));
         });


### PR DESCRIPTION
## Purpose
Optimize the `ConnectionActionProvider` caching logic by restricting it to official Ballerina connectors (`ballerina` and `ballerinax`) to ensure functional correctness in the presence of local source changes.

Fixes https://github.com/wso2/product-integrator/issues/795

## Approach
- Introduced a `cacheable` check based on the organization name.
- Non-official connectors bypass both in-memory and disk caching.Builder` to streamline template generation.

## What Was Fixed / Changed
- Caching is now disabled for all third-party and local connectors.
- `ConnectionActionProvider` refactored to handle non-cacheable contexts.
- Improved null-safety and immutability in template building.

## Affected Components
- `flow-model-generator/modules/flow-model-generator-core`

## How Has This Been Tested
- Added `testNonBallerinaPackagesBypassMemoryAndDiskCache` to verify bypass logic.
- Updated existing tests in `ConnectionActionProviderTest` to use valid cacheable organizations.

## Remarks & Notes
- This is a tactical solution to preserve functionality. The current architecture lacks a robust mechanism to invalidate caches when source files are updated (manually or otherwise).
- While this prevents stale data, it is not the optimal long-term solution as the node palette will now trigger a rebuild for local connection actions on every request.
- Simple "local connection" checks are insufficient because users may use locally published packages or connectors within the same workspace project, both of which require bypassing the persistent cache to remain accurate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request restricts ConnectionActionProvider caching to official Ballerina organizations (`ballerina` and `ballerinax`) so that third-party and local connectors bypass both in-memory and persistent disk caches. The change ensures connection action generation reflects current connector sources and schema changes instead of returning stale cached results.

## Changes

- ConnectionActionProvider
  - Added organization checks and a `cacheable` flag in ConnectorContext; cacheKey is computed once and stored in the context.
  - getOrBuildTemplates now bypasses Caffeine and disk caching when `cacheable` is false, returning fresh results for non-official packages.
  - Context construction made more null-safe (using Optional-based flow) and template lists are made immutable before caching.
  - Removed `.enableIndex()` from FunctionDataBuilder.

- Tests
  - Added test validating that non-Ballerina packages bypass memory and disk caches and rebuild on each request (testNonBallerinaPackagesBypassMemoryAndDiskCache).
  - Updated ConnectionActionProviderTest to use fully qualified cache keys and to exercise cacheable organization behavior.
  - Exposed the template cache gate for package-level tests and added assertions ensuring non-cacheable lookups do not write disk cache entries.

## Impact

Addresses the issue where connection actions could become stale after connector or schema changes by scoping caching to official organizations. This is a tactical solution that favors correctness for local and third-party development workflows at the cost of rebuilding local connection actions on each request due to bypassing persistent cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->