### PR TITLE
Remove isPublic property from automation functions

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/analyzers/function/ModuleNodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/analyzers/function/ModuleNodeAnalyzer.java
@@ -227,7 +227,7 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
             if (token.text().equals("isolated")) {
                 nodeBuilder.properties().isIsolated(true, true, false, false);
             }
-            if (token.text().equals("public")) {
+            if (token.text().equals("public") && nodeKind != NodeKind.AUTOMATION) {
                 nodeBuilder.properties().isPublic(true, false, true, false);
             }
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def1.json
@@ -238,23 +238,6 @@
         "editable": true,
         "advanced": true,
         "hidden": false
-      },
-      "isPublic": {
-        "metadata": {
-          "label": "public",
-          "description": "Make visible across the project"
-        },
-        "types": [
-          {
-            "fieldType": "FLAG",
-            "selected": true
-          }
-        ],
-        "value": "true",
-        "optional": false,
-        "editable": true,
-        "advanced": false,
-        "hidden": false
       }
     },
     "flags": 0

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def2.json
@@ -325,23 +325,6 @@
         "editable": true,
         "advanced": true,
         "hidden": false
-      },
-      "isPublic": {
-        "metadata": {
-          "label": "public",
-          "description": "Make visible across the project"
-        },
-        "types": [
-          {
-            "fieldType": "FLAG",
-            "selected": true
-          }
-        ],
-        "value": "true",
-        "optional": false,
-        "editable": true,
-        "advanced": false,
-        "hidden": false
       }
     },
     "flags": 0

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def3.json
@@ -325,23 +325,6 @@
         "editable": true,
         "advanced": true,
         "hidden": false
-      },
-      "isPublic": {
-        "metadata": {
-          "label": "public",
-          "description": "Make visible across the project"
-        },
-        "types": [
-          {
-            "fieldType": "FLAG",
-            "selected": true
-          }
-        ],
-        "value": "true",
-        "optional": false,
-        "editable": true,
-        "advanced": false,
-        "hidden": false
       }
     },
     "flags": 0


### PR DESCRIPTION
## Purpose
Fixes : https://github.com/wso2/product-integrator/issues/567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request removes the `isPublic` property from automation function definitions, correcting the behavior where automation functions were incorrectly marked with public visibility settings.

## Changes Made

1. **ModuleNodeAnalyzer.java**: Updated the public qualifier handling logic to exclude automation functions from receiving the public visibility flag. The code now only marks functions as public when the qualifier is explicitly "public" AND the function is not classified as an automation type.

2. **Automation Configuration Files**: Removed the `isPublic` property from automation function configuration files (`automation_def1.json`, `automation_def2.json`, and `automation_def3.json`). Also added UI configuration fields to clarify parameter behavior in the returnError block.

## Impact

This change ensures consistent handling of automation functions by preventing them from being assigned public visibility properties, aligning the generated models with the intended automation function behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->