### PR TITLE
Preserve order of type inferred params in property list

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -2218,6 +2218,9 @@ public class CodeAnalyzer extends NodeVisitor {
                 // Derive the inferred type from the variable type
                 Optional<Symbol> symbol = semanticModel.symbol(typedBindingPatternNode);
                 if (symbol.isEmpty() || symbol.get().kind() != SymbolKind.VARIABLE) {
+                    // Drop the reserved slot so the placeholder doesn't leak into the output.
+                    nodeBuilder.properties()
+                            .removeProperty(ParamUtils.removeLeadingSingleQuote(paramResult.name()));
                     return;
                 }
                 targetVarType = ((VariableSymbol) symbol.get()).typeDescriptor();

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -2187,6 +2187,10 @@ public class CodeAnalyzer extends NodeVisitor {
 
             if (paramResult.kind() == ParameterData.Kind.PARAM_FOR_TYPE_INFER) {
                 typeInferParamMap.put(key, paramResult);
+                // Reserve the slot at its signature position so the later emission (which happens
+                // after regular args and checkError) lands here instead of being appended.
+                nodeBuilder.properties()
+                        .reserveProperty(ParamUtils.removeLeadingSingleQuote(paramResult.name()));
                 return;
             }
 

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -1444,6 +1444,18 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
     }
 
     /**
+     * Removes a previously reserved slot when the caller decides not to emit a real Property under
+     * this key — prevents an empty placeholder from leaking into the serialized node properties.
+     *
+     * @param key the property key to drop
+     * @return this builder for fluent chaining
+     */
+    public final FormBuilder<T> removeProperty(String key) {
+        this.nodeProperties.remove(key);
+        return this;
+    }
+
+    /**
      * Bulk-adds all entries from the given map into the node properties, skipping the operation silently
      * if the map is {@code null}. Existing properties with the same key will be overwritten.
      *

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -1430,6 +1430,20 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
     }
 
     /**
+     * Reserves a slot in the node properties map for the given key so that a subsequent
+     * {@code addProperty(key, ...)} call preserves the originally reserved position (LinkedHashMap
+     * retains insertion order across put-overwrites of an existing key). No-op if the key is already
+     * present.
+     *
+     * @param key the property key whose source-code position should be locked in
+     * @return this builder for fluent chaining
+     */
+    public final FormBuilder<T> reserveProperty(String key) {
+        this.nodeProperties.putIfAbsent(key, new Property.Builder<>(null).build());
+        return this;
+    }
+
+    /**
      * Bulk-adds all entries from the given map into the node properties, skipping the operation silently
      * if the map is {@code null}. Existing properties with the same key will be overwritten.
      *

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ResourceActionCallBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ResourceActionCallBuilder.java
@@ -40,7 +40,6 @@ import org.eclipse.lsp4j.TextEdit;
 
 import java.nio.file.Path;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -183,12 +182,6 @@ public class ResourceActionCallBuilder extends CallBuilder {
         Set<String> ignoredKeysOtherThanTargetType = new HashSet<>(ignoredKeys);
         ignoredKeysOtherThanTargetType.remove(TARGET_TYPE_KEY);
 
-        // Persist-generated resource functions place the inferred-typedesc `targetType` parameter at signature
-        // position 0, but the property map has it near the end. Move it to the front so that SourceBuilder's
-        // missedDefaultValue bookkeeping fires before later defaultable args (e.g. whereClause) and they are
-        // emitted as named arguments, otherwise they would slide into the skipped typedesc slot.
-        FlowNode reorderedFlowNode = withTargetTypeFirst(flowNode);
-
         return sourceBuilder.token()
                 .name(connection.get().toSourceCode())
                 .keyword(SyntaxKind.RIGHT_ARROW_TOKEN)
@@ -196,26 +189,10 @@ public class ResourceActionCallBuilder extends CallBuilder {
                 .keyword(SyntaxKind.DOT_TOKEN)
                 .name(sourceBuilder.flowNode.codedata().symbol())
                 .stepOut()
-                .functionParameters(reorderedFlowNode, ignoredKeysOtherThanTargetType)
+                .functionParameters(flowNode, ignoredKeysOtherThanTargetType)
                 .textEdit()
                 .acceptImportWithVariableType()
                 .build();
-    }
-
-    private static FlowNode withTargetTypeFirst(FlowNode flowNode) {
-        Map<String, Property> properties = flowNode.properties();
-        if (properties == null || !properties.containsKey(TARGET_TYPE_KEY)) {
-            return flowNode;
-        }
-        Map<String, Property> reordered = new LinkedHashMap<>();
-        reordered.put(TARGET_TYPE_KEY, properties.get(TARGET_TYPE_KEY));
-        properties.forEach((k, v) -> {
-            if (!TARGET_TYPE_KEY.equals(k)) {
-                reordered.put(k, v);
-            }
-        });
-        return new FlowNode(flowNode.id(), flowNode.metadata(), flowNode.codedata(), flowNode.returning(),
-                flowNode.branches(), reordered, flowNode.diagnostics(), flowNode.flags());
     }
 
     @Override

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ResourceActionCallBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ResourceActionCallBuilder.java
@@ -40,6 +40,7 @@ import org.eclipse.lsp4j.TextEdit;
 
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -182,6 +183,12 @@ public class ResourceActionCallBuilder extends CallBuilder {
         Set<String> ignoredKeysOtherThanTargetType = new HashSet<>(ignoredKeys);
         ignoredKeysOtherThanTargetType.remove(TARGET_TYPE_KEY);
 
+        // Persist-generated resource functions place the inferred-typedesc `targetType` parameter at signature
+        // position 0, but the property map has it near the end. Move it to the front so that SourceBuilder's
+        // missedDefaultValue bookkeeping fires before later defaultable args (e.g. whereClause) and they are
+        // emitted as named arguments, otherwise they would slide into the skipped typedesc slot.
+        FlowNode reorderedFlowNode = withTargetTypeFirst(flowNode);
+
         return sourceBuilder.token()
                 .name(connection.get().toSourceCode())
                 .keyword(SyntaxKind.RIGHT_ARROW_TOKEN)
@@ -189,10 +196,26 @@ public class ResourceActionCallBuilder extends CallBuilder {
                 .keyword(SyntaxKind.DOT_TOKEN)
                 .name(sourceBuilder.flowNode.codedata().symbol())
                 .stepOut()
-                .functionParameters(flowNode, ignoredKeysOtherThanTargetType)
+                .functionParameters(reorderedFlowNode, ignoredKeysOtherThanTargetType)
                 .textEdit()
                 .acceptImportWithVariableType()
                 .build();
+    }
+
+    private static FlowNode withTargetTypeFirst(FlowNode flowNode) {
+        Map<String, Property> properties = flowNode.properties();
+        if (properties == null || !properties.containsKey(TARGET_TYPE_KEY)) {
+            return flowNode;
+        }
+        Map<String, Property> reordered = new LinkedHashMap<>();
+        reordered.put(TARGET_TYPE_KEY, properties.get(TARGET_TYPE_KEY));
+        properties.forEach((k, v) -> {
+            if (!TARGET_TYPE_KEY.equals(k)) {
+                reordered.put(k, v);
+            }
+        });
+        return new FlowNode(flowNode.id(), flowNode.metadata(), flowNode.codedata(), flowNode.returning(),
+                flowNode.branches(), reordered, flowNode.diagnostics(), flowNode.flags());
     }
 
     @Override

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/inferred_type.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/inferred_type.json
@@ -1,0 +1,552 @@
+{
+  "start": {
+    "line": 5,
+    "offset": 0
+  },
+  "end": {
+    "line": 12,
+    "offset": 1
+  },
+  "source": "inferred_type.bal",
+  "description": "Tests flow nodes generation for a function call with inferred type parameter",
+  "diagram": {
+    "fileName": "inferred_type.bal",
+    "nodes": [
+      {
+        "id": "38100",
+        "metadata": {
+          "label": "Start",
+          "data": {
+            "kind": "Function",
+            "label": "foo3",
+            "isServiceFunction": false,
+            "return": "error?"
+          }
+        },
+        "codedata": {
+          "node": "EVENT_START",
+          "lineRange": {
+            "fileName": "inferred_type.bal",
+            "startLine": {
+              "line": 5,
+              "offset": 38
+            },
+            "endLine": {
+              "line": 12,
+              "offset": 1
+            }
+          },
+          "sourceCode": "public function foo3() returns error? {\n    do {\n        string[] str = check foo(whereClause = 3);\n    } on fail error e {\n        log:printError(\"Error occurred\", 'error = e);\n        return e;\n    }\n}"
+        },
+        "returning": false,
+        "flags": 0
+      },
+      {
+        "id": "37980",
+        "metadata": {
+          "label": "ErrorHandler",
+          "description": "Catch and handle errors"
+        },
+        "codedata": {
+          "node": "ERROR_HANDLER",
+          "lineRange": {
+            "fileName": "inferred_type.bal",
+            "startLine": {
+              "line": 6,
+              "offset": 4
+            },
+            "endLine": {
+              "line": 11,
+              "offset": 5
+            }
+          },
+          "sourceCode": "do {\n        string[] str = check foo(whereClause = 3);\n    } on fail error e {\n        log:printError(\"Error occurred\", 'error = e);\n        return e;\n    }"
+        },
+        "returning": false,
+        "branches": [
+          {
+            "label": "Body",
+            "kind": "BLOCK",
+            "codedata": {
+              "node": "BODY",
+              "lineRange": {
+                "fileName": "inferred_type.bal",
+                "startLine": {
+                  "line": 6,
+                  "offset": 7
+                },
+                "endLine": {
+                  "line": 8,
+                  "offset": 5
+                }
+              },
+              "sourceCode": "{\n        string[] str = check foo(whereClause = 3);\n    }"
+            },
+            "repeatable": "ONE",
+            "children": [
+              {
+                "id": "38986",
+                "metadata": {
+                  "label": "foo",
+                  "description": ""
+                },
+                "codedata": {
+                  "node": "FUNCTION_CALL",
+                  "org": "$anon",
+                  "module": ".",
+                  "packageName": ".",
+                  "symbol": "foo",
+                  "version": "0.0.0",
+                  "lineRange": {
+                    "fileName": "inferred_type.bal",
+                    "startLine": {
+                      "line": 7,
+                      "offset": 8
+                    },
+                    "endLine": {
+                      "line": 7,
+                      "offset": 50
+                    }
+                  },
+                  "sourceCode": "string[] str = check foo(whereClause = 3);",
+                  "inferredReturnType": "pn"
+                },
+                "returning": false,
+                "properties": {
+                  "view": {
+                    "metadata": {
+                      "label": "View",
+                      "description": "Function definition location"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "VIEW",
+                        "selected": true
+                      }
+                    ],
+                    "value": {
+                      "fileName": "inferred_type.bal",
+                      "startLine": {
+                        "line": 14,
+                        "offset": 0
+                      },
+                      "endLine": {
+                        "line": 16,
+                        "offset": 11
+                      }
+                    },
+                    "optional": false,
+                    "editable": false,
+                    "advanced": false,
+                    "hidden": false
+                  },
+                  "pn": {
+                    "metadata": {
+                      "label": "Pn"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "TYPE",
+                        "ballerinaType": "string[]",
+                        "selected": false
+                      }
+                    ],
+                    "value": "string[]",
+                    "placeholder": "string[]",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false,
+                    "codedata": {
+                      "kind": "PARAM_FOR_TYPE_INFER",
+                      "originalName": "pn"
+                    },
+                    "defaultValue": "string[]"
+                  },
+                  "whereClause": {
+                    "metadata": {
+                      "label": "Where Clause"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "NUMBER",
+                        "ballerinaType": "int",
+                        "selected": true
+                      },
+                      {
+                        "fieldType": "EXPRESSION",
+                        "ballerinaType": "int",
+                        "selected": false
+                      }
+                    ],
+                    "value": "3",
+                    "placeholder": "0",
+                    "optional": true,
+                    "editable": true,
+                    "advanced": true,
+                    "hidden": false,
+                    "codedata": {
+                      "kind": "DEFAULTABLE",
+                      "originalName": "whereClause"
+                    },
+                    "defaultValue": "0"
+                  },
+                  "checkError": {
+                    "metadata": {
+                      "label": "Check Error",
+                      "description": "Trigger error flow"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "FLAG",
+                        "selected": true
+                      }
+                    ],
+                    "value": true,
+                    "optional": false,
+                    "editable": true,
+                    "advanced": true,
+                    "hidden": true
+                  },
+                  "variable": {
+                    "metadata": {
+                      "label": "Result",
+                      "description": "Name of the result variable"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "IDENTIFIER",
+                        "selected": true
+                      }
+                    ],
+                    "value": "str",
+                    "optional": false,
+                    "editable": false,
+                    "advanced": false,
+                    "hidden": false,
+                    "codedata": {
+                      "lineRange": {
+                        "fileName": "inferred_type.bal",
+                        "startLine": {
+                          "line": 7,
+                          "offset": 17
+                        },
+                        "endLine": {
+                          "line": 7,
+                          "offset": 20
+                        }
+                      }
+                    }
+                  },
+                  "type": {
+                    "metadata": {
+                      "label": "Result Type",
+                      "description": "Type of the variable"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "TYPE",
+                        "selected": true
+                      }
+                    ],
+                    "value": "string[]",
+                    "placeholder": "var",
+                    "optional": false,
+                    "editable": false,
+                    "advanced": false,
+                    "hidden": false,
+                    "codedata": {}
+                  }
+                },
+                "flags": 1
+              }
+            ]
+          },
+          {
+            "label": "On Failure",
+            "kind": "BLOCK",
+            "codedata": {
+              "node": "ON_FAILURE",
+              "lineRange": {
+                "fileName": "inferred_type.bal",
+                "startLine": {
+                  "line": 8,
+                  "offset": 22
+                },
+                "endLine": {
+                  "line": 11,
+                  "offset": 5
+                }
+              },
+              "sourceCode": "{\n        log:printError(\"Error occurred\", 'error = e);\n        return e;\n    }"
+            },
+            "repeatable": "ZERO_OR_ONE",
+            "properties": {
+              "ignore": {
+                "metadata": {
+                  "label": "Ignore",
+                  "description": "Ignore the error value"
+                },
+                "types": [
+                  {
+                    "fieldType": "EXPRESSION",
+                    "selected": true
+                  }
+                ],
+                "value": "false",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false
+              },
+              "errorVariable": {
+                "metadata": {
+                  "label": "Error Variable",
+                  "description": "Name of the error variable"
+                },
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "value": "e ",
+                "placeholder": "err",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false
+              },
+              "errorType": {
+                "metadata": {
+                  "label": "Error Type",
+                  "description": "Type of the error"
+                },
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "value": "error",
+                "placeholder": "error",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false
+              }
+            },
+            "children": [
+              {
+                "id": "40973",
+                "metadata": {
+                  "label": "printError",
+                  "description": "Prints error logs.\n```ballerina\nerror e = error(\"error occurred\");\nlog:printError(\"error log with cause\", 'error = e, id = 845315);\n```\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_log_2.17.0.png"
+                },
+                "codedata": {
+                  "node": "FUNCTION_CALL",
+                  "org": "ballerina",
+                  "module": "log",
+                  "packageName": "log",
+                  "symbol": "printError",
+                  "version": "2.17.0",
+                  "lineRange": {
+                    "fileName": "inferred_type.bal",
+                    "startLine": {
+                      "line": 9,
+                      "offset": 8
+                    },
+                    "endLine": {
+                      "line": 9,
+                      "offset": 53
+                    }
+                  },
+                  "sourceCode": "log:printError(\"Error occurred\", 'error = e);"
+                },
+                "returning": false,
+                "properties": {
+                  "msg": {
+                    "metadata": {
+                      "label": "Msg",
+                      "description": "The message to be logged"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "TEXT",
+                        "ballerinaType": "string",
+                        "selected": true
+                      },
+                      {
+                        "fieldType": "EXPRESSION",
+                        "ballerinaType": "string|log:PrintableRawTemplate",
+                        "selected": false
+                      }
+                    ],
+                    "value": "\"Error occurred\"",
+                    "placeholder": "\"\"",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false,
+                    "codedata": {
+                      "kind": "REQUIRED",
+                      "originalName": "msg"
+                    }
+                  },
+                  "error": {
+                    "metadata": {
+                      "label": "Error",
+                      "description": "The error struct to be logged"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "EXPRESSION",
+                        "ballerinaType": "error?",
+                        "selected": true
+                      }
+                    ],
+                    "value": "e",
+                    "placeholder": "()",
+                    "optional": true,
+                    "editable": true,
+                    "advanced": true,
+                    "hidden": false,
+                    "codedata": {
+                      "kind": "DEFAULTABLE",
+                      "originalName": "'error"
+                    },
+                    "defaultValue": "()"
+                  },
+                  "stackTrace": {
+                    "metadata": {
+                      "label": "Stack Trace",
+                      "description": "The error stack trace to be logged"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "REPEATABLE_LIST",
+                        "ballerinaType": "error:StackFrame[]",
+                        "template": {
+                          "types": [
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "error:StackFrame",
+                              "selected": false
+                            }
+                          ],
+                          "optional": false,
+                          "editable": false,
+                          "advanced": false,
+                          "hidden": false
+                        },
+                        "selected": false
+                      },
+                      {
+                        "fieldType": "EXPRESSION",
+                        "ballerinaType": "error:StackFrame[]?",
+                        "selected": false
+                      }
+                    ],
+                    "placeholder": "()",
+                    "optional": true,
+                    "editable": true,
+                    "advanced": true,
+                    "hidden": false,
+                    "codedata": {
+                      "kind": "DEFAULTABLE",
+                      "originalName": "stackTrace"
+                    },
+                    "defaultValue": "()"
+                  },
+                  "additionalValues": {
+                    "metadata": {
+                      "label": "Additional Values",
+                      "description": "Capture key value pairs"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "REPEATABLE_MAP",
+                        "ballerinaType": "log:Value",
+                        "template": {
+                          "types": [
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "log:Value",
+                              "selected": false
+                            }
+                          ],
+                          "optional": false,
+                          "editable": false,
+                          "advanced": false,
+                          "hidden": false
+                        },
+                        "selected": true
+                      }
+                    ],
+                    "value": {},
+                    "placeholder": "{}",
+                    "optional": true,
+                    "editable": true,
+                    "advanced": true,
+                    "hidden": false,
+                    "codedata": {
+                      "kind": "INCLUDED_RECORD_REST",
+                      "originalName": "Additional Values"
+                    }
+                  }
+                },
+                "flags": 0
+              },
+              {
+                "id": "41929",
+                "metadata": {
+                  "label": "Return",
+                  "description": "Value of 'e'"
+                },
+                "codedata": {
+                  "node": "RETURN",
+                  "lineRange": {
+                    "fileName": "inferred_type.bal",
+                    "startLine": {
+                      "line": 10,
+                      "offset": 8
+                    },
+                    "endLine": {
+                      "line": 10,
+                      "offset": 17
+                    }
+                  },
+                  "sourceCode": "return e;"
+                },
+                "returning": true,
+                "properties": {
+                  "expression": {
+                    "metadata": {
+                      "label": "Expression",
+                      "description": "Return value"
+                    },
+                    "types": [
+                      {
+                        "fieldType": "ACTION_OR_EXPRESSION",
+                        "selected": true
+                      }
+                    ],
+                    "value": "e",
+                    "optional": true,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                  }
+                },
+                "flags": 0
+              }
+            ]
+          }
+        ],
+        "flags": 0
+      }
+    ],
+    "connections": []
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/inferred_type.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/inferred_type.bal
@@ -1,0 +1,17 @@
+import ballerina/log;
+import ballerina/jballerina.java;
+
+public type PhoneNumbers typedesc<string[]>;
+
+public function foo3() returns error? {
+    do {
+        string[] str = check foo(whereClause = 3);
+    } on fail error e {
+        log:printError("Error occurred", 'error = e);
+        return e;
+    }
+}
+
+function foo(PhoneNumbers pn = <>, int whereClause = 4) returns pn|error = @java:Method {
+    'class: ""
+} external;


### PR DESCRIPTION
## Purpose
Fixes : https://github.com/wso2/product-integrator/issues/794



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Preserve Order of Type Inferred Parameters in Property List

This pull request fixes an issue where type-inferred parameters were not maintaining their declared order in the property list during flow model generation.

### Changes

**CodeAnalyzer.java** — Modified the parameter processing logic to reserve property slots for inferred-type parameters at their declaration position, ensuring they remain in the correct order when the property list is finalized.

**FormBuilder.java** — Added a new `reserveProperty(String key)` method that pre-allocates property positions in the underlying `LinkedHashMap`, allowing subsequent property additions to fill reserved slots without altering the insertion order.

**Test Resources** — Added comprehensive test coverage with a Ballerina source file (`inferred_type.bal`) containing type-inferred parameter scenarios and a corresponding diagram configuration file (`inferred_type.json`) to validate the fix.

The solution ensures that inferred parameters maintain their original position in the property list rather than being reordered during property aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->