### PR TITLE
Add disk cache for AI component discovery

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
@@ -57,7 +57,11 @@ class AiComponentDiskCache {
     private final AtomicBoolean diskAvailable;
 
     AiComponentDiskCache() {
-        this.cacheDirectory = Path.of(System.getProperty("java.io.tmpdir"), CACHE_DIR_NAME);
+        this(Path.of(System.getProperty("java.io.tmpdir"), CACHE_DIR_NAME));
+    }
+
+    AiComponentDiskCache(Path cacheDirectory) {
+        this.cacheDirectory = cacheDirectory;
         this.gson = new Gson();
         this.diskAvailable = new AtomicBoolean(true);
     }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Disk-backed cache for AI component type information discovered from semantic model analysis.
+ * <p>
+ * For a given module version (e.g., {@code ballerinax/ai.openai@1.4.0}), the AI component types it exposes are
+ * immutable. This cache persists the analysis results so that subsequent LS sessions can skip the expensive semantic
+ * model loading and compilation step.
+ * <p>
+ * Cache files are stored as JSON in a temporary directory. On I/O failure, the cache degrades gracefully — the system
+ * falls back to loading semantic models as before.
+ *
+ * @since 1.7.0
+ */
+class AiComponentDiskCache {
+
+    private static final Logger LOGGER = Logger.getLogger(AiComponentDiskCache.class.getName());
+    private static final int SCHEMA_VERSION = 1;
+    private static final String CACHE_DIR_NAME = "ballerina-ls-ai-component-cache";
+
+    private final Path cacheDirectory;
+    private final Gson gson;
+    private final AtomicBoolean diskAvailable;
+
+    AiComponentDiskCache() {
+        this.cacheDirectory = Path.of(System.getProperty("java.io.tmpdir"), CACHE_DIR_NAME);
+        this.gson = new Gson();
+        this.diskAvailable = new AtomicBoolean(true);
+    }
+
+    /**
+     * Loads cached component data for a module version.
+     *
+     * @param org     the module organization (e.g., "ballerinax")
+     * @param name    the module name (e.g., "ai.openai")
+     * @param version the module version (e.g., "1.4.0")
+     * @return the cached components, or empty if not cached, corrupt, or schema mismatch
+     */
+    Optional<List<CachedComponent>> load(String org, String name, String version) {
+        if (!diskAvailable.get() || version == null) {
+            return Optional.empty();
+        }
+        try {
+            Path file = cacheDirectory.resolve(toFileName(org, name, version));
+            if (!Files.exists(file)) {
+                return Optional.empty();
+            }
+            try (Reader reader = Files.newBufferedReader(file)) {
+                ModuleCache moduleCache = gson.fromJson(reader, ModuleCache.class);
+                if (moduleCache == null || moduleCache.schemaVersion != SCHEMA_VERSION) {
+                    return Optional.empty();
+                }
+                return Optional.of(moduleCache.components != null ? moduleCache.components : List.of());
+            }
+        } catch (IOException | RuntimeException e) {
+            LOGGER.log(Level.FINE, "Failed to read AI component cache for " + org + ":" + name + ":" + version, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Saves component data for a module version to disk. Writes atomically via temp file + rename. Saves even if the
+     * components list is empty (caches "no AI components found").
+     *
+     * @param org        the module organization
+     * @param name       the module name
+     * @param version    the module version
+     * @param components the discovered components (may be empty)
+     */
+    void save(String org, String name, String version, List<CachedComponent> components) {
+        if (!diskAvailable.get() || version == null) {
+            return;
+        }
+        try {
+            Files.createDirectories(cacheDirectory);
+            Path target = cacheDirectory.resolve(toFileName(org, name, version));
+            Path temp = Files.createTempFile(cacheDirectory, "tmp_", ".json");
+            try (Writer writer = Files.newBufferedWriter(temp)) {
+                gson.toJson(new ModuleCache(SCHEMA_VERSION, components), writer);
+            }
+            try {
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (java.nio.file.AtomicMoveNotSupportedException e) {
+                // ATOMIC_MOVE not supported (e.g., some Windows filesystems) — fall back to plain replace
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException | RuntimeException e) {
+            LOGGER.log(Level.WARNING, "Failed to write AI component cache, disabling disk cache", e);
+            diskAvailable.set(false);
+        }
+    }
+
+    private static String toFileName(String org, String name, String version) {
+        return (org + "_" + name + "_" + version).replace(".", "-") + ".json";
+    }
+
+    record CachedComponent(String className, String label, String description,
+                           String category, String symbol) {
+    }
+
+    private record ModuleCache(int schemaVersion, List<CachedComponent> components) {
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
@@ -111,10 +111,11 @@ class AiComponentDiskCache {
         if (!diskAvailable.get() || version == null) {
             return;
         }
+        Path temp = null;
         try {
             Files.createDirectories(cacheDirectory);
             Path target = cacheDirectory.resolve(toFileName(org, name, version));
-            Path temp = Files.createTempFile(cacheDirectory, "tmp_", ".json");
+            temp = Files.createTempFile(cacheDirectory, "tmp_", ".json");
             try (Writer writer = Files.newBufferedWriter(temp, StandardCharsets.UTF_8)) {
                 gson.toJson(new ModuleCache(SCHEMA_VERSION, components), writer);
             }
@@ -127,6 +128,13 @@ class AiComponentDiskCache {
         } catch (IOException | RuntimeException e) {
             LOGGER.log(Level.WARNING, "Failed to write AI component cache, disabling disk cache", e);
             diskAvailable.set(false);
+            if (temp != null) {
+                try {
+                    Files.deleteIfExists(temp);
+                } catch (IOException ignored) {
+                    // best-effort cleanup
+                }
+            }
         }
     }
 

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
@@ -19,10 +19,12 @@
 package io.ballerina.flowmodelgenerator.core;
 
 import com.google.gson.Gson;
+import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -77,12 +79,18 @@ class AiComponentDiskCache {
             if (!Files.exists(file)) {
                 return Optional.empty();
             }
-            try (Reader reader = Files.newBufferedReader(file)) {
+            try (Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
                 ModuleCache moduleCache = gson.fromJson(reader, ModuleCache.class);
-                if (moduleCache == null || moduleCache.schemaVersion != SCHEMA_VERSION) {
+                if (moduleCache == null || moduleCache.schemaVersion != SCHEMA_VERSION
+                        || moduleCache.components == null) {
                     return Optional.empty();
                 }
-                return Optional.of(moduleCache.components != null ? moduleCache.components : List.of());
+                for (CachedComponent c : moduleCache.components) {
+                    if (!isValid(c)) {
+                        return Optional.empty();
+                    }
+                }
+                return Optional.of(moduleCache.components);
             }
         } catch (IOException | RuntimeException e) {
             LOGGER.log(Level.FINE, "Failed to read AI component cache for " + org + ":" + name + ":" + version, e);
@@ -107,7 +115,7 @@ class AiComponentDiskCache {
             Files.createDirectories(cacheDirectory);
             Path target = cacheDirectory.resolve(toFileName(org, name, version));
             Path temp = Files.createTempFile(cacheDirectory, "tmp_", ".json");
-            try (Writer writer = Files.newBufferedWriter(temp)) {
+            try (Writer writer = Files.newBufferedWriter(temp, StandardCharsets.UTF_8)) {
                 gson.toJson(new ModuleCache(SCHEMA_VERSION, components), writer);
             }
             try {
@@ -124,6 +132,19 @@ class AiComponentDiskCache {
 
     private static String toFileName(String org, String name, String version) {
         return (org + "_" + name + "_" + version).replace(".", "-") + ".json";
+    }
+
+    private static boolean isValid(CachedComponent c) {
+        if (c == null || c.className() == null || c.label() == null
+                || c.description() == null || c.category() == null || c.symbol() == null) {
+            return false;
+        }
+        try {
+            NodeKind.valueOf(c.category());
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     record CachedComponent(String className, String label, String description,

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -732,13 +732,7 @@ public class AiUtils {
                 .map(m -> new ModuleInfo(m.org(), m.name(), m.name(), m.version()))
                 .toList();
 
-        List<AvailableNode> modelProviders = new ArrayList<>();
-        List<AvailableNode> embeddingProviders = new ArrayList<>();
-        List<AvailableNode> vectorStores = new ArrayList<>();
-        List<AvailableNode> chunkers = new ArrayList<>();
-        List<AvailableNode> dataLoaders = new ArrayList<>();
-        List<AvailableNode> shortTermMemoryStores = new ArrayList<>();
-        List<AvailableNode> knowledgeBases = new ArrayList<>();
+        List<AvailableNode> categoryNodes = new ArrayList<>();
 
         for (ModuleInfo module : modules) {
             // Include version in codedata only if the project has a Dependencies.toml.
@@ -750,10 +744,10 @@ public class AiUtils {
                     diskCache.load(module.org(), module.packageName(), module.version());
             if (cached.isPresent()) {
                 for (AiComponentDiskCache.CachedComponent comp : cached.get()) {
-                    NodeKind kind = NodeKind.valueOf(comp.category());
-                    AvailableNode node = reconstructFromCache(comp, module, codedataVersion);
-                    addToCategory(kind, node, modelProviders, embeddingProviders, vectorStores,
-                            chunkers, dataLoaders, shortTermMemoryStores, knowledgeBases);
+                    if (!category.name().equals(comp.category())) {
+                        continue;
+                    }
+                    categoryNodes.add(reconstructFromCache(comp, module, codedataVersion));
                 }
                 continue;
             }
@@ -774,36 +768,14 @@ public class AiUtils {
                     .filter(ClassSymbol.class::isInstance).map(ClassSymbol.class::cast);
 
             for (var classSymbol : classSymbols.toList()) {
-                if (isModelProviderClass(classSymbol)) {
-                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, MODEL_PROVIDER);
-                    modelProviders.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, MODEL_PROVIDER));
-                } else if (isEmbeddingProviderClass(classSymbol)) {
-                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion,
-                            EMBEDDING_PROVIDER);
-                    embeddingProviders.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, EMBEDDING_PROVIDER));
-                } else if (isVectorStoreClass(classSymbol)) {
-                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, VECTOR_STORE);
-                    vectorStores.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, VECTOR_STORE));
-                } else if (isChunkerClass(classSymbol)) {
-                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, CHUNKER);
-                    chunkers.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, CHUNKER));
-                } else if (isDataLoaderClass(classSymbol)) {
-                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, DATA_LOADER);
-                    dataLoaders.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, DATA_LOADER));
-                } else if (isShortTermMemoryStoreClass(classSymbol)) {
-                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion,
-                            SHORT_TERM_MEMORY_STORE);
-                    shortTermMemoryStores.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, SHORT_TERM_MEMORY_STORE));
-                } else if (isKnowledgeBaseClass(classSymbol)) {
-                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, KNOWLEDGE_BASE);
-                    knowledgeBases.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, KNOWLEDGE_BASE));
+                NodeKind classKind = classifyComponent(classSymbol);
+                if (classKind == null) {
+                    continue;
+                }
+                AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, classKind);
+                toCache.add(toCachedComponent(classSymbol, node, classKind));
+                if (classKind == category) {
+                    categoryNodes.add(node);
                 }
             }
 
@@ -811,15 +783,46 @@ public class AiUtils {
             diskCache.save(module.org(), module.packageName(), module.version(), toCache);
         }
 
-        mergeIntoCache(cachedModelProviderMap, cacheKey, modelProviders);
-        mergeIntoCache(cachedEmbeddingProviderMap, cacheKey, embeddingProviders);
-        mergeIntoCache(cachedVectorStoreMap, cacheKey, vectorStores);
-        mergeIntoCache(cachedChunkerMap, cacheKey, chunkers);
-        mergeIntoCache(cachedDataLoaderMap, cacheKey, dataLoaders);
-        mergeIntoCache(cachedShortTermMemoryStoreMap, cacheKey, shortTermMemoryStores);
-        mergeIntoCache(cachedKnowledgeBaseMap, cacheKey, knowledgeBases);
-
+        mergeIntoCache(getCategoryCache(category), cacheKey, categoryNodes);
         completed.add(category);
+    }
+
+    private static NodeKind classifyComponent(ClassSymbol classSymbol) {
+        if (isModelProviderClass(classSymbol)) {
+            return MODEL_PROVIDER;
+        }
+        if (isEmbeddingProviderClass(classSymbol)) {
+            return EMBEDDING_PROVIDER;
+        }
+        if (isVectorStoreClass(classSymbol)) {
+            return VECTOR_STORE;
+        }
+        if (isChunkerClass(classSymbol)) {
+            return CHUNKER;
+        }
+        if (isDataLoaderClass(classSymbol)) {
+            return DATA_LOADER;
+        }
+        if (isShortTermMemoryStoreClass(classSymbol)) {
+            return SHORT_TERM_MEMORY_STORE;
+        }
+        if (isKnowledgeBaseClass(classSymbol)) {
+            return KNOWLEDGE_BASE;
+        }
+        return null;
+    }
+
+    private static Map<String, List<AvailableNode>> getCategoryCache(NodeKind category) {
+        return switch (category) {
+            case MODEL_PROVIDER -> cachedModelProviderMap;
+            case EMBEDDING_PROVIDER -> cachedEmbeddingProviderMap;
+            case VECTOR_STORE -> cachedVectorStoreMap;
+            case CHUNKER -> cachedChunkerMap;
+            case DATA_LOADER -> cachedDataLoaderMap;
+            case SHORT_TERM_MEMORY_STORE -> cachedShortTermMemoryStoreMap;
+            case KNOWLEDGE_BASE -> cachedKnowledgeBaseMap;
+            default -> throw new IllegalArgumentException("Unsupported AI component category: " + category);
+        };
     }
 
     private static void mergeIntoCache(Map<String, List<AvailableNode>> cacheMap,
@@ -972,24 +975,6 @@ public class AiUtils {
         String className = classSymbol.getName().orElse("");
         return new AiComponentDiskCache.CachedComponent(className, node.metadata().label(),
                 node.metadata().description(), category.name(), node.codedata().symbol());
-    }
-
-    private static void addToCategory(NodeKind category, AvailableNode node,
-                                      List<AvailableNode> modelProviders, List<AvailableNode> embeddingProviders,
-                                      List<AvailableNode> vectorStores, List<AvailableNode> chunkers,
-                                      List<AvailableNode> dataLoaders, List<AvailableNode> shortTermMemoryStores,
-                                      List<AvailableNode> knowledgeBases) {
-        switch (category) {
-            case MODEL_PROVIDER -> modelProviders.add(node);
-            case EMBEDDING_PROVIDER -> embeddingProviders.add(node);
-            case VECTOR_STORE -> vectorStores.add(node);
-            case CHUNKER -> chunkers.add(node);
-            case DATA_LOADER -> dataLoaders.add(node);
-            case SHORT_TERM_MEMORY_STORE -> shortTermMemoryStores.add(node);
-            case KNOWLEDGE_BASE -> knowledgeBases.add(node);
-            default -> {
-            }
-        }
     }
 
     private static Optional<String> getDisplayLabel(ClassSymbol classSymbol) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -750,8 +750,9 @@ public class AiUtils {
                     diskCache.load(module.org(), module.packageName(), module.version());
             if (cached.isPresent()) {
                 for (AiComponentDiskCache.CachedComponent comp : cached.get()) {
+                    NodeKind kind = NodeKind.valueOf(comp.category());
                     AvailableNode node = reconstructFromCache(comp, module, codedataVersion);
-                    addToCategory(comp.category(), node, modelProviders, embeddingProviders, vectorStores,
+                    addToCategory(kind, node, modelProviders, embeddingProviders, vectorStores,
                             chunkers, dataLoaders, shortTermMemoryStores, knowledgeBases);
                 }
                 continue;
@@ -776,33 +777,33 @@ public class AiUtils {
                 if (isModelProviderClass(classSymbol)) {
                     AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, MODEL_PROVIDER);
                     modelProviders.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, "MODEL_PROVIDER"));
+                    toCache.add(toCachedComponent(classSymbol, node, MODEL_PROVIDER));
                 } else if (isEmbeddingProviderClass(classSymbol)) {
                     AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion,
                             EMBEDDING_PROVIDER);
                     embeddingProviders.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, "EMBEDDING_PROVIDER"));
+                    toCache.add(toCachedComponent(classSymbol, node, EMBEDDING_PROVIDER));
                 } else if (isVectorStoreClass(classSymbol)) {
                     AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, VECTOR_STORE);
                     vectorStores.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, "VECTOR_STORE"));
+                    toCache.add(toCachedComponent(classSymbol, node, VECTOR_STORE));
                 } else if (isChunkerClass(classSymbol)) {
                     AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, CHUNKER);
                     chunkers.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, "CHUNKER"));
+                    toCache.add(toCachedComponent(classSymbol, node, CHUNKER));
                 } else if (isDataLoaderClass(classSymbol)) {
                     AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, DATA_LOADER);
                     dataLoaders.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, "DATA_LOADER"));
+                    toCache.add(toCachedComponent(classSymbol, node, DATA_LOADER));
                 } else if (isShortTermMemoryStoreClass(classSymbol)) {
                     AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion,
                             SHORT_TERM_MEMORY_STORE);
                     shortTermMemoryStores.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, "SHORT_TERM_MEMORY_STORE"));
+                    toCache.add(toCachedComponent(classSymbol, node, SHORT_TERM_MEMORY_STORE));
                 } else if (isKnowledgeBaseClass(classSymbol)) {
                     AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, KNOWLEDGE_BASE);
                     knowledgeBases.add(node);
-                    toCache.add(toCachedComponent(classSymbol, node, "KNOWLEDGE_BASE"));
+                    toCache.add(toCachedComponent(classSymbol, node, KNOWLEDGE_BASE));
                 }
             }
 
@@ -967,25 +968,25 @@ public class AiUtils {
     }
 
     private static AiComponentDiskCache.CachedComponent toCachedComponent(ClassSymbol classSymbol,
-                                                                          AvailableNode node, String category) {
+                                                                          AvailableNode node, NodeKind category) {
         String className = classSymbol.getName().orElse("");
         return new AiComponentDiskCache.CachedComponent(className, node.metadata().label(),
-                node.metadata().description(), category, node.codedata().symbol());
+                node.metadata().description(), category.name(), node.codedata().symbol());
     }
 
-    private static void addToCategory(String category, AvailableNode node,
+    private static void addToCategory(NodeKind category, AvailableNode node,
                                       List<AvailableNode> modelProviders, List<AvailableNode> embeddingProviders,
                                       List<AvailableNode> vectorStores, List<AvailableNode> chunkers,
                                       List<AvailableNode> dataLoaders, List<AvailableNode> shortTermMemoryStores,
                                       List<AvailableNode> knowledgeBases) {
         switch (category) {
-            case "MODEL_PROVIDER" -> modelProviders.add(node);
-            case "EMBEDDING_PROVIDER" -> embeddingProviders.add(node);
-            case "VECTOR_STORE" -> vectorStores.add(node);
-            case "CHUNKER" -> chunkers.add(node);
-            case "DATA_LOADER" -> dataLoaders.add(node);
-            case "SHORT_TERM_MEMORY_STORE" -> shortTermMemoryStores.add(node);
-            case "KNOWLEDGE_BASE" -> knowledgeBases.add(node);
+            case MODEL_PROVIDER -> modelProviders.add(node);
+            case EMBEDDING_PROVIDER -> embeddingProviders.add(node);
+            case VECTOR_STORE -> vectorStores.add(node);
+            case CHUNKER -> chunkers.add(node);
+            case DATA_LOADER -> dataLoaders.add(node);
+            case SHORT_TERM_MEMORY_STORE -> shortTermMemoryStores.add(node);
+            case KNOWLEDGE_BASE -> knowledgeBases.add(node);
             default -> {
             }
         }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -151,6 +151,7 @@ public class AiUtils {
     private static final String NAME = "name";
     private static final String VERSION = "version";
     private static final String INIT_METHOD = "init";
+    private static final AiComponentDiskCache diskCache = new AiComponentDiskCache();
 
     public static final String MEMORY_DEFAULT_VALUE = "10";
     public static final String AI_PROMPT_TYPE = "ai:Prompt";
@@ -740,6 +741,23 @@ public class AiUtils {
         List<AvailableNode> knowledgeBases = new ArrayList<>();
 
         for (ModuleInfo module : modules) {
+            // Include version in codedata only if the project has a Dependencies.toml.
+            // Omitting version (null) means "use latest from Central".
+            String codedataVersion = hasDependenciesToml ? module.version() : null;
+
+            // Try disk cache first — avoids expensive semantic model loading
+            Optional<List<AiComponentDiskCache.CachedComponent>> cached =
+                    diskCache.load(module.org(), module.packageName(), module.version());
+            if (cached.isPresent()) {
+                for (AiComponentDiskCache.CachedComponent comp : cached.get()) {
+                    AvailableNode node = reconstructFromCache(comp, module, codedataVersion);
+                    addToCategory(comp.category(), node, modelProviders, embeddingProviders, vectorStores,
+                            chunkers, dataLoaders, shortTermMemoryStores, knowledgeBases);
+                }
+                continue;
+            }
+
+            // Cache miss — load semantic model (expensive)
             Optional<SemanticModel> semanticModel;
             try {
                 semanticModel = getSemanticModel(module);
@@ -749,32 +767,47 @@ public class AiUtils {
             if (semanticModel.isEmpty()) {
                 continue;
             }
+
+            List<AiComponentDiskCache.CachedComponent> toCache = new ArrayList<>();
             Stream<ClassSymbol> classSymbols = semanticModel.get().moduleSymbols().stream()
                     .filter(ClassSymbol.class::isInstance).map(ClassSymbol.class::cast);
 
-            // Include version in codedata only if the project has a Dependencies.toml.
-            // Omitting version (null) means "use latest from Central".
-            String codedataVersion = hasDependenciesToml ? module.version() : null;
-
             for (var classSymbol : classSymbols.toList()) {
                 if (isModelProviderClass(classSymbol)) {
-                    modelProviders.add(buildAvailableNode(classSymbol, module, codedataVersion, MODEL_PROVIDER));
+                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, MODEL_PROVIDER);
+                    modelProviders.add(node);
+                    toCache.add(toCachedComponent(classSymbol, node, "MODEL_PROVIDER"));
                 } else if (isEmbeddingProviderClass(classSymbol)) {
-                    embeddingProviders.add(buildAvailableNode(classSymbol, module, codedataVersion,
-                            EMBEDDING_PROVIDER));
+                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion,
+                            EMBEDDING_PROVIDER);
+                    embeddingProviders.add(node);
+                    toCache.add(toCachedComponent(classSymbol, node, "EMBEDDING_PROVIDER"));
                 } else if (isVectorStoreClass(classSymbol)) {
-                    vectorStores.add(buildAvailableNode(classSymbol, module, codedataVersion, VECTOR_STORE));
+                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, VECTOR_STORE);
+                    vectorStores.add(node);
+                    toCache.add(toCachedComponent(classSymbol, node, "VECTOR_STORE"));
                 } else if (isChunkerClass(classSymbol)) {
-                    chunkers.add(buildAvailableNode(classSymbol, module, codedataVersion, CHUNKER));
+                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, CHUNKER);
+                    chunkers.add(node);
+                    toCache.add(toCachedComponent(classSymbol, node, "CHUNKER"));
                 } else if (isDataLoaderClass(classSymbol)) {
-                    dataLoaders.add(buildAvailableNode(classSymbol, module, codedataVersion, DATA_LOADER));
+                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, DATA_LOADER);
+                    dataLoaders.add(node);
+                    toCache.add(toCachedComponent(classSymbol, node, "DATA_LOADER"));
                 } else if (isShortTermMemoryStoreClass(classSymbol)) {
-                    shortTermMemoryStores.add(buildAvailableNode(classSymbol, module, codedataVersion,
-                            SHORT_TERM_MEMORY_STORE));
+                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion,
+                            SHORT_TERM_MEMORY_STORE);
+                    shortTermMemoryStores.add(node);
+                    toCache.add(toCachedComponent(classSymbol, node, "SHORT_TERM_MEMORY_STORE"));
                 } else if (isKnowledgeBaseClass(classSymbol)) {
-                    knowledgeBases.add(buildAvailableNode(classSymbol, module, codedataVersion, KNOWLEDGE_BASE));
+                    AvailableNode node = buildAvailableNode(classSymbol, module, codedataVersion, KNOWLEDGE_BASE);
+                    knowledgeBases.add(node);
+                    toCache.add(toCachedComponent(classSymbol, node, "KNOWLEDGE_BASE"));
                 }
             }
+
+            // Persist ALL discovered components to disk (even if empty — caches "no components")
+            diskCache.save(module.org(), module.packageName(), module.version(), toCache);
         }
 
         mergeIntoCache(cachedModelProviderMap, cacheKey, modelProviders);
@@ -914,6 +947,48 @@ public class AiUtils {
             default -> codedataBuilder.object(className).symbol(INIT_METHOD);
         }
         return new AvailableNode(metadata, codedataBuilder.build(), true);
+    }
+
+    private static AvailableNode reconstructFromCache(AiComponentDiskCache.CachedComponent comp,
+                                                      ModuleInfo moduleInfo, String codedataVersion) {
+        String icon = CommonUtils.generateIcon(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version());
+        Metadata metadata = new Metadata.Builder<>(null).label(comp.label()).description(comp.description())
+                .icon(icon).build();
+        NodeKind kind = NodeKind.valueOf(comp.category());
+        Codedata.Builder<Object> codedataBuilder = new Codedata.Builder<>(null).version(codedataVersion)
+                .packageName(moduleInfo.packageName()).module(moduleInfo.moduleName()).org(moduleInfo.org())
+                .node(kind);
+        if (INIT_METHOD.equals(comp.symbol())) {
+            codedataBuilder.object(comp.className()).symbol(INIT_METHOD);
+        } else {
+            codedataBuilder.symbol(comp.symbol());
+        }
+        return new AvailableNode(metadata, codedataBuilder.build(), true);
+    }
+
+    private static AiComponentDiskCache.CachedComponent toCachedComponent(ClassSymbol classSymbol,
+                                                                          AvailableNode node, String category) {
+        String className = classSymbol.getName().orElse("");
+        return new AiComponentDiskCache.CachedComponent(className, node.metadata().label(),
+                node.metadata().description(), category, node.codedata().symbol());
+    }
+
+    private static void addToCategory(String category, AvailableNode node,
+                                      List<AvailableNode> modelProviders, List<AvailableNode> embeddingProviders,
+                                      List<AvailableNode> vectorStores, List<AvailableNode> chunkers,
+                                      List<AvailableNode> dataLoaders, List<AvailableNode> shortTermMemoryStores,
+                                      List<AvailableNode> knowledgeBases) {
+        switch (category) {
+            case "MODEL_PROVIDER" -> modelProviders.add(node);
+            case "EMBEDDING_PROVIDER" -> embeddingProviders.add(node);
+            case "VECTOR_STORE" -> vectorStores.add(node);
+            case "CHUNKER" -> chunkers.add(node);
+            case "DATA_LOADER" -> dataLoaders.add(node);
+            case "SHORT_TERM_MEMORY_STORE" -> shortTermMemoryStores.add(node);
+            case "KNOWLEDGE_BASE" -> knowledgeBases.add(node);
+            default -> {
+            }
+        }
     }
 
     private static Optional<String> getDisplayLabel(ClassSymbol classSymbol) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCacheTest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCacheTest.java
@@ -67,7 +67,7 @@ public class AiComponentDiskCacheTest {
         Assert.assertEquals(loaded.get(), components);
     }
 
-    @Test(description = "Verifies an empty component list persists and loads back as an empty list, not empty Optional.")
+    @Test(description = "Verifies an empty component list persists and loads back as an empty list, not as empty.")
     public void testEmptyListPersistsAndLoadsAsEmpty() {
         cache.save("ballerinax", "ai.empty", "1.0.0", List.of());
         Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.empty", "1.0.0");
@@ -85,7 +85,8 @@ public class AiComponentDiskCacheTest {
     @Test(description = "Verifies a cache file with corrupt JSON is treated as a miss rather than throwing.")
     public void testCorruptJsonReturnsEmpty() throws IOException {
         cache.save("ballerinax", "ai.corrupt", "1.0.0", List.of(
-                new CachedComponent("X", "label", "desc", NodeKind.MODEL_PROVIDER.name(), "init")));
+                new CachedComponent("X", "label", "desc", NodeKind.MODEL_PROVIDER.name(),
+                        "init")));
         Files.writeString(findCacheFile(), "{ not valid json");
 
         Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.corrupt", "1.0.0");
@@ -106,7 +107,8 @@ public class AiComponentDiskCacheTest {
     @Test(description = "Verifies load rejects the whole file when any cached component has a null required field.")
     public void testNullFieldInComponentRejectsFile() {
         List<CachedComponent> bad = List.of(
-                new CachedComponent(null, "label", "desc", NodeKind.MODEL_PROVIDER.name(), "init"));
+                new CachedComponent(null, "label", "desc", NodeKind.MODEL_PROVIDER.name(),
+                        "init"));
         cache.save("ballerinax", "ai.nulls", "1.0.0", bad);
 
         Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.nulls", "1.0.0");
@@ -117,7 +119,8 @@ public class AiComponentDiskCacheTest {
     @Test(description = "Verifies load rejects the whole file when any category is not a valid NodeKind name.")
     public void testUnknownCategoryRejectsFile() {
         List<CachedComponent> bad = List.of(
-                new CachedComponent("X", "label", "desc", "NOT_A_REAL_CATEGORY", "init"));
+                new CachedComponent("X", "label", "desc", "NOT_A_REAL_CATEGORY",
+                        "init"));
         cache.save("ballerinax", "ai.bogus", "1.0.0", bad);
 
         Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.bogus", "1.0.0");
@@ -134,10 +137,12 @@ public class AiComponentDiskCacheTest {
     @Test(description = "Verifies a save with a null version is a no-op and writes no files.")
     public void testNullVersionBypassesSave() throws IOException {
         cache.save("ballerinax", "ai.openai", null, List.of(
-                new CachedComponent("X", "l", "d", NodeKind.MODEL_PROVIDER.name(), "init")));
+                new CachedComponent("X", "l", "d", NodeKind.MODEL_PROVIDER.name(),
+                        "init")));
 
         try (var stream = Files.list(tempDir)) {
-            Assert.assertEquals(stream.count(), 0L, "save() with null version must not write any files");
+            Assert.assertEquals(stream.count(), 0L,
+                    "save() with null version must not write any files");
         }
     }
 
@@ -148,7 +153,8 @@ public class AiComponentDiskCacheTest {
         AiComponentDiskCache blockedCache = new AiComponentDiskCache(blockedCachePath);
         try {
             List<CachedComponent> components = List.of(
-                    new CachedComponent("X", "l", "d", NodeKind.MODEL_PROVIDER.name(), "init"));
+                    new CachedComponent("X", "l", "d", NodeKind.MODEL_PROVIDER.name(),
+                            "init"));
 
             // First save fails because the cache path is a regular file — disables the cache
             blockedCache.save("ballerinax", "ai.blocked", "1.0.0", components);

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCacheTest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCacheTest.java
@@ -1,0 +1,198 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import io.ballerina.flowmodelgenerator.core.AiComponentDiskCache.CachedComponent;
+import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Tests for {@link AiComponentDiskCache}.
+ *
+ * @since 1.7.0
+ */
+public class AiComponentDiskCacheTest {
+
+    private Path tempDir;
+    private AiComponentDiskCache cache;
+
+    @BeforeMethod
+    public void setup() throws IOException {
+        tempDir = Files.createTempDirectory("ai-component-disk-cache-test");
+        cache = new AiComponentDiskCache(tempDir);
+    }
+
+    @AfterMethod
+    public void cleanup() throws IOException {
+        deleteRecursively(tempDir);
+    }
+
+    @Test(description = "Verifies a saved component list roundtrips back unchanged from the same cache instance.")
+    public void testRoundtrip() {
+        List<CachedComponent> components = List.of(
+                new CachedComponent("OpenAiProvider", "OpenAI", "OpenAI model provider",
+                        NodeKind.MODEL_PROVIDER.name(), "init"),
+                new CachedComponent("PineconeStore", "Pinecone", "Pinecone vector store",
+                        NodeKind.VECTOR_STORE.name(), "init"));
+
+        cache.save("ballerinax", "ai.openai", "1.4.0", components);
+        Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.openai", "1.4.0");
+
+        Assert.assertTrue(loaded.isPresent());
+        Assert.assertEquals(loaded.get(), components);
+    }
+
+    @Test(description = "Verifies an empty component list persists and loads back as an empty list, not empty Optional.")
+    public void testEmptyListPersistsAndLoadsAsEmpty() {
+        cache.save("ballerinax", "ai.empty", "1.0.0", List.of());
+        Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.empty", "1.0.0");
+
+        Assert.assertTrue(loaded.isPresent());
+        Assert.assertTrue(loaded.get().isEmpty());
+    }
+
+    @Test(description = "Verifies a load for a module that was never saved returns an empty Optional.")
+    public void testMissingFileReturnsEmpty() {
+        Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.nope", "1.0.0");
+        Assert.assertTrue(loaded.isEmpty());
+    }
+
+    @Test(description = "Verifies a cache file with corrupt JSON is treated as a miss rather than throwing.")
+    public void testCorruptJsonReturnsEmpty() throws IOException {
+        cache.save("ballerinax", "ai.corrupt", "1.0.0", List.of(
+                new CachedComponent("X", "label", "desc", NodeKind.MODEL_PROVIDER.name(), "init")));
+        Files.writeString(findCacheFile(), "{ not valid json");
+
+        Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.corrupt", "1.0.0");
+
+        Assert.assertTrue(loaded.isEmpty());
+    }
+
+    @Test(description = "Verifies a cache file with a mismatched schemaVersion is treated as a miss.")
+    public void testSchemaMismatchReturnsEmpty() throws IOException {
+        cache.save("ballerinax", "ai.oldschema", "1.0.0", List.of());
+        Files.writeString(findCacheFile(), "{\"schemaVersion\":999,\"components\":[]}");
+
+        Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.oldschema", "1.0.0");
+
+        Assert.assertTrue(loaded.isEmpty());
+    }
+
+    @Test(description = "Verifies load rejects the whole file when any cached component has a null required field.")
+    public void testNullFieldInComponentRejectsFile() {
+        List<CachedComponent> bad = List.of(
+                new CachedComponent(null, "label", "desc", NodeKind.MODEL_PROVIDER.name(), "init"));
+        cache.save("ballerinax", "ai.nulls", "1.0.0", bad);
+
+        Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.nulls", "1.0.0");
+
+        Assert.assertTrue(loaded.isEmpty());
+    }
+
+    @Test(description = "Verifies load rejects the whole file when any category is not a valid NodeKind name.")
+    public void testUnknownCategoryRejectsFile() {
+        List<CachedComponent> bad = List.of(
+                new CachedComponent("X", "label", "desc", "NOT_A_REAL_CATEGORY", "init"));
+        cache.save("ballerinax", "ai.bogus", "1.0.0", bad);
+
+        Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.bogus", "1.0.0");
+
+        Assert.assertTrue(loaded.isEmpty());
+    }
+
+    @Test(description = "Verifies a load with a null version short-circuits to empty without touching the filesystem.")
+    public void testNullVersionBypassesLoad() {
+        Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.openai", null);
+        Assert.assertTrue(loaded.isEmpty());
+    }
+
+    @Test(description = "Verifies a save with a null version is a no-op and writes no files.")
+    public void testNullVersionBypassesSave() throws IOException {
+        cache.save("ballerinax", "ai.openai", null, List.of(
+                new CachedComponent("X", "l", "d", NodeKind.MODEL_PROVIDER.name(), "init")));
+
+        try (var stream = Files.list(tempDir)) {
+            Assert.assertEquals(stream.count(), 0L, "save() with null version must not write any files");
+        }
+    }
+
+    @Test(description = "Verifies a disk write failure disables the cache so subsequent saves become no-ops.")
+    public void testDiskWriteFailureDisablesCache() throws IOException {
+        // Block the cache directory path with a regular file so createDirectories will fail
+        Path blockedCachePath = Files.createTempFile("blocked-cache-path", ".txt");
+        AiComponentDiskCache blockedCache = new AiComponentDiskCache(blockedCachePath);
+        try {
+            List<CachedComponent> components = List.of(
+                    new CachedComponent("X", "l", "d", NodeKind.MODEL_PROVIDER.name(), "init"));
+
+            // First save fails because the cache path is a regular file — disables the cache
+            blockedCache.save("ballerinax", "ai.blocked", "1.0.0", components);
+
+            // Remove the blocker so the path is free
+            Files.delete(blockedCachePath);
+
+            // Second save must be a no-op now; if the cache were still enabled,
+            // createDirectories would create a directory at blockedCachePath
+            blockedCache.save("ballerinax", "ai.blocked", "1.0.0", components);
+
+            Assert.assertFalse(Files.exists(blockedCachePath),
+                    "disabled cache must not create the cache directory on subsequent saves");
+        } finally {
+            Files.deleteIfExists(blockedCachePath);
+        }
+    }
+
+    private Path findCacheFile() throws IOException {
+        try (var stream = Files.list(tempDir)) {
+            return stream.filter(p -> !p.getFileName().toString().startsWith("tmp_"))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("no cache file found in " + tempDir));
+        }
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (root == null || Files.notExists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            paths.sorted((left, right) -> right.getNameCount() - left.getNameCount())
+                    .forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof IOException ioException) {
+                throw ioException;
+            }
+            throw e;
+        }
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
@@ -3,6 +3,7 @@
 <suite name="flow-model-generator-core-test-suite">
     <test name="flow-model-generator-core-tests">
         <classes>
+            <class name="io.ballerina.flowmodelgenerator.core.AiComponentDiskCacheTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.ConnectionActionProviderTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.service.ServiceIndexLoaderTest"/>
         </classes>


### PR DESCRIPTION
## Purpose

Related to https://github.com/wso2/product-integrator/issues/472

Adds disk caching for AI component metadata (Model Provider, Embedding Provider, Vector Stores, etc.) to avoid re-loading semantic models for AI modules every time users fetch AI component nodes in the WSO2 Integrator UI.

## Goals
- Skip semantic model loading for AI modules already analyzed in a prior LS session.
- Persist discovery results across LS restarts — first-time cost paid once per module version, not per session.
- Degrade gracefully on I/O failure; fall back to the existing semantic-model path.

## Approach

New `AiComponentDiskCache` class persists component metadata as JSON, one file per `(org, name, version)`, in `java.io.tmpdir/ballerina-ls-ai-component-cache/`. Safe because pinned module versions expose an immutable set of AI components.

Integration in `AiUtils.loadAiComponentsForProject`:

1. Check disk cache first. On hit, reconstruct `AvailableNode`s from cached metadata and skip the semantic model.
2. On miss, run the existing semantic-model walk and persist all discovered components (including the empty case).
3. Existing in-memory caches are unchanged — disk layer sits beneath them.

Lookup order: in-memory → disk → semantic model.

Resilience:

- Atomic writes (temp file + `ATOMIC_MOVE`, with fallback for filesystems that don't support it).
- `SCHEMA_VERSION = 1` — mismatched/corrupt files are ignored, not failed on.
- `diskAvailable` flag self-disables the cache for the session on any write failure.
- `version == null` (no `Dependencies.toml`, "use latest from Central") bypasses the cache — caching an unpinned version would be unsafe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Introduces a disk-based cache for AI component metadata to optimize semantic model loading in the flow model generator. This reduces redundant re-analysis of AI module information across language-server sessions.

## Key Changes

**New AiComponentDiskCache Class**
- Implements persistent JSON-based caching of AI component information (className, label, description, category, symbol)
- Stores cache files in a temp directory under `ballerina-ls-ai-component-cache/`, organized by module org, name, and version
- Includes internal schema versioning (v1) for forward compatibility and validation
- Provides atomic write operations with filesystem fallback support to ensure reliable persistence

**Integration with AiUtils**
- Modified `buildCategoryCache()` to check the disk cache before performing semantic model analysis
- On cache hit: reconstructs component nodes from cached metadata and skips semantic model loading
- On cache miss: executes the existing semantic model analysis and persists results to disk for future sessions
- Maintains existing in-memory caching layer; disk cache operates transparently beneath it

## Resilience & Safety
- Gracefully degrades on I/O failures by disabling disk caching for the session and falling back to semantic model loading
- Ignores corrupted or mismatched cache files rather than failing
- Skips caching for unpinned module versions (those without a fixed version constraint)
- Uses atomic file operations (temp file + rename) to prevent partial or corrupted cache entries

## Impact
- First-time analysis cost for each module version is paid once, then amortized across LS restarts
- No changes to public APIs; all modifications are internal to the component analysis flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->