### PR TITLE
Show WSO2 default embedding provider vector dimensions in low-code UI

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/EmbeddingProviderBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/EmbeddingProviderBuilder.java
@@ -19,6 +19,7 @@
 package io.ballerina.flowmodelgenerator.core.model.node;
 
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.flowmodelgenerator.core.Constants;
 import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
@@ -44,6 +45,7 @@ import static io.ballerina.modelgenerator.commons.FunctionDataBuilder.GET_DEFAUL
  * @since 1.1.0
  */
 public class EmbeddingProviderBuilder extends CallBuilder {
+
     public static final String LABEL = "Embedding Provider";
     public static final String DESCRIPTION = "Embedding providers available in the integration for connecting" +
             " to an embedding model";
@@ -51,6 +53,10 @@ public class EmbeddingProviderBuilder extends CallBuilder {
     private static final String EMBEDDING_PROVIDER_NAME_LABEL = "Embedding Provider Name";
     private static final String EMBEDDING_PROVIDER_NAME_LABEL_DOC = "Name of the embedding-provider connection";
     private static final String CHECK_ERROR_DOC = "Terminate on error";
+    private static final String WSO2_EMBEDDING_PROVIDER_RETURN_TYPE =
+            Constants.Ai.AI_PACKAGE + ":" + Constants.Ai.WSO2_EMBEDDING_PROVIDER_NAME;
+    private static final String WSO2_EMBEDDING_PROVIDER_VECTOR_DIMENSION_DOC =
+            "The embedding vector dimension is 1536.";
 
     @Override
     public void setConcreteConstData() {
@@ -103,7 +109,16 @@ public class EmbeddingProviderBuilder extends CallBuilder {
                 .filePath(context.filePath())
                 .build();
 
-        metadata().label(functionData.packageName()).description(functionData.description())
+        String description = functionData.description();
+
+        // Append documentation about the default embedding provider’s vector dimensions.
+        // This helps surface the vector size in the low-code UI so users are aware of it.
+        if (WSO2_EMBEDDING_PROVIDER_RETURN_TYPE.equals(functionData.returnType())) {
+            description = (description == null || description.isBlank())
+                    ? WSO2_EMBEDDING_PROVIDER_VECTOR_DIMENSION_DOC
+                    : description + " " + WSO2_EMBEDDING_PROVIDER_VECTOR_DIMENSION_DOC;
+        }
+        metadata().label(functionData.packageName()).description(description)
                 .icon(CommonUtils.generateIcon(functionData.org(), functionData.packageName(), functionData.version()));
 
         codedata().node(NodeKind.EMBEDDING_PROVIDER)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/EmbeddingProviderBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/EmbeddingProviderBuilder.java
@@ -56,7 +56,7 @@ public class EmbeddingProviderBuilder extends CallBuilder {
     private static final String WSO2_EMBEDDING_PROVIDER_RETURN_TYPE =
             Constants.Ai.AI_PACKAGE + ":" + Constants.Ai.WSO2_EMBEDDING_PROVIDER_NAME;
     private static final String WSO2_EMBEDDING_PROVIDER_VECTOR_DIMENSION_DOC =
-            "The embedding vector dimension is 1536.";
+            "The embedding vectors have a dimension of 1536.";
 
     @Override
     public void setConcreteConstData() {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_default_embedding_provider_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_default_embedding_provider_template.json
@@ -13,7 +13,7 @@
       "id": "31",
       "metadata": {
         "label": "Embedding Provider",
-        "description": "Creates a default embedding provider based on the provided `wso2ProviderConfig`. The embedding vector dimension is 1536.",
+        "description": "Creates a default embedding provider based on the provided `wso2ProviderConfig`. The embedding vectors have a dimension of 1536.",
         "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.1.0.png"
       },
       "codedata": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_default_embedding_provider_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_default_embedding_provider_template.json
@@ -13,7 +13,7 @@
       "id": "31",
       "metadata": {
         "label": "Embedding Provider",
-        "description": "Creates a default embedding provider based on the provided `wso2ProviderConfig`.",
+        "description": "Creates a default embedding provider based on the provided `wso2ProviderConfig`. The embedding vector dimension is 1536.",
         "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.1.0.png"
       },
       "codedata": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_wso2_embedding_provider_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_wso2_embedding_provider_template.json
@@ -14,7 +14,7 @@
       "id": "31",
       "metadata": {
         "label": "Embedding Provider",
-        "description": "Initializes a new `Wso2EmbeddingProvider` instance.\n",
+        "description": "Initializes a new `Wso2EmbeddingProvider` instance.\n The embedding vector dimension is 1536.",
         "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.1.0.png"
       },
       "codedata": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_wso2_embedding_provider_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_wso2_embedding_provider_template.json
@@ -14,7 +14,7 @@
       "id": "31",
       "metadata": {
         "label": "Embedding Provider",
-        "description": "Initializes a new `Wso2EmbeddingProvider` instance.\n The embedding vector dimension is 1536.",
+        "description": "Initializes a new `Wso2EmbeddingProvider` instance.\n  The embedding vectors have a dimension of 1536.",
         "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.1.0.png"
       },
       "codedata": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_wso2_embedding_provider_template.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/get_wso2_embedding_provider_template.json
@@ -14,7 +14,7 @@
       "id": "31",
       "metadata": {
         "label": "Embedding Provider",
-        "description": "Initializes a new `Wso2EmbeddingProvider` instance.\n  The embedding vectors have a dimension of 1536.",
+        "description": "Initializes a new `Wso2EmbeddingProvider` instance.\n The embedding vectors have a dimension of 1536.",
         "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.1.0.png"
       },
       "codedata": {


### PR DESCRIPTION
## Purpose

Related to https://github.com/wso2/product-integrator/issues/902

Append "The embedding vector dimension is 1536." to the description of the WSO2 default embedding provider so users know the fixed dimension when configuring downstream vector stores.

<img width="404" height="505" alt="image" src="https://github.com/user-attachments/assets/2b74d7d7-b9c1-49d3-abf7-102aeee6c6ae" />
