### PR TITLE
Remove hardcoded default username/password in FTP init form

### DIFF
--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/services/ftp_init.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/services/ftp_init.json
@@ -216,7 +216,7 @@
                                   },
                                   "enabled": true,
                                   "editable": true,
-                                  "value": "\"default\"",
+                                  "value": "",
                                   "types": [
                                     {
                                       "fieldType": "TEXT",
@@ -232,8 +232,8 @@
                                   "valueType": "IDENTIFIER",
                                   "valueTypeConstraint": "string",
                                   "isType": false,
-                                  "placeholder": "default",
-                                  "optional": true,
+                                  "placeholder": "",
+                                  "optional": false,
                                   "advanced": false
                                 },
                                 "password": {
@@ -243,7 +243,7 @@
                                   },
                                   "enabled": true,
                                   "editable": true,
-                                  "value": "\"default\"",
+                                  "value": "",
                                   "types": [
                                     {
                                       "fieldType": "TEXT",
@@ -259,7 +259,7 @@
                                   "valueType": "IDENTIFIER",
                                   "valueTypeConstraint": "string",
                                   "isType": false,
-                                  "placeholder": "default",
+                                  "placeholder": "",
                                   "optional": true,
                                   "advanced": false
                                 }
@@ -395,7 +395,7 @@
                                   },
                                   "enabled": true,
                                   "editable": true,
-                                  "value": "\"default\"",
+                                  "value": "",
                                   "types": [
                                     {
                                       "fieldType": "TEXT",
@@ -411,8 +411,8 @@
                                   "valueType": "IDENTIFIER",
                                   "valueTypeConstraint": "string",
                                   "isType": false,
-                                  "placeholder": "default",
-                                  "optional": true,
+                                  "placeholder": "",
+                                  "optional": false,
                                   "advanced": false
                                 },
                                 "password": {
@@ -422,7 +422,7 @@
                                   },
                                   "enabled": true,
                                   "editable": true,
-                                  "value": "\"default\"",
+                                  "value": "",
                                   "types": [
                                     {
                                       "fieldType": "TEXT",
@@ -438,7 +438,7 @@
                                   "valueType": "IDENTIFIER",
                                   "valueTypeConstraint": "string",
                                   "isType": false,
-                                  "placeholder": "default",
+                                  "placeholder": "",
                                   "optional": true,
                                   "advanced": false
                                 }
@@ -654,7 +654,7 @@
                                   },
                                   "enabled": true,
                                   "editable": true,
-                                  "value": "\"default\"",
+                                  "value": "",
                                   "types": [
                                     {
                                       "fieldType": "TEXT",
@@ -670,8 +670,8 @@
                                   "valueType": "IDENTIFIER",
                                   "valueTypeConstraint": "string",
                                   "isType": false,
-                                  "placeholder": "default",
-                                  "optional": true,
+                                  "placeholder": "",
+                                  "optional": false,
                                   "advanced": false
                                 },
                                 "password": {
@@ -681,7 +681,7 @@
                                   },
                                   "enabled": true,
                                   "editable": true,
-                                  "value": "\"default\"",
+                                  "value": "",
                                   "types": [
                                     {
                                       "fieldType": "TEXT",

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/ftp_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/ftp_service_model.json
@@ -159,8 +159,8 @@
                                         "label": "Username",
                                         "description": "Remote server username for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -175,7 +175,7 @@
                                       ],
                                       "enabled": true,
                                       "editable": true,
-                                      "optional": true,
+                                      "optional": false,
                                       "advanced": false
                                     },
                                     "password": {
@@ -183,8 +183,8 @@
                                         "label": "Password",
                                         "description": "Remote server password for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -321,8 +321,8 @@
                                         "label": "Username",
                                         "description": "Remote server username for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -337,7 +337,7 @@
                                       ],
                                       "enabled": true,
                                       "editable": true,
-                                      "optional": true,
+                                      "optional": false,
                                       "advanced": false
                                     },
                                     "password": {
@@ -345,8 +345,8 @@
                                         "label": "Password",
                                         "description": "Remote server password for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -557,8 +557,8 @@
                                         "label": "Username",
                                         "description": "Remote server username for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -573,7 +573,7 @@
                                       ],
                                       "enabled": true,
                                       "editable": true,
-                                      "optional": true,
+                                      "optional": false,
                                       "advanced": false
                                     },
                                     "password": {
@@ -585,7 +585,7 @@
                                         "type": "IDENTIFIER"
                                       },
                                       "placeholder": "",
-                                      "value": "\"default\"",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/ftp_service_model_sftp_basic_auth.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_init_model/config/ftp_service_model_sftp_basic_auth.json
@@ -159,8 +159,8 @@
                                         "label": "Username",
                                         "description": "Remote server username for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -175,7 +175,7 @@
                                       ],
                                       "enabled": true,
                                       "editable": true,
-                                      "optional": true,
+                                      "optional": false,
                                       "advanced": false
                                     },
                                     "password": {
@@ -183,8 +183,8 @@
                                         "label": "Password",
                                         "description": "Remote server password for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -321,8 +321,8 @@
                                         "label": "Username",
                                         "description": "Remote server username for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -337,7 +337,7 @@
                                       ],
                                       "enabled": true,
                                       "editable": true,
-                                      "optional": true,
+                                      "optional": false,
                                       "advanced": false
                                     },
                                     "password": {
@@ -345,8 +345,8 @@
                                         "label": "Password",
                                         "description": "Remote server password for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -557,8 +557,8 @@
                                         "label": "Username",
                                         "description": "Remote server username for authentication"
                                       },
-                                      "placeholder": "default",
-                                      "value": "\"default\"",
+                                      "placeholder": "",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",
@@ -573,7 +573,7 @@
                                       ],
                                       "enabled": true,
                                       "editable": true,
-                                      "optional": true,
+                                      "optional": false,
                                       "advanced": false
                                     },
                                     "password": {
@@ -585,7 +585,7 @@
                                         "type": "IDENTIFIER"
                                       },
                                       "placeholder": "",
-                                      "value": "\"default\"",
+                                      "value": "",
                                       "types": [
                                         {
                                           "fieldType": "TEXT",


### PR DESCRIPTION
## Summary
- Clear `value="\"default\""` from Basic Authentication username and password fields across FTP/SFTP/FTPS in `ftp_init.json`
- Clear the `"default"` placeholder that previously showed in the form input
- Mark username as mandatory (`optional: false`); password remains optional

Motivation: the "default" strings were leaking into the listener configuration form as apparent default credentials, which is misleading and also bled through to the generated Ballerina code. The form now starts with genuinely empty fields.

## Test plan
- [ ] Open the FTP service listener form in BI — username/password start empty, no "default" placeholder
- [ ] Verify username is marked required (blank username blocks form submit)
- [ ] Verify password can be left blank
- [ ] Repeat for SFTP and FTPS protocol selections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request removes hardcoded "default" placeholder values from the FTP, SFTP, and FTPS listener service initialization forms. The changes ensure that authentication fields start empty rather than displaying default text, preventing unintended values from appearing in generated Ballerina code.

**Key changes:**
- Cleared `value` and `placeholder` fields for both `userName` and `password` in the Basic Authentication configuration across all three protocol variants
- Made the `userName` field mandatory by setting `optional: false` while keeping `password` optional
- Updated corresponding test fixtures to reflect the new form initialization behavior

The modifications improve clarity of the form initialization process and strengthen field validation by requiring users to explicitly provide a username, while allowing the password field to remain optional based on configuration needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->