### PR TITLE
Fix readonly intersection type handling issue

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
@@ -22,8 +22,11 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Documentation;
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
@@ -459,11 +462,34 @@ public class TypesManagerService implements ExtendedLanguageServerService {
                             packageName,
                             versionName));
                 }
-                if (typeSymbol.get() instanceof TypeSymbol tSymbol && tSymbol.typeKind() != TypeDescKind.RECORD) {
+                Symbol resolvedSymbol = typeSymbol.get();
+                TypeSymbol effectiveRecordSymbol = null;
+                String typeDefDocumentation = null;
+                if (resolvedSymbol instanceof TypeDefinitionSymbol typeDefinitionSymbol) {
+                    TypeSymbol descriptor = typeDefinitionSymbol.typeDescriptor();
+                    if (descriptor instanceof IntersectionTypeSymbol intersectionTypeSymbol
+                            && intersectionTypeSymbol.effectiveTypeDescriptor().typeKind() == TypeDescKind.RECORD) {
+                        effectiveRecordSymbol = intersectionTypeSymbol.effectiveTypeDescriptor();
+                        typeDefDocumentation = typeDefinitionSymbol.documentation()
+                                .flatMap(Documentation::description).orElse(null);
+                    } else if (descriptor.typeKind() != TypeDescKind.RECORD) {
+                        throw new IllegalArgumentException(
+                                String.format("Type '%s' is not a record", request.typeConstraint()));
+                    }
+                } else if (resolvedSymbol instanceof TypeSymbol tSymbol && tSymbol.typeKind() != TypeDescKind.RECORD) {
                     throw new IllegalArgumentException(
                             String.format("Type '%s' is not a record", request.typeConstraint()));
                 }
-                response.setRecordConfig(Type.fromSemanticSymbol(typeSymbol.get(), semanticModel.get(), packageName));
+                Type recordConfig;
+                if (effectiveRecordSymbol != null) {
+                    recordConfig = Type.fromSemanticSymbol(effectiveRecordSymbol, semanticModel.get(), packageName);
+                    if (recordConfig != null && typeDefDocumentation != null) {
+                        recordConfig.documentation = typeDefDocumentation;
+                    }
+                } else {
+                    recordConfig = Type.fromSemanticSymbol(resolvedSymbol, semanticModel.get(), packageName);
+                }
+                response.setRecordConfig(recordConfig);
             } catch (Throwable e) {
                 response.setError(e);
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
@@ -28,6 +28,7 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
@@ -462,39 +463,57 @@ public class TypesManagerService implements ExtendedLanguageServerService {
                             packageName,
                             versionName));
                 }
-                Symbol resolvedSymbol = typeSymbol.get();
-                TypeSymbol effectiveRecordSymbol = null;
-                String typeDefDocumentation = null;
-                if (resolvedSymbol instanceof TypeDefinitionSymbol typeDefinitionSymbol) {
-                    TypeSymbol descriptor = typeDefinitionSymbol.typeDescriptor();
-                    if (descriptor instanceof IntersectionTypeSymbol intersectionTypeSymbol
-                            && intersectionTypeSymbol.effectiveTypeDescriptor().typeKind() == TypeDescKind.RECORD) {
-                        effectiveRecordSymbol = intersectionTypeSymbol.effectiveTypeDescriptor();
-                        typeDefDocumentation = typeDefinitionSymbol.documentation()
-                                .flatMap(Documentation::description).orElse(null);
-                    } else if (descriptor.typeKind() != TypeDescKind.RECORD) {
-                        throw new IllegalArgumentException(
-                                String.format("Type '%s' is not a record", request.typeConstraint()));
-                    }
-                } else if (resolvedSymbol instanceof TypeSymbol tSymbol && tSymbol.typeKind() != TypeDescKind.RECORD) {
-                    throw new IllegalArgumentException(
-                            String.format("Type '%s' is not a record", request.typeConstraint()));
-                }
-                Type recordConfig;
-                if (effectiveRecordSymbol != null) {
-                    recordConfig = Type.fromSemanticSymbol(effectiveRecordSymbol, semanticModel.get(), packageName);
-                    if (recordConfig != null && typeDefDocumentation != null) {
-                        recordConfig.documentation = typeDefDocumentation;
-                    }
-                } else {
-                    recordConfig = Type.fromSemanticSymbol(resolvedSymbol, semanticModel.get(), packageName);
-                }
+                Type recordConfig = buildRecordConfig(
+                        typeSymbol.get(), semanticModel.get(), packageName, request.typeConstraint());
                 response.setRecordConfig(recordConfig);
             } catch (Throwable e) {
                 response.setError(e);
             }
             return response;
         });
+    }
+
+    private static Type buildRecordConfig(Symbol symbol, SemanticModel semanticModel, String packageName,
+                                          String typeConstraint) {
+        String aliasDocumentation = null;
+        TypeSymbol descriptor = null;
+        if (symbol instanceof TypeDefinitionSymbol typeDefinitionSymbol) {
+            aliasDocumentation = typeDefinitionSymbol.documentation()
+                    .flatMap(Documentation::description).orElse(null);
+            descriptor = typeDefinitionSymbol.typeDescriptor();
+        } else if (symbol instanceof TypeSymbol typeSymbol) {
+            descriptor = typeSymbol;
+        }
+
+        TypeSymbol recordSymbol = descriptor == null ? null : resolveRecordTypeSymbol(descriptor);
+        if (recordSymbol == null) {
+            throw new IllegalArgumentException(
+                    String.format("Type '%s' is not a record", typeConstraint));
+        }
+
+        Type recordConfig = Type.fromSemanticSymbol(recordSymbol, semanticModel, packageName);
+        if (recordConfig != null && aliasDocumentation != null
+                && descriptor.typeKind() != TypeDescKind.RECORD) {
+            recordConfig.documentation = aliasDocumentation;
+        }
+        return recordConfig;
+    }
+
+    private static TypeSymbol resolveRecordTypeSymbol(TypeSymbol typeSymbol) {
+        TypeSymbol current = typeSymbol;
+        while (current != null) {
+            if (current.typeKind() == TypeDescKind.RECORD) {
+                return current;
+            }
+            if (current instanceof TypeReferenceTypeSymbol typeRef) {
+                current = typeRef.typeDescriptor();
+            } else if (current instanceof IntersectionTypeSymbol intersection) {
+                current = intersection.effectiveTypeDescriptor();
+            } else {
+                return null;
+            }
+        }
+        return null;
     }
 
     @JsonRequest

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
@@ -485,15 +485,25 @@ public class TypesManagerService implements ExtendedLanguageServerService {
             descriptor = typeSymbol;
         }
 
-        TypeSymbol recordSymbol = descriptor == null ? null : resolveRecordTypeSymbol(descriptor);
+        if (descriptor == null) {
+            throw new IllegalArgumentException(
+                    String.format("Type '%s' is not a record", typeConstraint));
+        }
+
+        // Direct record: pass the original symbol so Type.fromSemanticSymbol can read
+        // field/type-def documentation from the TypeDefinitionSymbol.
+        if (descriptor.typeKind() == TypeDescKind.RECORD) {
+            return Type.fromSemanticSymbol(symbol, semanticModel, packageName);
+        }
+
+        TypeSymbol recordSymbol = resolveRecordTypeSymbol(descriptor);
         if (recordSymbol == null) {
             throw new IllegalArgumentException(
                     String.format("Type '%s' is not a record", typeConstraint));
         }
 
         Type recordConfig = Type.fromSemanticSymbol(recordSymbol, semanticModel, packageName);
-        if (recordConfig != null && aliasDocumentation != null
-                && descriptor.typeKind() != TypeDescKind.RECORD) {
+        if (recordConfig != null && aliasDocumentation != null) {
             recordConfig.documentation = aliasDocumentation;
         }
         return recordConfig;

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
@@ -84,10 +84,12 @@ import org.eclipse.lsp4j.services.LanguageServer;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -511,7 +513,8 @@ public class TypesManagerService implements ExtendedLanguageServerService {
 
     private static TypeSymbol resolveRecordTypeSymbol(TypeSymbol typeSymbol) {
         TypeSymbol current = typeSymbol;
-        while (current != null) {
+        Set<TypeSymbol> visited = new HashSet<>();
+        while (current != null && visited.add(current)) {
             if (current.typeKind() == TypeDescKind.RECORD) {
                 return current;
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/config/config5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/config/config5.json
@@ -1,0 +1,49 @@
+{
+  "filePath": "proj",
+  "description": "Returns a flat record for a `readonly & record{}` intersection type.",
+  "codedata": {
+    "org": "org",
+    "module": "source",
+    "packageName": "source",
+    "version": "0.3.0"
+  },
+  "typeConstraint": "ServerConfig",
+  "output": {
+    "fields": [
+      {
+        "name": "host",
+        "typeName": "string",
+        "optional": false,
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      },
+      {
+        "name": "port",
+        "typeName": "int",
+        "optional": false,
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      },
+      {
+        "name": "apiKey",
+        "typeName": "string",
+        "optional": false,
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      }
+    ],
+    "hasRestType": false,
+    "typeName": "record",
+    "optional": false,
+    "defaultable": false,
+    "documentation": "Immutable server configuration used to connect to a remote endpoint.\nCredentials are shared across callers and must not be mutated.",
+    "isRestType": false,
+    "selected": false
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/config/config6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/config/config6.json
@@ -1,0 +1,49 @@
+{
+  "filePath": "proj",
+  "description": "Returns a flat record for a `readonly & <typeRef>` intersection that references another record type.",
+  "codedata": {
+    "org": "org",
+    "module": "source",
+    "packageName": "source",
+    "version": "0.3.0"
+  },
+  "typeConstraint": "SpecializedConfig",
+  "output": {
+    "fields": [
+      {
+        "name": "host",
+        "typeName": "string",
+        "optional": false,
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      },
+      {
+        "name": "port",
+        "typeName": "int",
+        "optional": false,
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      },
+      {
+        "name": "apiKey",
+        "typeName": "string",
+        "optional": false,
+        "defaultable": false,
+        "documentation": "",
+        "isRestType": false,
+        "selected": false
+      }
+    ],
+    "hasRestType": false,
+    "typeName": "record",
+    "optional": false,
+    "defaultable": false,
+    "documentation": "Immutable server configuration used to connect to a remote endpoint.\nCredentials are shared across callers and must not be mutated.",
+    "isRestType": false,
+    "selected": false
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/proj/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/proj/types.bal
@@ -22,6 +22,10 @@ type Employee record {|
 
 # Immutable server configuration used to connect to a remote endpoint.
 # Credentials are shared across callers and must not be mutated.
+type SpecializedConfig readonly & ServerConfig;
+
+# Immutable server configuration used to connect to a remote endpoint.
+# Credentials are shared across callers and must not be mutated.
 type ServerConfig readonly & record {|
     string host;
     int port;

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/proj/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/record_config/source/proj/types.bal
@@ -19,3 +19,11 @@ type Employee record {|
     decimal salary;
     EmployeeLog...;
 |};
+
+# Immutable server configuration used to connect to a remote endpoint.
+# Credentials are shared across callers and must not be mutated.
+type ServerConfig readonly & record {|
+    string host;
+    int port;
+    string apiKey;
+|};


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-integrator/issues/710

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
This has handled only the specific case where the readonly and type intersection resolution for the typesManager/recordConfig api but for other cases and the intersection handling needs to be properly discussed

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request fixes incorrect handling of readonly intersection types in the flow model generator's record configuration logic. It ensures record shapes wrapped in a readonly intersection (e.g., readonly & record or readonly & TypeAlias) are correctly resolved, validated, and included in the generated configuration output so downstream consumers can expose the correct fields.

## Changes

- TypesManagerService.java
  - Refactored recordConfig to delegate record resolution to a new buildRecordConfig helper.
  - Added resolution logic that:
    - Unwraps TypeDefinitionSymbol aliases to preserve alias documentation while resolving the underlying type descriptor.
    - Traverses TypeReferenceTypeSymbol and IntersectionTypeSymbol (using effectiveTypeDescriptor) to locate an underlying record TypeSymbol.
    - Protects against cycles using a visited HashSet during traversal.
  - Applies extracted alias documentation to the resulting Type where appropriate.
  - Preserves previous validation behavior for non-record types and preserves compatibility for existing flows.

- Tests / Resources
  - Added a new immutable record type and a readonly intersection alias in test sources (types.bal): ServerConfig and SpecializedConfig (readonly & ServerConfig).
  - Added corresponding test configuration JSON files (config5.json and config6.json) to validate generation of immutable record outputs for readonly & record and readonly & type-alias intersection scenarios.

## Outcome

This change addresses the rendering issue where readonly record branches inside unions were not exposing their fields in the model provider. With proper intersection resolution and alias documentation preservation, the model provider and downstream UI can present and populate branch-specific record fields correctly. Broader intersection-handling scenarios remain to be discussed and addressed in follow-up work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->