### PR TITLE
Make media type field optional

### DIFF
--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/HttpResponse.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/HttpResponse.java
@@ -173,7 +173,7 @@ public class HttpResponse {
         }
 
         public Builder mediaType(String mediaType, boolean editable) {
-            this.mediaType = createValue(mediaType, Value.FieldType.EXPRESSION, editable);
+            this.mediaType = createOptionalValue(mediaType, Value.FieldType.EXPRESSION, editable);
             return this;
         }
 

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/get_http_contract_resource_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/get_http_contract_resource_model.json
@@ -511,7 +511,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_advance_params_1.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_advance_params_1.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_advance_params_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_advance_params_2.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_advance_params_3.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_advance_params_3.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_annotations_1.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_annotations_1.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_headers.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_headers.json
@@ -751,7 +751,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_default.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_default.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_delete.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_delete.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {
@@ -520,7 +520,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_get.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_get.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_head.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_head.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_options.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_options.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_patch.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_patch.json
@@ -524,7 +524,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_post.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_post.json
@@ -524,7 +524,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_put.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_methods_put.json
@@ -524,7 +524,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {
@@ -613,7 +613,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_path_param_1.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_path_param_1.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_path_param_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_path_param_2.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_path_param_3.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_path_param_3.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_payload_1.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_payload_1.json
@@ -524,7 +524,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_payload_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_payload_2.json
@@ -511,7 +511,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_query_param_1.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_query_param_1.json
@@ -672,7 +672,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_query_param_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_query_param_2.json
@@ -525,7 +525,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_query_param_3.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_query_param_3.json
@@ -511,7 +511,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_response_1.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_response_1.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_response_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_response_2.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_response_4.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_response_4.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": false,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {
@@ -520,7 +520,7 @@
             ],
             "enabled": true,
             "editable": false,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {
@@ -609,7 +609,7 @@
             ],
             "enabled": true,
             "editable": false,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {
@@ -644,9 +644,9 @@
             "imports": {},
             "value": [
               {
+                "type": "string",
                 "optional": false,
-                "name": "x\\-path",
-                "type": "string"
+                "name": "x\\-path"
               }
             ],
             "types": [

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_response_5.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/http_response_5.json
@@ -431,7 +431,7 @@
             ],
             "enabled": true,
             "editable": true,
-            "optional": false,
+            "optional": true,
             "advanced": false
           },
           "name": {
@@ -465,9 +465,9 @@
             "imports": {},
             "value": [
               {
+                "type": "string",
                 "optional": false,
-                "name": "x\\-path",
-                "type": "string"
+                "name": "x\\-path"
               }
             ],
             "types": [


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/wso2/product-integrator/issues/939

<img width="1166" height="897" alt="Screenshot 2026-04-26 at 21 31 02" src="https://github.com/user-attachments/assets/375b8685-9e4a-442f-8bfe-094b598bd18f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request makes the media type field optional for HTTP response configurations in the service model generator, resolving an issue where users could not save changes when updating response types without specifying a media type.

## Changes

**Core Logic Change:**
- Modified `HttpResponse.java` to generate media type as an optional field (using `createOptionalValue`) instead of a required field

**Test Fixtures:**
- Updated 25+ test configuration files to reflect the new optional behavior for media type and response accessor fields
- Adjusted expected outputs to align with the optional field metadata changes

## Impact

This change enables users to update HTTP resource response configurations (including response types and status codes) without being required to specify a media type/content type, allowing the Save button to remain functional throughout configuration updates. The change improves the user experience when modifying response definitions in the Ballerina service configuration interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->