### PR TITLE
Fix issue in visualizable API for arrays

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
@@ -2776,6 +2776,8 @@ public class DataMapManager {
             return new DataMapCapability(false, "false");
         } else if (kind == TypeDescKind.STRING) {
             return new DataMapCapability(false, "\"\"");
+        } else if (kind == TypeDescKind.ARRAY) {
+            return new DataMapCapability(false, "[]");
         }
         return null;
     }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/DataMappingVisualizeTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/DataMappingVisualizeTest.java
@@ -55,6 +55,7 @@ public class DataMappingVisualizeTest extends AbstractLSTest {
                 {Path.of("variable7.json")},
                 {Path.of("variable8.json")},
                 {Path.of("variable9.json")},
+                {Path.of("variable10.json")},
         };
     }
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/config/variable10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/config/variable10.json
@@ -1,0 +1,20 @@
+{
+  "source": "variable8.bal",
+  "description": "Test reference type visualization",
+  "codedata": {
+    "node": "TYPEDESC",
+    "org": "",
+    "module": "",
+    "packageName": "",
+    "symbol": "PhoneNumbers",
+    "version": ""
+  },
+  "position": {
+    "line": 7,
+    "offset": 12
+  },
+  "visualizableProperties": {
+    "isDataMapped": false,
+    "defaultValue": "[]"
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/variable8.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_visualize/source/variable8.bal
@@ -1,0 +1,14 @@
+import ballerina/http;
+
+public type PhoneNumbers string[];
+
+service on new http:Listener(9090) {
+
+    resource function get location() returns PhoneNumbers|http:NotFound {
+        do {
+
+        } on fail error e {
+            return http:NOT_FOUND;
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Addresses https://github.com/wso2/product-integrator/issues/774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue in the visualizable API for array types. The primary change improves the handling of array types in the data mapping framework.

### Changes

**Core Logic Fix:**
- Added support for array type handling in `DataMapManager.java`'s capability detection method. When a resolved type is identified as an array, the method now returns a `DataMapCapability` with an empty array as the default value (`[]`) instead of returning null. This ensures arrays are properly recognized and handled in the data mapping visualization.

**Testing Improvements:**
- Extended the test suite by adding a new test configuration (`variable10.json`) to the data provider in `DataMappingVisualizeTest.java`, increasing test coverage for the visualizable API.
- Added corresponding test resources including a Ballerina source file (`variable8.bal`) that defines a reference type as an array (`PhoneNumbers = string[]`) and exposes it through an HTTP service resource. This fixture exercises the array handling in a realistic scenario.

These changes address the issue reported in the referenced external issue (#774) by ensuring that array-typed references are correctly visualized and processed by the data mapping framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->