### PR TITLE
Extend daily build pipeline for main and patch branches

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -89,9 +89,10 @@ jobs:
 
       - name: Build with Gradle
         env:
+          ORG_GRADLE_PROJECT_version: ${{ matrix.version }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew -Pversion=${{ matrix.version }} build pack -x check
+        run: ./gradlew build pack -x check
 
       - name: Upload daily build jar
         uses: actions/upload-artifact@v4
@@ -142,7 +143,9 @@ jobs:
             ${{ runner.os }}-ballerina-${{ matrix.branch }}-
 
       - name: Build with Gradle
+        shell: cmd
         env:
+          ORG_GRADLE_PROJECT_version: ${{ matrix.version }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew.bat -Pversion=${{ matrix.version }} build -x check
+        run: ./gradlew.bat build -x check

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -92,7 +92,55 @@ jobs:
           ORG_GRADLE_PROJECT_version: ${{ matrix.version }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build pack -x check
+        run: ./gradlew build -x check
+
+  ubuntu-pack:
+    name: Ubuntu pack (${{ matrix.branch }})
+    needs:
+      - prepare-matrix
+      - ubuntu-build
+    if: ${{ always() && needs.prepare-matrix.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.targets) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 21.0.3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.1
+        with:
+          version: 2201.13.1
+
+      - name: Cache Ballerina dependencies (Ubuntu)
+        uses: actions/cache@v4
+        id: cache-ballerina
+        with:
+          path: /home/runner/.ballerina/repositories/
+          key: ${{ runner.os }}-ballerina-${{ matrix.branch }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-ballerina-${{ matrix.branch }}-
+
+      - name: Pack with Gradle
+        env:
+          ORG_GRADLE_PROJECT_version: ${{ matrix.version }}
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew pack -x check
 
       - name: Upload daily build jar
         uses: actions/upload-artifact@v4

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -49,56 +49,9 @@ jobs:
 
           echo "targets=${targets}" >> "${GITHUB_OUTPUT}"
 
-  ubuntu-build:
-    name: Ubuntu build (${{ matrix.branch }})
-    needs: prepare-matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.prepare-matrix.outputs.targets) }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.branch }}
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 21.0.3
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.1
-        with:
-          version: 2201.13.1
-
-      - name: Cache Ballerina dependencies (Ubuntu)
-        uses: actions/cache@v4
-        id: cache-ballerina
-        with:
-          path: /home/runner/.ballerina/repositories/
-          key: ${{ runner.os }}-ballerina-${{ matrix.branch }}-${{ hashFiles('**/gradle.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-ballerina-${{ matrix.branch }}-
-
-      - name: Build with Gradle
-        env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew -Pversion=${{ matrix.version }} build
-
   ubuntu-pack:
     name: Ubuntu pack (${{ matrix.branch }})
-    needs:
-      - prepare-matrix
-      - ubuntu-build
-    if: ${{ always() && needs.prepare-matrix.result == 'success' }}
+    needs: prepare-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -146,6 +99,52 @@ jobs:
           path: build/ballerina-language-server-${{ matrix.version }}.jar
           archive: false
           if-no-files-found: error
+
+  ubuntu-test:
+    name: Ubuntu test (${{ matrix.branch }})
+    needs:
+      - prepare-matrix
+      - ubuntu-pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.targets) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 21.0.3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.1
+        with:
+          version: 2201.13.1
+
+      - name: Cache Ballerina dependencies (Ubuntu)
+        uses: actions/cache@v4
+        id: cache-ballerina
+        with:
+          path: /home/runner/.ballerina/repositories/
+          key: ${{ runner.os }}-ballerina-${{ matrix.branch }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-ballerina-${{ matrix.branch }}-
+
+      - name: Test with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew -Pversion=${{ matrix.version }} test
 
   windows-build:
     name: Windows build (${{ matrix.branch }})

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -143,10 +143,10 @@ jobs:
         run: ./gradlew pack -x check
 
       - name: Upload daily build jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: daily-build-${{ matrix.branch }}-${{ matrix.version }}
           path: build/ballerina-language-server-${{ matrix.version }}.jar
+          archive: false
           if-no-files-found: error
 
   windows-build:

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -2,15 +2,66 @@ name: Daily build
 
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '30 1 * * *'
 
 jobs:
-  ubuntu-build:
+  prepare-matrix:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    outputs:
+      targets: ${{ steps.resolve-targets.outputs.targets }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve target branches
+        id: resolve-targets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_branch=$(git ls-remote --heads origin | awk -F'/' '/refs\/heads\/1\.[0-9]+\.x$/ { print $NF }' | sort -V | tail -n 1)
+          if [ -z "${latest_branch}" ]; then
+            echo "Unable to find a branch matching 1.d.x on origin" >&2
+            exit 1
+          fi
+
+          timestamp=$(date '+%Y%m%d-%H%M%S')
+          targets='[]'
+
+          for branch in main "${latest_branch}"; do
+            git fetch --depth=1 origin "${branch}:refs/remotes/origin/${branch}"
+
+            branch_version=$(git show "origin/${branch}:gradle.properties" | awk -F= '$1 == "version" { print $2; exit }')
+            if [ -z "${branch_version}" ]; then
+              echo "Unable to resolve version from gradle.properties for ${branch}" >&2
+              exit 1
+            fi
+
+            build_version="${branch_version}-${timestamp}"
+            targets=$(jq -c \
+              --arg branch "${branch}" \
+              --arg version "${build_version}" \
+              '. + [{branch: $branch, version: $version}]' <<< "${targets}")
+          done
+
+          echo "targets=${targets}" >> "${GITHUB_OUTPUT}"
+
+  ubuntu-build:
+    name: Ubuntu build (${{ matrix.branch }})
+    needs: prepare-matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.targets) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v3
@@ -31,25 +82,40 @@ jobs:
         id: cache-ballerina
         with:
           path: /home/runner/.ballerina/repositories/
-          key: ${{ runner.os }}-ballerina-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/gradle.properties') }}
+          key: ${{ runner.os }}-ballerina-${{ matrix.branch }}-${{ hashFiles('**/gradle.properties') }}
           restore-keys: |
-            ${{ runner.os }}-ballerina-${{ github.base_ref || github.ref_name }}-
+            ${{ runner.os }}-ballerina-${{ matrix.branch }}-
 
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build
+        run: ./gradlew -Pversion=${{ matrix.version }} build pack
+
+      - name: Upload daily build jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-build-${{ matrix.branch }}-${{ matrix.version }}
+          path: build/ballerina-language-server-${{ matrix.version }}.jar
+          if-no-files-found: error
 
   windows-build:
+    name: Windows build (${{ matrix.branch }})
+    needs: prepare-matrix
     runs-on: windows-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.targets) }}
     steps:
       - name: Enable long paths for Git
         run: git config --system core.longpaths true
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v3
@@ -70,12 +136,12 @@ jobs:
         id: cache-ballerina
         with:
           path: C:\Users\runneradmin\.ballerina\repositories\
-          key: ${{ runner.os }}-ballerina-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/gradle.properties') }}
+          key: ${{ runner.os }}-ballerina-${{ matrix.branch }}-${{ hashFiles('**/gradle.properties') }}
           restore-keys: |
-            ${{ runner.os }}-ballerina-${{ github.base_ref || github.ref_name }}-
+            ${{ runner.os }}-ballerina-${{ matrix.branch }}-
 
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew.bat build
+        run: ./gradlew.bat -Pversion=${{ matrix.version }} build

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -3,6 +3,7 @@ name: Daily build
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch:
 
 jobs:
   prepare-matrix:
@@ -90,7 +91,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew -Pversion=${{ matrix.version }} build pack
+        run: ./gradlew -Pversion=${{ matrix.version }} build pack -x check
 
       - name: Upload daily build jar
         uses: actions/upload-artifact@v4
@@ -144,4 +145,4 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew.bat -Pversion=${{ matrix.version }} build
+        run: ./gradlew.bat -Pversion=${{ matrix.version }} build -x check

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -91,7 +91,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew -Pversion=${{ matrix.version }} build -x check
+        run: ./gradlew -Pversion=${{ matrix.version }} build
 
   ubuntu-pack:
     name: Ubuntu pack (${{ matrix.branch }})
@@ -193,4 +193,4 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew.bat build -x check
+        run: ./gradlew.bat build

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -89,10 +89,9 @@ jobs:
 
       - name: Build with Gradle
         env:
-          ORG_GRADLE_PROJECT_version: ${{ matrix.version }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build -x check
+        run: ./gradlew -Pversion=${{ matrix.version }} build -x check
 
   ubuntu-pack:
     name: Ubuntu pack (${{ matrix.branch }})
@@ -137,10 +136,9 @@ jobs:
 
       - name: Pack with Gradle
         env:
-          ORG_GRADLE_PROJECT_version: ${{ matrix.version }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew pack -x check
+        run: ./gradlew -Pversion=${{ matrix.version }} pack -x check
 
       - name: Upload daily build jar
         uses: actions/upload-artifact@v7
@@ -193,7 +191,6 @@ jobs:
       - name: Build with Gradle
         shell: cmd
         env:
-          ORG_GRADLE_PROJECT_version: ${{ matrix.version }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew.bat build -x check

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -34,7 +34,7 @@ jobs:
           for branch in main "${latest_branch}"; do
             git fetch --depth=1 origin "${branch}:refs/remotes/origin/${branch}"
 
-            branch_version=$(git show "origin/${branch}:gradle.properties" | awk -F= '$1 == "version" { print $2; exit }')
+            branch_version=$(git show "origin/${branch}:gradle.properties" | awk -F= '$1 == "version" { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); gsub(/\r/, "", $2); print $2; exit }')
             if [ -z "${branch_version}" ]; then
               echo "Unable to resolve version from gradle.properties for ${branch}" >&2
               exit 1


### PR DESCRIPTION
## Purpose

Extend daily builds to produce versioned artifacts for both `main` and the latest supported `1.d.x` branch.

## Approach

Refactor the workflow to resolve target branches dynamically, derive timestamped versions from each branch, and run branch-scoped build/package jobs with artifact publishing.

## What Was Fixed / Changed

- Replaced single-ref execution with a dynamic branch matrix for `main` and the latest maintenance line.
- Added Ubuntu packaging and direct JAR artifact upload.
- Isolated checkout and cache behavior per target branch.

## Affected Components

- `.github/workflows`

## How Has This Been Tested

- Validated using `workflow_dispatch` confirming matrix resolution, cross-platform builds, and Ubuntu artifact publication.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated: builds now run daily or on demand, discover multiple release branches, run a matrix of build/test/pack tasks per branch, produce versioned artifacts, and use branch-scoped caching to speed successive runs. No functional changes for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->