### PR TITLE
Support array types in converted variables

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
@@ -4173,7 +4173,7 @@ public class DataMapManager {
     }
 
     public JsonElement convertType(Path filePath, SemanticModel semanticModel, JsonElement cd, String typeName,
-                                   String variableName, String parentTypeName, boolean isInput,
+                                   String variableName, String parentTypeName, boolean isInput, boolean isArray,
                                    Map<String, String> imports) {
         Codedata codedata = gson.fromJson(cd, Codedata.class);
         NonTerminalNode node = getNode(codedata.lineRange());
@@ -4197,7 +4197,7 @@ public class DataMapManager {
                 if (codedata.isNew() != null && codedata.isNew()) {
                     ExpressionNode expr = letExpr.expression();
                     String statement = String.format(", %s %s = %s", typeName, variableName,
-                            expr.kind() == SyntaxKind.MAPPING_CONSTRUCTOR ? expr.toSourceCode().trim() : "{}");
+                            getConvertedOutputExpression(expr, isArray));
                     SeparatedNodeList<LetVariableDeclarationNode> letVarDeclarationNodes = letExpr.letVarDeclarations();
                     LinePosition linePosition =
                             letVarDeclarationNodes.get(letVarDeclarationNodes.size() - 1).lineRange().endLine();
@@ -4231,7 +4231,7 @@ public class DataMapManager {
             boolean hasErrorReturn = addErrorReturn(functionDefinitionNode, semanticModel, textEdits);
             if (!isInput) {
                 statement = String.format("let %s %s = %s in %s", typeName, variableName,
-                        expression.kind() == SyntaxKind.MAPPING_CONSTRUCTOR ? expression.toSourceCode().trim() : "{}",
+                        getConvertedOutputExpression(expression, isArray),
                         addTypeConversion(parentTypeName, textEdits, variableName, document.syntaxTree().rootNode(),
                                 hasErrorReturn));
             } else {
@@ -4247,6 +4247,24 @@ public class DataMapManager {
 
         textEditsMap.put(filePath, textEdits);
         return gson.toJsonTree(textEditsMap);
+    }
+
+    private String getConvertedOutputExpression(ExpressionNode expr, boolean isArray) {
+        SyntaxKind kind = expr.kind();
+
+        if (isArray) {
+            if (kind == SyntaxKind.LIST_CONSTRUCTOR) {
+                return expr.toSourceCode().trim();
+            } else {
+                return "[]";
+            }
+        }
+
+        if (kind == SyntaxKind.MAPPING_CONSTRUCTOR) {
+            return expr.toSourceCode().trim();
+        } else {
+            return "{}";
+        }
     }
 
     private LetVariableDeclarationNode getMatchingLetVar(SeparatedNodeList<LetVariableDeclarationNode> letVarNodes,

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DataMapManager.java
@@ -1223,20 +1223,27 @@ public class DataMapManager {
                 if (convertedVariables != null && convertedVariables.inputs() != null) {
                     for (ConvertedVariable convertedVariable : convertedVariables.inputs()) {
                         if (convertedVariable.paramName().equals(name)) {
-                            TypedBindingPatternNode typedBindingPatternNode =
-                                    convertedVariable.letVarDeclaration().typedBindingPattern();
-                            Optional<Symbol> optSymbol = semanticModel.symbol(typedBindingPatternNode.typeDescriptor());
+                            LetVariableDeclarationNode letVarDeclaration = convertedVariable.letVarDeclaration();
+                            Optional<Symbol> optSymbol = semanticModel.symbol(letVarDeclaration);
                             if (optSymbol.isEmpty()) {
                                 continue;
                             }
-                            BindingPatternNode bindingPattern = typedBindingPatternNode.bindingPattern();
+
+                            Symbol letVarSymbol = optSymbol.get();
+                            if (letVarSymbol.kind() != SymbolKind.VARIABLE) {
+                                continue;
+                            }
+
+                            BindingPatternNode bindingPattern =
+                                    letVarDeclaration.typedBindingPattern().bindingPattern();
                             if (bindingPattern.kind() != SyntaxKind.CAPTURE_BINDING_PATTERN) {
                                 continue;
                             }
+
                             String text = ((CaptureBindingPatternNode) bindingPattern).variableName().text();
                             MappingPort convertedMappingPort = getRefMappingPort(text, text,
-                                    ReferenceType.fromSemanticSymbol(optSymbol.get(), typeDefSymbols),
-                                    new HashMap<>(), references);
+                                    ReferenceType.fromSemanticSymbol(((VariableSymbol) letVarSymbol).typeDescriptor(),
+                                            typeDefSymbols), new HashMap<>(), references);
                             convertedMappingPort.category = "converted-variable";
                             refMappingPort.setConvertedVariable(convertedMappingPort);
                         }
@@ -1396,18 +1403,23 @@ public class DataMapManager {
                     for (ConvertedVariable convertedVariable : convertedVariables.inputs()) {
                         if (convertedVariable.paramName().equals(name)) {
                             LetVariableDeclarationNode letVarDeclarationNode = convertedVariable.letVarDeclaration();
-                            Optional<Symbol> optSymbol =
-                                    semanticModel.symbol(letVarDeclarationNode.typedBindingPattern().typeDescriptor());
+                            Optional<Symbol> optSymbol = semanticModel.symbol(letVarDeclarationNode);
                             if (optSymbol.isEmpty()) {
                                 continue;
                             }
+
+                            Symbol letVarSymbol = optSymbol.get();
+                            if (letVarSymbol.kind() != SymbolKind.VARIABLE) {
+                                continue;
+                            }
+
                             String letVarName = getLetVarName(letVarDeclarationNode);
                             if (letVarName == null) {
                                 continue;
                             }
                             MappingPort convertedMappingPort = getRefMappingPort(letVarName, letVarName,
-                                    ReferenceType.fromSemanticSymbol(optSymbol.get(), typeDefSymbols),
-                                    new HashMap<>(), references);
+                                    ReferenceType.fromSemanticSymbol(((VariableSymbol) letVarSymbol).typeDescriptor(),
+                                            typeDefSymbols), new HashMap<>(), references);
                             convertedMappingPort.category = "converted-variable";
                             refMappingPort.setConvertedVariable(convertedMappingPort);
                         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/DataMapperService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/DataMapperService.java
@@ -614,7 +614,7 @@ public class DataMapperService implements ExtendedLanguageServerService {
                 DataMapManager dataMapManager = new DataMapManager(document.get());
                 response.setTextEdits(dataMapManager.convertType(filePath, semanticModel.get(), request.codedata(),
                         request.typeName(), request.variableName(), request.parentTypeName(), request.isInput(),
-                        request.imports()));
+                        request.isArray(), request.imports()));
             } catch (Throwable e) {
                 response.setError(e);
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/DataMapperConvertTypeRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/DataMapperConvertTypeRequest.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * @param parentTypeName The parent type name of the converted type
  * @param variableName The converted variable name
  * @param isInput      The converted variable is input or output
- * @param isArray      The converted variable is array or not
+ * @param isArray      Whether the converted variable is an array
  * @param imports      The imports to be added for the conversion
  *
  * @since 2.0.0

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/DataMapperConvertTypeRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/DataMapperConvertTypeRequest.java
@@ -31,11 +31,12 @@ import java.util.Map;
  * @param parentTypeName The parent type name of the converted type
  * @param variableName The converted variable name
  * @param isInput      The converted variable is input or output
+ * @param isArray      The converted variable is array or not
  * @param imports      The imports to be added for the conversion
  *
  * @since 2.0.0
  */
 public record DataMapperConvertTypeRequest(String filePath, JsonElement codedata, String typeName,
                                            String parentTypeName, String variableName, boolean isInput,
-                                           Map<String, String> imports) {
+                                           boolean isArray, Map<String, String> imports) {
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/DataMappingConvertTypeTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/DataMappingConvertTypeTest.java
@@ -68,6 +68,7 @@ public class DataMappingConvertTypeTest extends AbstractLSTest {
                 {Path.of("variable15.json")},
                 {Path.of("variable16.json")},
                 {Path.of("variable17.json")},
+                {Path.of("variable18.json")},
         };
     }
 
@@ -80,7 +81,7 @@ public class DataMappingConvertTypeTest extends AbstractLSTest {
         DataMapperConvertTypeRequest request =
                 new DataMapperConvertTypeRequest(sourceDir.resolve(testConfig.source()).toAbsolutePath().toString(),
                         testConfig.codedata(), testConfig.typeName(), testConfig.parentTypeName(),
-                        testConfig.variableName(), testConfig.isInput(), testConfig.imports());
+                        testConfig.variableName(), testConfig.isInput(), testConfig.isArray(), testConfig.imports());
         JsonObject jsonMap =
                 getResponseAndCloseFile(request, testConfig.source()).getAsJsonObject("textEdits");
 
@@ -112,7 +113,8 @@ public class DataMappingConvertTypeTest extends AbstractLSTest {
         if (assertFailure) {
             TestConfig updatedConfig = new TestConfig(testConfig.source(), testConfig.description(),
                     testConfig.codedata(), testConfig.typeName(), testConfig.parentTypeName(),
-                    testConfig.variableName(), testConfig.isInput(), testConfig.imports(), newMap);
+                    testConfig.variableName(), testConfig.isInput(), testConfig.isArray(), testConfig.imports(),
+                    newMap);
 //            updateConfig(configJsonPath, updatedConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }
@@ -148,12 +150,13 @@ public class DataMappingConvertTypeTest extends AbstractLSTest {
      * @param parentTypeName The name of the parent type of the converted type
      * @param variableName The name of the converting variable
      * @param isInput      Whether the variable is an input variable or not
+     * @param isArray      Whether the variable type is an array or not
      * @param imports      The imports to be added for the conversion
      * @param output       Generated source expression
      */
     private record TestConfig(String source, String description, JsonElement codedata, String typeName,
-                              String parentTypeName, String variableName, boolean isInput, Map<String, String> imports,
-                              Map<String, List<TextEdit>> output) {
+                              String parentTypeName, String variableName, boolean isInput, boolean isArray,
+                              Map<String, String> imports, Map<String, List<TextEdit>> output) {
 
         public String description() {
             return description == null ? "" : description;

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/DataMappingModelTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/DataMappingModelTest.java
@@ -171,6 +171,8 @@ public class DataMappingModelTest extends AbstractLSTest {
                 {Path.of("function_def_transformed_type6.json")},
                 {Path.of("function_def_transformed_type7.json")},
                 {Path.of("json_submapping.json")},
+                {Path.of("function_def_transformed_type8.json")},
+                {Path.of("function_def_transformed_type9.json")},
         };
     }
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_convert_type/config/variable18.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_convert_type/config/variable18.json
@@ -1,0 +1,68 @@
+{
+  "source": "variable1.bal",
+  "description": "Sample diagram node",
+  "codedata": {
+    "node": "VARIABLE",
+    "lineRange": {
+      "fileName": "main.bal",
+      "startLine": {
+        "line": 59,
+        "offset": 0
+      },
+      "endLine": {
+        "line": 61,
+        "offset": 2
+      }
+    },
+    "isNew": true,
+    "sourceCode": ""
+  },
+  "typeName": "Students",
+  "parentTypeName": "json",
+  "variableName": "transform10",
+  "isInput": false,
+  "isArray": true,
+  "output": {
+    "variable1.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 59,
+            "character": 58
+          },
+          "end": {
+            "line": 59,
+            "character": 58
+          }
+        },
+        "newText": "|error"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "import ballerina/data.jsondata;\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 59,
+            "character": 62
+          },
+          "end": {
+            "line": 61,
+            "character": 1
+          }
+        },
+        "newText": "let Students transform10 = [] in check jsondata:toJson(transform10)"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_convert_type/source/variable1.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_convert_type/source/variable1.bal
@@ -54,3 +54,9 @@ function transform11(json user, json student) returns json|error =>
         {a: 10, b: 20};
 
 function transform9(xml user, json student) returns xml => xml ``;
+
+type Students Student[];
+
+function transform10(json user, json student) returns json => {
+
+};

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_model/config/function_def_transformed_type8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_model/config/function_def_transformed_type8.json
@@ -1,0 +1,149 @@
+{
+  "source": "function_def_transformed_type1.bal",
+  "description": "Sample diagram node",
+  "codedata": {
+    "node": "DATA_MAPPER_DEFINITION",
+    "lineRange": {
+      "fileName": "function_def_transformed_type1.bal",
+      "startLine": {
+        "line": 27,
+        "offset": 0
+      },
+      "endLine": {
+        "line": 29,
+        "offset": 77
+      }
+    },
+    "sourceCode": ""
+  },
+  "position": {
+    "line": 28,
+    "offset": 4
+  },
+  "targetField": "transform3",
+  "model": {
+    "inputs": [
+      {
+        "name": "j",
+        "displayName": "j",
+        "typeName": "json",
+        "kind": "json",
+        "category": "parameter",
+        "convertedVariable": {
+          "member": {
+            "fields": [],
+            "name": "foo",
+            "displayName": "<fooItem>",
+            "typeName": "Foo",
+            "kind": "record",
+            "ref": "44280666"
+          },
+          "name": "foo",
+          "displayName": "foo",
+          "typeName": "Foo[]",
+          "kind": "array",
+          "category": "converted-variable",
+          "ref": "-325930948"
+        }
+      },
+      {
+        "fields": [],
+        "name": "u",
+        "displayName": "u",
+        "typeName": "User",
+        "kind": "record",
+        "category": "parameter",
+        "ref": "1373151159"
+      }
+    ],
+    "output": {
+      "name": "secondaryPhones",
+      "displayName": "secondaryPhones",
+      "typeName": "json",
+      "kind": "json",
+      "convertedVariable": {
+        "fields": [],
+        "name": "transform3",
+        "displayName": "transform3Converted",
+        "typeName": "SecondaryPhones",
+        "kind": "record",
+        "category": "converted-variable",
+        "ref": "-782972947"
+      }
+    },
+    "subMappings": [
+      {
+        "fields": [],
+        "name": "user",
+        "displayName": "user",
+        "typeName": "User",
+        "kind": "record",
+        "ref": "1373151159"
+      }
+    ],
+    "mappings": [],
+    "refs": {
+      "44280666": {
+        "fields": [
+          {
+            "name": "code",
+            "displayName": "code",
+            "typeName": "string",
+            "kind": "string",
+            "optional": false
+          },
+          {
+            "name": "number",
+            "displayName": "number",
+            "typeName": "string",
+            "kind": "string",
+            "optional": false
+          }
+        ],
+        "typeName": "Foo",
+        "kind": "record"
+      },
+      "-782972947": {
+        "fields": [
+          {
+            "name": "code",
+            "displayName": "code",
+            "typeName": "string",
+            "kind": "string",
+            "optional": false
+          },
+          {
+            "name": "number",
+            "displayName": "number",
+            "typeName": "string",
+            "kind": "string",
+            "optional": false
+          }
+        ],
+        "typeName": "SecondaryPhones",
+        "kind": "record"
+      },
+      "1373151159": {
+        "fields": [
+          {
+            "name": "code",
+            "displayName": "code",
+            "typeName": "string",
+            "kind": "string",
+            "optional": false
+          },
+          {
+            "name": "number",
+            "displayName": "number",
+            "typeName": "string",
+            "kind": "string",
+            "optional": false
+          }
+        ],
+        "typeName": "User",
+        "kind": "record"
+      }
+    },
+    "hasInvalidOutput": false
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_model/config/function_def_transformed_type9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_model/config/function_def_transformed_type9.json
@@ -1,0 +1,151 @@
+{
+  "source": "function_def_transformed_type2.bal",
+  "description": "Sample diagram node",
+  "codedata": {
+    "node": "DATA_MAPPER_DEFINITION",
+    "lineRange": {
+      "fileName": "function_def_transformed_type1.bal",
+      "startLine": {
+        "line": 40,
+        "offset": 0
+      },
+      "endLine": {
+        "line": 43,
+        "offset": 40
+      }
+    },
+    "sourceCode": ""
+  },
+  "position": {
+    "line": 41,
+    "offset": 4
+  },
+  "targetField": "transformJsonXml4.0",
+  "model": {
+    "inputs": [
+      {
+        "name": "customerDetails",
+        "displayName": "customerDetails",
+        "typeName": "json",
+        "kind": "json",
+        "category": "parameter",
+        "convertedVariable": {
+          "member": {
+            "fields": [],
+            "name": "customerDetailsConverted",
+            "displayName": "<customerDetailsConvertedItem>",
+            "typeName": "CreateOrder",
+            "kind": "record",
+            "ref": "-555319738"
+          },
+          "name": "customerDetailsConverted",
+          "displayName": "customerDetailsConverted",
+          "typeName": "CreateOrder[]",
+          "kind": "array",
+          "category": "converted-variable",
+          "ref": "667729809"
+        }
+      },
+      {
+        "name": "customerDetails1",
+        "displayName": "customerDetails1",
+        "typeName": "json",
+        "kind": "json",
+        "category": "parameter"
+      },
+      {
+        "fields": [],
+        "name": "ordersItem",
+        "displayName": "ordersItem",
+        "typeName": "CreateOrder",
+        "kind": "record",
+        "category": "local-variable",
+        "focusExpression": "customerDetailsConverted",
+        "ref": "-555319738",
+        "isIterationVariable": true
+      }
+    ],
+    "output": {
+      "member": {
+        "fields": [],
+        "name": "transformJsonXml4",
+        "displayName": "<transformJsonXml4Item>",
+        "typeName": "CreateOrder",
+        "kind": "record",
+        "ref": "-555319738"
+      },
+      "name": "transformJsonXml4",
+      "displayName": "transformJsonXml4",
+      "typeName": "CreateOrder[]",
+      "kind": "array",
+      "ref": "667729809"
+    },
+    "subMappings": [],
+    "mappings": [
+      {
+        "output": "transformJsonXml4.OrderId",
+        "inputs": [],
+        "expression": "\"\"",
+        "diagnostics": [],
+        "elements": [],
+        "isQueryExpression": false,
+        "isFunctionCall": false
+      },
+      {
+        "output": "transformJsonXml4.CustomerName",
+        "inputs": [],
+        "expression": "\"\"",
+        "diagnostics": [],
+        "elements": [],
+        "isQueryExpression": false,
+        "isFunctionCall": false
+      }
+    ],
+    "query": {
+      "output": "transformJsonXml4",
+      "inputs": [
+        "customerDetailsConverted"
+      ],
+      "fromClause": {
+        "type": "from",
+        "properties": {
+          "name": "ordersItem",
+          "type": "CreateOrder",
+          "expression": "customerDetailsConverted",
+          "isOuter": false
+        }
+      },
+      "intermediateClauses": [],
+      "resultClause": {
+        "type": "select",
+        "properties": {
+          "expression": "{OrderId: \"\", CustomerName: \"\"}",
+          "isOuter": false
+        }
+      }
+    },
+    "refs": {
+      "-555319738": {
+        "fields": [
+          {
+            "name": "OrderId",
+            "displayName": "OrderId",
+            "typeName": "string",
+            "kind": "string",
+            "optional": false
+          },
+          {
+            "name": "CustomerName",
+            "displayName": "CustomerName",
+            "typeName": "string",
+            "kind": "string",
+            "optional": false
+          }
+        ],
+        "typeName": "CreateOrder",
+        "kind": "record"
+      }
+    },
+    "hasInvalidOutput": false
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_model/source/function_def_transformed_type1.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_model/source/function_def_transformed_type1.bal
@@ -24,3 +24,7 @@ function transform1(xml varXml) returns json => let Foo varXmlConverted = check 
 function transform2(json j, User u) returns json|error =>
     let User user = {code: u.code, number: u.number}, Foo foo = check jsondata:parseAsType(j),
     SecondaryPhones secondaryPhones = {} in jsondata:toJson(secondaryPhones);
+
+function transform3(json j, User u) returns json|error =>
+    let User user = {code: u.code, number: u.number}, Foo[] foo = check jsondata:parseAsType(j),
+    SecondaryPhones secondaryPhones = {} in jsondata:toJson(secondaryPhones);

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_model/source/function_def_transformed_type2.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_mapper_model/source/function_def_transformed_type2.bal
@@ -35,3 +35,10 @@ function transformJsonXml2(json customerDetails, json customerDetails1) returns 
 
 function transformJsonXml3(CustomerDetails customerDetails) returns xml|error =>
     let CreateOrders transformJsonXml3 = {} in check xmldata:toXml(transformJsonXml3);
+
+public type NewOrders CreateOrder[];
+
+function transformJsonXml4(json customerDetails, json customerDetails1) returns xml|error =>
+    let CreateOrder[] customerDetailsConverted = check jsondata:parseAsType(customerDetails),
+        NewOrders transformJsonXml4 = from var ordersItem in customerDetailsConverted select {OrderId: "", CustomerName: ""} in
+        xmldata:toXml(transformJsonXml4);


### PR DESCRIPTION
## Purpose
Addresses https://github.com/wso2/product-integrator/issues/1162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request adds support for array types in the data mapper's type-conversion and modeling logic. It extends the conversion API and request pipeline with an explicit isArray flag, updates core conversion behavior to generate array-appropriate default expressions, and adjusts semantic resolution for converted variables. Additional tests and fixtures exercise the new array-handling behavior.

## Changes Made

- Core logic
  - DataMapManager.convertType(filePath, semanticModel, cd, typeName, variableName, parentTypeName, isInput, isArray, imports): added isArray parameter and refactored conversion logic to select array-aware default output expressions (e.g., "[]" for arrays, "{}" for non-arrays). Also refined how converted-variable types are resolved from semantic symbols.
- Request pipeline
  - DataMapperConvertTypeRequest: added boolean isArray component and documentation.
  - DataMapperService: propagates the new isArray flag into calls to DataMapManager.
- Tests and fixtures
  - Added test data (variable18.json and a model fixture) and updated tests to include an array-conversion scenario for a Students (Student[]) type.
  - Updated test source files to include the type alias and function variants required by the new test cases.

## Impact

These changes enable correct handling of array type conversions in data mapping workflows by ensuring the conversion code and generated/default expressions reflect array semantics and by improving the semantic resolution for converted variables. This improves the accuracy of generated transformation code and test coverage for array conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->