### PR TITLE
Add CONNECTION property type and SAMPLE_CONNECTION test node

### DIFF
--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/connection.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/connection.json
@@ -42,7 +42,7 @@
         "name": "httpConnection",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       },

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/http_service.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/http_service.json
@@ -21,7 +21,7 @@
         "name": "httpClient",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       }
@@ -44,7 +44,7 @@
         "name": "refListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       },
@@ -65,7 +65,7 @@
         "name": "securedEP",
         "scope": "Global",
         "visibility": "public",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       }
@@ -88,7 +88,7 @@
         "name": "HTTP Service - /root/path-id",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {
           "post#data": {
@@ -210,7 +210,7 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {
           "init": {
@@ -271,7 +271,7 @@
         "name": "HTTP Service - /api/v1",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {
           "get#path": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/listener.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/listener.json
@@ -21,7 +21,7 @@
         "name": "httpDefaultListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       },
@@ -82,7 +82,7 @@
         "name": "refListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       }

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/listener.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/listener.json
@@ -61,7 +61,7 @@
         "name": "rabbitmqListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.3.1.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.3.3.png",
         "module": "rabbitmq",
         "children": {}
       },

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/project.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/project.json
@@ -21,7 +21,7 @@
         "name": "httpClient",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       },
@@ -42,7 +42,7 @@
         "name": "httpClient2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       }
@@ -65,7 +65,7 @@
         "name": "ls",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       },
@@ -86,7 +86,7 @@
         "name": "securedEP",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       },
@@ -107,7 +107,7 @@
         "name": "securedEP2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {}
       }
@@ -170,7 +170,7 @@
         "name": "HTTP Service - /api2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {
           "get#path": {
@@ -212,7 +212,7 @@
         "name": "HTTP Service - /api1",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {
           "get#path": {
@@ -273,7 +273,7 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {
           "init": {
@@ -334,7 +334,7 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
         "module": "http",
         "children": {
           "init": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/rabbitmq.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/rabbitmq.json
@@ -21,7 +21,7 @@
         "name": "rabbitmqListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.3.1.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.3.3.png",
         "module": "rabbitmq",
         "children": {}
       }
@@ -44,7 +44,7 @@
         "name": "RabbitMQ Event Integration - \"queueName\"",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.3.1.png",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.3.3.png",
         "module": "rabbitmq",
         "children": {
           "onMessage": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/connections.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/connections.json
@@ -22,7 +22,7 @@
           "name": "httpEp",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {}
         }

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/main.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/main.json
@@ -89,7 +89,7 @@
           "name": "httpListener",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {}
         }
@@ -114,7 +114,7 @@
           "name": "HTTP Service - /restaurant",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {
             "post#orders": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/resources/existing_project.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/resources/existing_project.json
@@ -121,7 +121,7 @@
           "name": "httpEp",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {}
         }
@@ -232,7 +232,7 @@
           "name": "httpListener",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {}
         }
@@ -542,7 +542,7 @@
           "name": "HTTP Service - /restaurant",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {
             "post#orders": {

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/resources/no_preexisting_project.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/resources/no_preexisting_project.json
@@ -121,7 +121,7 @@
           "name": "httpEp",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {}
         }
@@ -245,7 +245,7 @@
           "name": "httpListener",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {}
         }
@@ -565,7 +565,7 @@
           "name": "HTTP Service - /restaurant",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.2.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
           "module": "http",
           "children": {
             "get#menu": {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -297,7 +297,8 @@ public class AiUtils {
                 original.metadata().keywords(),
                 original.metadata().icon(),
                 original.metadata().functionKind(),
-                original.metadata().data()
+                original.metadata().data(),
+                original.metadata().connectors()
         );
 
         return new Property(

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
@@ -322,7 +322,8 @@ public class AvailableNodesGenerator {
                 .node(NodeKind.VARIABLE)
                 .node(NodeKind.ASSIGN)
                 .node(function)
-                .node(NodeKind.DATA_MAPPER_CALL);
+                .node(NodeKind.DATA_MAPPER_CALL)
+                .node(NodeKind.SAMPLE_CONNECTION);
 
         this.rootBuilder.stepIn(Category.Name.CONTROL)
                 .node(NodeKind.IF)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -459,6 +459,44 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
         return this;
     }
 
+    public FormBuilder<T> connectionSelector(String placeholder) {
+        return connectionSelector(placeholder, null, null);
+    }
+
+    public FormBuilder<T> connectionSelector(String placeholder, String searchNodesKind) {
+        return connectionSelector(placeholder, searchNodesKind, null);
+    }
+
+    public FormBuilder<T> connectionSelector(String placeholder, String searchNodesKind,
+                                             List<Metadata.AllowedConnector> connectors) {
+        return connectionSelector(Property.CONNECTION_KEY, Property.CONNECTION_LABEL, placeholder,
+                searchNodesKind, connectors);
+    }
+
+    public FormBuilder<T> connectionSelector(String key, String label, String placeholder, String searchNodesKind,
+                                             List<Metadata.AllowedConnector> connectors) {
+        propertyBuilder
+                .metadata()
+                    .label(label)
+                    .description(Property.CONNECTION_DOC)
+                    .stepOut()
+                .value(placeholder)
+                .placeholder(placeholder)
+                .type()
+                    .fieldType(Property.ValueType.CONNECTION)
+                    .selected(true)
+                    .stepOut()
+                .editable();
+        if (connectors != null && !connectors.isEmpty()) {
+            propertyBuilder.metadata().connectors(connectors);
+        }
+        if (searchNodesKind != null) {
+            propertyBuilder.codedata().searchNodesKind(searchNodesKind);
+        }
+        addProperty(key);
+        return this;
+    }
+
     public FormBuilder<T> callConnection(ExpressionNode expressionNode, String key, Map<String, Object> metadataData) {
         propertyBuilder
                 .metadata()

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Metadata.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Metadata.java
@@ -22,6 +22,7 @@ package io.ballerina.flowmodelgenerator.core.model;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.modelgenerator.commons.CommonUtils;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,10 +36,21 @@ import java.util.Map;
  * @param icon         The icon of the component
  * @param functionKind The kind of the function
  * @param data         The additional data
+ * @param connectors   For CONNECTION-typed properties: allowed target connectors. Each entry pairs a
+ *                     connector codedata with the label of its "Add new connection" button. When
+ *                     non-empty, the UI union-filters the dropdown by (module, object) across entries
+ *                     and renders one Add button per entry. When null/empty, the dropdown lists every
+ *                     connection in the project and no Add button is shown.
  * @since 1.0.0
  */
 public record Metadata(String label, String description, List<String> keywords, String icon, String functionKind,
-                       Map<String, Object> data) {
+                       Map<String, Object> data, List<AllowedConnector> connectors) {
+
+    /**
+     * A connector that the CONNECTION field accepts, along with the label for its Add-new button.
+     */
+    public record AllowedConnector(Codedata codedata, String addNewConnectionLabel) {
+    }
 
     public static class Builder<T> extends FacetedBuilder<T> {
 
@@ -48,6 +60,7 @@ public record Metadata(String label, String description, List<String> keywords, 
         private String icon;
         private String functionKind;
         private Map<String, Object> data;
+        private List<AllowedConnector> connectors;
 
         public Builder(T parentBuilder) {
             super(parentBuilder);
@@ -109,8 +122,21 @@ public record Metadata(String label, String description, List<String> keywords, 
             return this;
         }
 
+        public Builder<T> connectors(List<AllowedConnector> connectors) {
+            this.connectors = connectors;
+            return this;
+        }
+
+        public Builder<T> addConnector(Codedata codedata, String addNewConnectionLabel) {
+            if (connectors == null) {
+                connectors = new ArrayList<>();
+            }
+            connectors.add(new AllowedConnector(codedata, addNewConnectionLabel));
+            return this;
+        }
+
         public Metadata build() {
-            return new Metadata(label, description, keywords, icon, functionKind, data);
+            return new Metadata(label, description, keywords, icon, functionKind, data, connectors);
         }
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Metadata.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Metadata.java
@@ -48,6 +48,9 @@ public record Metadata(String label, String description, List<String> keywords, 
 
     /**
      * A connector that the CONNECTION field accepts, along with the label for its Add-new button.
+     *
+     * @param codedata               The codedata of the connector
+     * @param addNewConnectionLabel  The label for the "Add new connection" button
      */
     public record AllowedConnector(Codedata codedata, String addNewConnectionLabel) {
     }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeBuilder.java
@@ -68,7 +68,6 @@ import io.ballerina.flowmodelgenerator.core.model.node.ModelProviderBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.NPFunctionCall;
 import io.ballerina.flowmodelgenerator.core.model.node.NPFunctionDefinitionBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.NewConnectionBuilder;
-import io.ballerina.flowmodelgenerator.core.model.node.SampleConnectionNodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.PanicBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ParallelFlowBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.RemoteActionCallBuilder;
@@ -76,6 +75,7 @@ import io.ballerina.flowmodelgenerator.core.model.node.ResourceActionCallBuilder
 import io.ballerina.flowmodelgenerator.core.model.node.RetryBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ReturnBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.RollbackBuilder;
+import io.ballerina.flowmodelgenerator.core.model.node.SampleConnectionNodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.SendDataBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ShortTermMemoryStoreBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.StartBuilder;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeBuilder.java
@@ -68,6 +68,7 @@ import io.ballerina.flowmodelgenerator.core.model.node.ModelProviderBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.NPFunctionCall;
 import io.ballerina.flowmodelgenerator.core.model.node.NPFunctionDefinitionBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.NewConnectionBuilder;
+import io.ballerina.flowmodelgenerator.core.model.node.SampleConnectionNodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.PanicBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ParallelFlowBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.RemoteActionCallBuilder;
@@ -191,6 +192,7 @@ public abstract class NodeBuilder implements DiagnosticHandler.DiagnosticCapable
         put(NodeKind.WAIT_DATA, WaitDataBuilder::new);
         put(NodeKind.SEND_DATA, SendDataBuilder::new);
         put(NodeKind.WORKFLOW_RUN, WorkflowRunBuilder::new);
+        put(NodeKind.SAMPLE_CONNECTION, SampleConnectionNodeBuilder::new);
     }};
 
     public static NodeBuilder getNodeFromKind(NodeKind kind) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeKind.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeKind.java
@@ -110,5 +110,6 @@ public enum NodeKind {
     ACTIVITY_CALL,
     ACTIVITY_CREATION,
     SEND_DATA,
-    WAIT_DATA
+    WAIT_DATA,
+    SAMPLE_CONNECTION
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -367,7 +367,8 @@ public record Property(Metadata metadata, List<PropertyType> types, Object value
          * to choose from, generating a typed subset record on save.
          */
         RECORD_FIELD_SELECTOR,
-        ADVANCE_PARAM_LIST
+        ADVANCE_PARAM_LIST,
+        CONNECTION
     }
 
     public static class Builder<T> extends FacetedBuilder<T> implements DiagnosticHandler.DiagnosticCapable {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/PropertyCodedata.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/PropertyCodedata.java
@@ -28,9 +28,13 @@ import io.ballerina.tools.text.LineRange;
  * @param originalName      The original name of the property
  * @param dependentProperty The property that is dependent for this property to be enabled
  * @param lineRange         The line range of the property
+ * @param searchNodesKind   For CONNECTION-typed properties: the node kind passed to searchNodes
+ *                          (e.g., "NEW_CONNECTION", "MODEL_PROVIDER") so the UI can list matching
+ *                          connections.
  * @since 1.0.0
  */
-public record PropertyCodedata(String kind, String originalName, String dependentProperty, LineRange lineRange) {
+public record PropertyCodedata(String kind, String originalName, String dependentProperty, LineRange lineRange,
+                               String searchNodesKind) {
 
     public static class Builder<T> extends FacetedBuilder<T> {
 
@@ -38,6 +42,7 @@ public record PropertyCodedata(String kind, String originalName, String dependen
         private String originalName;
         private String dependentProperty;
         private LineRange lineRange;
+        private String searchNodesKind;
 
         public Builder(T parentBuilder) {
             super(parentBuilder);
@@ -63,8 +68,13 @@ public record PropertyCodedata(String kind, String originalName, String dependen
             return this;
         }
 
+        public Builder<T> searchNodesKind(String searchNodesKind) {
+            this.searchNodesKind = searchNodesKind;
+            return this;
+        }
+
         public PropertyCodedata build() {
-            return new PropertyCodedata(kind, originalName, dependentProperty, lineRange);
+            return new PropertyCodedata(kind, originalName, dependentProperty, lineRange, searchNodesKind);
         }
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/SampleConnectionNodeBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/SampleConnectionNodeBuilder.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.model.node;
+
+import io.ballerina.flowmodelgenerator.core.model.Codedata;
+import io.ballerina.flowmodelgenerator.core.model.Metadata;
+import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
+import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+import io.ballerina.flowmodelgenerator.core.model.Property;
+import io.ballerina.flowmodelgenerator.core.model.SourceBuilder;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Sample node for smoke-testing the CONNECTION fieldType in the UI.
+ *
+ * <p>Renders three CONNECTION fields exercising each metadata shape:
+ * <ul>
+ *     <li>{@code anyConnection} — no {@code connectors} array: dropdown lists every connection,
+ *         no Add button.</li>
+ *     <li>{@code httpConnection} — one connector entry: dropdown filtered to HTTP, single Add button.</li>
+ *     <li>{@code aiConnection} — two connector entries: union-filtered to Mistral or Milvus,
+ *         two Add buttons.</li>
+ * </ul>
+ *
+ * @since 1.8.0
+ */
+public class SampleConnectionNodeBuilder extends NodeBuilder {
+
+    public static final String LABEL = "Sample Connection (Test)";
+    public static final String DESCRIPTION = "Smoke-test node for the CONNECTION field type";
+    private static final String NEW_LINE = System.lineSeparator();
+
+    private static final String ANY_KEY = "anyConnection";
+    private static final String HTTP_KEY = "httpConnection";
+    private static final String AI_KEY = "aiConnection";
+
+    @Override
+    public void setConcreteConstData() {
+        metadata().label(LABEL).description(DESCRIPTION);
+        codedata().node(NodeKind.SAMPLE_CONNECTION);
+    }
+
+    @Override
+    public void setConcreteTemplateData(TemplateContext context) {
+        Codedata httpConnector = new Codedata.Builder<>(null)
+                .node(NodeKind.NEW_CONNECTION)
+                .org("ballerina").module("http").packageName("http")
+                .object("Client").symbol("init").version("2.16.2")
+                .build();
+        Codedata mistralConnector = new Codedata.Builder<>(null)
+                .node(NodeKind.NEW_CONNECTION)
+                .org("ballerinax").module("mistral").packageName("mistral")
+                .object("Client").symbol("init").version("1.0.2")
+                .build();
+        Codedata milvusConnector = new Codedata.Builder<>(null)
+                .node(NodeKind.NEW_CONNECTION)
+                .org("ballerinax").module("milvus").packageName("milvus")
+                .object("Client").symbol("init").version("1.1.1")
+                .build();
+
+        // Field 1: no codedata — list all connections, no Add button.
+        properties().connectionSelector(ANY_KEY, "Any Connection",
+                "NEW_CONNECTION", "NEW_CONNECTION", null);
+
+        // Field 2: one connector — filter to HTTP, single Add button.
+        properties().connectionSelector(HTTP_KEY, "HTTP Connection",
+                "NEW_CONNECTION", "NEW_CONNECTION",
+                List.of(new Metadata.AllowedConnector(httpConnector, "Add new HTTP connection")));
+
+        // Field 3: two connectors — union-filter to Mistral or Milvus, two Add buttons.
+        properties().connectionSelector(AI_KEY, "AI Connection",
+                "NEW_CONNECTION", "NEW_CONNECTION",
+                List.of(
+                        new Metadata.AllowedConnector(mistralConnector, "Add new Mistral connection"),
+                        new Metadata.AllowedConnector(milvusConnector, "Add new Milvus connection")
+                ));
+    }
+
+    @Override
+    public Map<Path, List<TextEdit>> toSource(SourceBuilder sourceBuilder) {
+        String anyValue = sourceBuilder.getProperty(ANY_KEY).map(Property::toSourceCode).orElse("()");
+        String httpValue = sourceBuilder.getProperty(HTTP_KEY).map(Property::toSourceCode).orElse("()");
+        String aiValue = sourceBuilder.getProperty(AI_KEY).map(Property::toSourceCode).orElse("()");
+        String comment = "// Sample connection node - any: " + anyValue
+                + ", http: " + httpValue
+                + ", ai: " + aiValue
+                + NEW_LINE;
+        return sourceBuilder
+                .token().name(NEW_LINE).name(comment).stepOut()
+                .comment()
+                .build();
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WaitDataBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WaitDataBuilder.java
@@ -468,7 +468,7 @@ public class WaitDataBuilder extends CallBuilder {
                 dataTypeName,
                 true,
                 new Metadata(dataTypeName, "Data record for workflow function",
-                        null, null, null, null),
+                        null, null, null, null, null),
                 new Codedata.Builder<>(null).node(NodeKind.RECORD).build(),
                 Map.of(),
                 members,

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProviderTest.java
@@ -216,7 +216,7 @@ public class ConnectionActionProviderTest {
     public void testPolymorphicSerializationRoundTrip() {
         String key = "ballerina:http:http:Client:polymorphic";
         List<Item> expected = List.of(new Category(
-                new Metadata("Connections", "Connector actions", null, null, null, null),
+                new Metadata("Connections", "Connector actions", null, null, null, null, null),
                 List.of(availableNode("query", null, null), availableNode("close", null, null))));
 
         provider.getOrBuild(key, () -> expected);
@@ -314,7 +314,7 @@ public class ConnectionActionProviderTest {
 
     private static AvailableNode availableNode(String symbol, String parentSymbol, Map<String, Object> data) {
         return new AvailableNode(
-                new Metadata(symbol, symbol + " description", null, "icon-" + symbol, null, null),
+                new Metadata(symbol, symbol + " description", null, "icon-" + symbol, null, null, null),
                 new Codedata(NodeKind.METHOD_CALL, "ballerina", "http", "http", "Client", symbol, "1.0.0",
                         null, null, parentSymbol, null, null, false, false, null, data),
                 true);

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
@@ -5,6 +5,7 @@
         <classes>
             <class name="io.ballerina.flowmodelgenerator.core.AiComponentDiskCacheTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.ConnectionActionProviderTest"/>
+            <class name="io.ballerina.flowmodelgenerator.core.model.ConnectionSelectorTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.service.ServiceIndexLoaderTest"/>
         </classes>
     </test>


### PR DESCRIPTION
## Summary
- Introduces `Property.ValueType.CONNECTION`, a declarative property type for connection-picker form fields, so node builders can describe a "select existing / add new connection" field without the UI having to special-case it.
- Adds `Metadata.connectors: List<AllowedConnector>` (codedata + per-entry `addNewConnectionLabel`) and `PropertyCodedata.searchNodesKind` so the side panel can union-filter the dropdown by `(module, object)` and render one Add button per allowed connector. When `connectors` is absent the editor lists every connection in the project with no Add link.
- New `SAMPLE_CONNECTION` smoke-test node exercises three metadata shapes (no connectors, one connector, two connectors) so the UI side can be validated end-to-end.

## Test plan
- [ ] `./gradlew :flow-model-generator-core:test`
- [ ] In the VS Code extension dev host, add a `SAMPLE_CONNECTION` node from the Statement category; confirm three CONNECTION fields render with the expected filter + Add-button behavior.

Related: wso2-enterprise/integration-engineering#1459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection-type properties and connection selector UI with placeholder, search, and allowed-connector options
  * Added a sample connection node to exercise connection fields and rendering

* **Bug Fixes**
  * Preserve existing connector metadata when updating a property's metadata

* **Chores**
  * Extended metadata and builder APIs and added CONNECTION value type and SAMPLE_CONNECTION node kind
  * Updated test fixtures and resources; refreshed several test artifact icon URLs

* **Tests**
  * Added/updated tests and test config for connection selector behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-language-server/pull/928)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->