### PR TITLE
Fix record editor not working for intersection types

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/type/TypeSymbolAnalyzerFromTypeModel.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/type/TypeSymbolAnalyzerFromTypeModel.java
@@ -28,6 +28,7 @@ import io.ballerina.compiler.syntax.tree.NodeParser;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import org.ballerinalang.diagramutil.connector.models.connector.Type;
 import org.ballerinalang.diagramutil.connector.models.connector.types.ArrayType;
+import org.ballerinalang.diagramutil.connector.models.connector.types.IntersectionType;
 import org.ballerinalang.diagramutil.connector.models.connector.types.RecordType;
 import org.ballerinalang.diagramutil.connector.models.connector.types.UnionType;
 
@@ -54,12 +55,27 @@ public class TypeSymbolAnalyzerFromTypeModel {
                 TypeSymbolAnalyzerFromTypeModel.updateTypeConfig(recordType, mapping);
             } else if (type instanceof UnionType unionType) {
                 TypeSymbolAnalyzerFromTypeModel.updateUnionTypeConfig(unionType, mapping);
+            } else if (type instanceof IntersectionType intersectionType) {
+                TypeSymbolAnalyzerFromTypeModel.updateIntersectionTypeConfig(intersectionType, mapping);
             }
         } else {
             throw new IllegalArgumentException("Invalid expression");
         }
 
         return type;
+    }
+
+    private static void updateIntersectionTypeConfig(IntersectionType intersectionType,
+                                                     MappingConstructorExpressionNode mappingConstructor) {
+        for (Type type : intersectionType.members) {
+            if (type instanceof RecordType recordType) {
+                updateTypeConfig(recordType, mappingConstructor);
+                if (recordType.selected) {
+                    intersectionType.selected = true;
+                    break;
+                }
+            }
+        }
     }
 
     private static void updateUnionTypeConfig(UnionType unionType,

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/type/TypeSymbolAnalyzerFromTypeModel.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/type/TypeSymbolAnalyzerFromTypeModel.java
@@ -68,14 +68,24 @@ public class TypeSymbolAnalyzerFromTypeModel {
     private static void updateIntersectionTypeConfig(IntersectionType intersectionType,
                                                      MappingConstructorExpressionNode mappingConstructor) {
         for (Type type : intersectionType.members) {
-            if (type instanceof RecordType recordType) {
-                updateTypeConfig(recordType, mappingConstructor);
-                if (recordType.selected) {
-                    intersectionType.selected = true;
-                    break;
-                }
+            if (updateIntersectionMemberConfig(type, mappingConstructor)) {
+                intersectionType.selected = true;
+                break;
             }
         }
+    }
+
+    private static boolean updateIntersectionMemberConfig(Type type,
+                                                          MappingConstructorExpressionNode mappingConstructor) {
+        if (type instanceof RecordType recordType) {
+            updateTypeConfig(recordType, mappingConstructor);
+            return recordType.selected;
+        }
+        if (type instanceof IntersectionType nestedIntersectionType) {
+            updateIntersectionTypeConfig(nestedIntersectionType, mappingConstructor);
+            return nestedIntersectionType.selected;
+        }
+        return false;
     }
 
     private static void updateUnionTypeConfig(UnionType unionType,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/find_matching_type/config/config10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/find_matching_type/config/config10.json
@@ -1,0 +1,86 @@
+{
+  "filePath": "proj",
+  "typeMembers": [
+    {
+      "type": "Pet",
+      "packageInfo": "org:source:0.3.0",
+      "packageName": "source",
+      "kind": "RECORD_TYPE",
+      "selected": false
+    }
+  ],
+  "expr": "{photoUrls: [], name: \"\"}",
+  "output": {
+    "recordConfig": {
+      "members": [
+        {
+          "typeName": "readonly",
+          "optional": false,
+          "defaultable": false,
+          "isRestType": false,
+          "selected": false
+        },
+        {
+          "fields": [
+            {
+              "memberType": {
+                "typeName": "string",
+                "optional": false,
+                "defaultable": false,
+                "isRestType": false,
+                "selected": false
+              },
+              "elements": [],
+              "name": "photoUrls",
+              "typeName": "array",
+              "optional": false,
+              "defaultable": false,
+              "documentation": "",
+              "isRestType": false,
+              "selected": true
+            },
+            {
+              "name": "name",
+              "typeName": "string",
+              "optional": false,
+              "defaultable": false,
+              "documentation": "",
+              "isRestType": false,
+              "value": "\"\"",
+              "selected": true
+            },
+            {
+              "name": "id",
+              "typeName": "int",
+              "optional": true,
+              "defaultable": false,
+              "documentation": "",
+              "isRestType": false,
+              "selected": false
+            }
+          ],
+          "hasRestType": true,
+          "restType": {
+            "typeName": "anydata",
+            "optional": false,
+            "defaultable": false,
+            "isRestType": false,
+            "selected": false
+          },
+          "typeName": "record",
+          "optional": false,
+          "defaultable": false,
+          "isRestType": false,
+          "selected": true
+        }
+      ],
+      "name": "Pet",
+      "typeName": "intersection",
+      "optional": false,
+      "defaultable": false,
+      "isRestType": false,
+      "selected": true
+    },
+    "typeName": "Pet"
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/find_matching_type/source/proj/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/find_matching_type/source/proj/types.bal
@@ -19,3 +19,9 @@ type Employee record {|
     decimal salary;
     EmployeeLog...;
 |};
+
+public type Pet readonly & record {
+    string[] photoUrls;
+    string name;
+    int id?;
+};


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/wso2/product-integrator/issues/1224

https://github.com/user-attachments/assets/15460495-8d59-489e-b5a3-81557ddfa9cd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue where the record editor in the VS Code Ballerina extension fails to display or edit record values when the record type is defined as an intersection type (e.g., `readonly & record`). 

## Changes

The fix introduces support for intersection types in the type analysis logic:

1. **Type Analysis Enhancement** - Modified `TypeSymbolAnalyzerFromTypeModel` to recognize and properly handle intersection types when processing record construction expressions. When an intersection type is encountered, the analyzer now iterates through the intersection's member types, applies type configuration to any `RecordType` members, and marks the intersection as selected once a matching record type is identified.

2. **Test Coverage** - Added comprehensive test resources to validate the fix:
   - New test type `Pet` defined as `readonly & record` with multiple fields
   - Test configuration and expected output specifications for the `Pet` type matching scenario

## Impact

Users can now successfully edit record values defined as intersection types through the Record Configuration form, resolving the "Record construction assistance is unavailable" error that previously occurred in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->