### PR TITLE
Emit REPEATABLE_LIST listener properties in generated source

### DIFF
--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Value.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Value.java
@@ -137,7 +137,8 @@ public class Value {
         return enabled && (
                 (value != null && ((value instanceof String && !((String) value).isEmpty()) ||
                         (value instanceof JsonPrimitive jsonPrimitive && !jsonPrimitive.getAsString().isEmpty()) ||
-                                (value instanceof Map<?, ?>))) ||
+                                (value instanceof Map<?, ?>) ||
+                                (value instanceof List<?> list && !list.isEmpty()))) ||
                         (values != null && !values.isEmpty()));
     }
 

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_listener/config/update_ftp_listener_sftp_compression.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_listener/config/update_ftp_listener_sftp_compression.json
@@ -1,0 +1,182 @@
+{
+  "filePath": "update_ftp_listener.bal",
+  "description": "REPEATABLE_LIST property (sftpCompression) sent as a List value should be emitted in the constructor call",
+  "listener": {
+    "name": "Ftp Listener",
+    "type": "ftp",
+    "displayName": "Ftp",
+    "description": "FTP listener",
+    "moduleName": "ftp",
+    "orgName": "ballerina",
+    "version": "2.16.0",
+    "packageName": "ftp",
+    "listenerProtocol": "ftp",
+    "icon": "",
+    "properties": {
+      "variableNameKey": {
+        "metadata": {
+          "label": "Name",
+          "description": "The name of the listener"
+        },
+        "codedata": {
+          "lineRange": {
+            "fileName": "update_ftp_listener.bal",
+            "startLine": {
+              "line": 2,
+              "offset": 22
+            },
+            "endLine": {
+              "line": 2,
+              "offset": 31
+            }
+          }
+        },
+        "value": "listener1",
+        "types": [
+          {
+            "fieldType": "IDENTIFIER",
+            "selected": true
+          }
+        ],
+        "enabled": true,
+        "editable": false,
+        "optional": false,
+        "advanced": false
+      },
+      "listenerType": {
+        "metadata": {
+          "label": "Listener Type",
+          "description": "The type of the listener"
+        },
+        "value": "Listener",
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "selected": true
+          }
+        ],
+        "enabled": false,
+        "editable": false,
+        "optional": false,
+        "advanced": false
+      },
+      "host": {
+        "metadata": {
+          "label": "Host",
+          "description": "FTP server host"
+        },
+        "codedata": {
+          "type": "LISTENER_INIT_PARAM",
+          "originalName": "host"
+        },
+        "placeholder": "\"127.0.0.1\"",
+        "value": "\"127.0.0.1\"",
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": true
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "string",
+            "selected": false
+          }
+        ],
+        "enabled": true,
+        "editable": true,
+        "optional": true,
+        "advanced": false
+      },
+      "sftpCompression": {
+        "metadata": {
+          "label": "Sftp Compression",
+          "description": "Compression algorithms to use (SFTP only)"
+        },
+        "codedata": {
+          "type": "LISTENER_INIT_PARAM",
+          "originalName": "sftpCompression"
+        },
+        "placeholder": "[]",
+        "value": [
+          {
+            "key": "ar-elm-1",
+            "value": "\"zlib\"",
+            "types": [
+              {
+                "fieldType": "SINGLE_SELECT",
+                "ballerinaType": "ftp:TransferCompression",
+                "selected": true
+              },
+              {
+                "fieldType": "EXPRESSION",
+                "ballerinaType": "ftp:TransferCompression",
+                "selected": false
+              }
+            ]
+          }
+        ],
+        "types": [
+          {
+            "fieldType": "REPEATABLE_LIST",
+            "ballerinaType": "ftp:TransferCompression[]",
+            "template": {
+              "types": [
+                {
+                  "fieldType": "SINGLE_SELECT",
+                  "ballerinaType": "ftp:TransferCompression",
+                  "selected": true
+                },
+                {
+                  "fieldType": "EXPRESSION",
+                  "ballerinaType": "ftp:TransferCompression",
+                  "selected": false
+                }
+              ]
+            },
+            "selected": true
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "ftp:TransferCompression[]",
+            "selected": false
+          }
+        ],
+        "enabled": true,
+        "editable": true,
+        "optional": true,
+        "advanced": false
+      }
+    },
+    "codedata": {
+      "lineRange": {
+        "fileName": "update_ftp_listener.bal",
+        "startLine": {
+          "line": 2,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 2,
+          "offset": 59
+        }
+      }
+    }
+  },
+  "output": {
+    "update_ftp_listener.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 2,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 59
+          }
+        },
+        "newText": "listener ftp:Listener listener1 = new (host = \"127.0.0.1\", sftpCompression = [\"zlib\"]);"
+      }
+    ]
+  }
+}

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_listener/source/update_ftp_listener.bal
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_listener/source/update_ftp_listener.bal
@@ -1,0 +1,3 @@
+import ballerina/ftp;
+
+listener ftp:Listener listener1 = new (host = "127.0.0.1");


### PR DESCRIPTION
## Purpose

Fixes wso2/product-integrator#170 — editing the FTP listener and adding values to `sftpCompression` (a `TransferCompression[]` field — array of enum) appears to work in the editor, but the chosen values never make it to the generated `.bal` source.

## Root cause

The front-end sends a `REPEATABLE_LIST` property's value back as a JSON array (each element being a sub-`Value` map). After Gson deserialization on the LS side, `Value.value` is a `java.util.List<?>`.

`Value.isEnabledWithValue()` only recognized `String`, `JsonPrimitive`, `Map`, and the separate `values` field — it had no `List<?>` branch. So the predicate returned `false`, and `Listener.appendListenerConstructorCall` silently skipped the property when generating the constructor call.

`Value.getValue()` already knows how to render a `List<?>` via `buildListSourceCode` (produces `[…]` syntax), so the fix is purely in the gating predicate.

## Change

```diff
 public boolean isEnabledWithValue() {
     return enabled && (
             (value != null && ((value instanceof String && !((String) value).isEmpty()) ||
                     (value instanceof JsonPrimitive jsonPrimitive && !jsonPrimitive.getAsString().isEmpty()) ||
-                            (value instanceof Map<?, ?>))) ||
+                            (value instanceof Map<?, ?>) ||
+                            (value instanceof List<?> list && !list.isEmpty()))) ||
                     (values != null && !values.isEmpty()));
 }
```

## Test

Added an `UpdateListenerTest` fixture (`update_ftp_listener_sftp_compression.json` + `update_ftp_listener.bal`) that sends a `Listener` model with `sftpCompression` carrying the front-end-shape list value and asserts the regenerated source contains `sftpCompression = ["zlib"]`. Without the fix the test fails (the property is dropped from the constructor call); with the fix it passes.

```
$ ./gradlew :service-model-generator:service-model-generator-ls-extension:test --tests UpdateListenerTest
…
update_ftp_listener_sftp_compression.json — passed
update_http_listener.json — passed
BUILD SUCCESSFUL
```

## Security checks

- [x] No keys / passwords / tokens / secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug where repeatable list listener properties were not being emitted in generated Ballerina source code. The language server was dropping array-type configuration values during listener constructor generation, preventing users from persisting changes to such properties through the configuration UI.

## Changes

**Root Cause Fix:**
Modified the `Value.isEnabledWithValue()` method in the service model generator to recognize non-empty `List<?>` types as valid values, allowing array-type listener properties to be properly included during code generation. Previously, the method only checked for `String`, `JsonPrimitive`, and `Map` types, causing list properties to be skipped.

**Test Coverage:**
Added test fixtures for FTP listener configuration to validate that repeatable list properties (specifically the `sftpCompression` array) are correctly round-tripped through the code generation process, ensuring that user edits to such properties persist in the generated source.

## Impact

Enables proper handling of array-type listener configuration properties, allowing users to edit and persist changes to properties like `sftpCompression` in the FTP listener without data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->