### PR TITLE
Make inputs required in DATA_MAPPER_CREATION  template node

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataMapperCreationBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataMapperCreationBuilder.java
@@ -94,6 +94,10 @@ public class DataMapperCreationBuilder extends NodeBuilder {
         return false;
     }
 
+    protected boolean isInputsOptional() {
+        return false;
+    }
+
     @Override
     public void setConcreteConstData() {
         metadata().label(LABEL).description(DESCRIPTION);
@@ -135,7 +139,7 @@ public class DataMapperCreationBuilder extends NodeBuilder {
     public void setOptionalProperties(NodeBuilder nodeBuilder) {
         nodeBuilder.properties()
                 .endNestedProperty(Property.ValueType.REPEATABLE_PROPERTY, Property.PARAMETERS_KEY, PARAMETERS_LABEL,
-                        getParametersDoc(), getParameterSchema(), true, false);
+                        getParametersDoc(), getParameterSchema(), isInputsOptional(), false);
     }
 
     @Override

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionCreationBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionCreationBuilder.java
@@ -101,4 +101,9 @@ public class FunctionCreationBuilder extends DataMapperCreationBuilder {
     protected boolean isOutputOptional() {
         return true;
     }
+
+    @Override
+    protected boolean isInputsOptional() {
+        return true;
+    }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-creation.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-creation.json
@@ -103,7 +103,7 @@
           }
         ],
         "value": {},
-        "optional": true,
+        "optional": false,
         "editable": false,
         "advanced": false,
         "hidden": false


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2-enterprise/integration-engineering/issues/1352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request modifies the DATA_MAPPER_CREATION template node to require inputs rather than making them optional, addressing issue #1352. The change improves data mapper configuration by enforcing that inputs must be explicitly provided.

## Changes

**Core Implementation:**
- Added `isInputsOptional()` method to `DataMapperCreationBuilder` that defaults to `false`, changing the inputs property from optional to required
- Updated `FunctionCreationBuilder` to explicitly override `isInputsOptional()` returning `true`, ensuring function creation inputs remain optional

**Test Configuration:**
- Updated the `data_mapper-creation.json` test resource to reflect the new required-inputs behavior by changing the `optional` flag for parameters from `true` to `false`

## Impact

The DATA_MAPPER_CREATION template node now enforces that users provide inputs, while function creation nodes continue to allow optional inputs. This change ensures consistent input handling across different template node types and improves the configuration experience by making required fields explicit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->