### PR TITLE
Fix AI component discovery dropping same-minor-version packages on older distributions

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -641,9 +641,7 @@ public class AiUtils {
         return 0;
     }
 
-    // Compares only the major.minor components (ignores patch). Within the same major.minor,
-    // patch bumps are backward-compatible, so modules built against a newer patch of the same
-    // minor version are safe to show even if the user's local distribution is on an older patch.
+    // Compares only major.minor (ignores patch) — patch bumps within the same minor are backward-compatible.
     private static int compareMajorMinor(String version1, String version2) {
         String[] parts1 = version1.split("\\.");
         String[] parts2 = version2.split("\\.");

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -597,7 +597,7 @@ public class AiUtils {
         Collection<List<Module>> candidateModules = (version == null)
                 ? dependentModules.values()
                 : dependentModules.entrySet().stream()
-                .filter(entry -> compareSemver(version, entry.getKey()) >= 0)
+                .filter(entry -> compareMajorMinor(version, entry.getKey()) >= 0)
                 .map(Map.Entry::getValue)
                 .toList();
 
@@ -632,6 +632,22 @@ public class AiUtils {
         int length = Math.max(parts1.length, parts2.length);
 
         for (int i = 0; i < length; i++) {
+            int num1 = i < parts1.length ? Integer.parseInt(parts1[i]) : 0;
+            int num2 = i < parts2.length ? Integer.parseInt(parts2[i]) : 0;
+            if (num1 != num2) {
+                return Integer.compare(num1, num2);
+            }
+        }
+        return 0;
+    }
+
+    // Compares only the major.minor components (ignores patch). Within the same major.minor,
+    // patch bumps are backward-compatible, so modules built against a newer patch of the same
+    // minor version are safe to show even if the user's local distribution is on an older patch.
+    private static int compareMajorMinor(String version1, String version2) {
+        String[] parts1 = version1.split("\\.");
+        String[] parts2 = version2.split("\\.");
+        for (int i = 0; i < 2; i++) {
             int num1 = i < parts1.length ? Integer.parseInt(parts1[i]) : 0;
             int num2 = i < parts2.length ? Integer.parseInt(parts2[i]) : 0;
             if (num1 != num2) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -642,7 +642,7 @@ public class AiUtils {
     }
 
     // Compares only major.minor (ignores patch) — patch bumps within the same minor are backward-compatible.
-    private static int compareMajorMinor(String version1, String version2) {
+    static int compareMajorMinor(String version1, String version2) {
         String[] parts1 = version1.split("\\.");
         String[] parts2 = version2.split("\\.");
         for (int i = 0; i < 2; i++) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/resources/dependent_modules_fallback.json
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/resources/dependent_modules_fallback.json
@@ -277,6 +277,21 @@
       "org": "ballerinax",
       "name": "ai.weaviate",
       "version": "1.0.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.devant",
+      "version": "1.0.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.pgvector",
+      "version": "1.0.4"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.weaviate",
+      "version": "1.0.4"
     }
   ],
   "1.6.0": [
@@ -361,6 +376,51 @@
       "org": "ballerinax",
       "name": "ai.mistral",
       "version": "1.2.2"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.azure",
+      "version": "1.4.2"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.deepseek",
+      "version": "1.1.2"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.openai",
+      "version": "1.3.2"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.ollama",
+      "version": "1.2.2"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.deepseek",
+      "version": "1.1.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.mistral",
+      "version": "1.2.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.openai",
+      "version": "1.3.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.azure",
+      "version": "1.4.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.openai",
+      "version": "1.3.4"
     }
   ],
   "1.9.0": [
@@ -382,6 +442,67 @@
     {
       "org": "ballerinax",
       "name": "ai.openrouter",
+      "version": "1.0.0"
+    }
+  ],
+  "1.10.0": [
+    {
+      "org": "ballerinax",
+      "name": "ai.pinecone",
+      "version": "1.1.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.pinecone",
+      "version": "1.1.4"
+    }
+  ],
+  "1.11.0": [
+    {
+      "org": "ballerinax",
+      "name": "ai.googleapis.vertex",
+      "version": "1.0.0"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.anthropic",
+      "version": "1.3.2"
+    }
+  ],
+  "1.11.2": [
+    {
+      "org": "ballerinax",
+      "name": "ai.anthropic",
+      "version": "1.3.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.openrouter",
+      "version": "1.0.1"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.googleapis.vertex",
+      "version": "1.0.1"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.ollama",
+      "version": "1.2.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.milvus",
+      "version": "1.0.3"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.memory.redis",
+      "version": "1.0.0"
+    },
+    {
+      "org": "ballerinax",
+      "name": "ai.microsoft.sharepoint",
       "version": "1.0.0"
     }
   ]

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiUtilsTest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link AiUtils}.
+ *
+ * @since 1.7.0
+ */
+public class AiUtilsTest {
+
+    @Test(description = "Same patch: 1.11.1 vs 1.11.1 should be equal (0).")
+    public void testCompareMajorMinor_samePatch() {
+        Assert.assertEquals(AiUtils.compareMajorMinor("1.11.1", "1.11.1"), 0);
+    }
+
+    @Test(description = "Newer patch in entry: 1.11.1 vs 1.11.2 should be equal (0) — "
+            + "same minor means the entry is compatible.")
+    public void testCompareMajorMinor_newerPatchInEntry() {
+        Assert.assertEquals(AiUtils.compareMajorMinor("1.11.1", "1.11.2"), 0);
+    }
+
+    @Test(description = "Older patch in entry: 1.11.2 vs 1.11.0 should be equal (0) — "
+            + "both are the same minor.")
+    public void testCompareMajorMinor_olderPatchInEntry() {
+        Assert.assertEquals(AiUtils.compareMajorMinor("1.11.2", "1.11.0"), 0);
+    }
+
+    @Test(description = "Higher minor in entry: 1.11.1 vs 1.12.0 should be negative — "
+            + "a 1.12.x module must not appear for a 1.11.x user.")
+    public void testCompareMajorMinor_higherMinorInEntry() {
+        Assert.assertTrue(AiUtils.compareMajorMinor("1.11.1", "1.12.0") < 0);
+    }
+
+    @Test(description = "Lower minor in entry: 1.11.1 vs 1.10.0 should be positive — "
+            + "a 1.10.x module is always compatible with a 1.11.x user.")
+    public void testCompareMajorMinor_lowerMinorInEntry() {
+        Assert.assertTrue(AiUtils.compareMajorMinor("1.11.1", "1.10.0") > 0);
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
+++ b/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
@@ -4,6 +4,7 @@
     <test name="flow-model-generator-core-tests">
         <classes>
             <class name="io.ballerina.flowmodelgenerator.core.AiComponentDiskCacheTest"/>
+            <class name="io.ballerina.flowmodelgenerator.core.AiUtilsTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.ConnectionActionProviderTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.service.ServiceIndexLoaderTest"/>
         </classes>

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_loader_manager/config/data_loaders.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_loader_manager/config/data_loaders.json
@@ -11,13 +11,29 @@
             "metadata": {
               "label": "Text Data Loader",
               "description": "Dataloader that can be used to load supported file types as `TextDocument`s.\nCurrently only supports `pdf`, `docx`, `markdown`, `html`, and `pptx` file types.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.11.2.png"
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.11.3.png"
             },
             "codedata": {
               "node": "DATA_LOADER",
               "org": "ballerina",
               "module": "ai",
               "packageName": "ai",
+              "object": "TextDataLoader",
+              "symbol": "init"
+            },
+            "enabled": true
+          },
+          {
+            "metadata": {
+              "label": "Microsoft SharePoint Text Data Loader",
+              "description": "A data loader that retrieves documents from SharePoint document libraries as text.",
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.microsoft.sharepoint_1.0.0.png"
+            },
+            "codedata": {
+              "node": "DATA_LOADER",
+              "org": "ballerinax",
+              "module": "ai.microsoft.sharepoint",
+              "packageName": "ai.microsoft.sharepoint",
               "object": "TextDataLoader",
               "symbol": "init"
             },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_loader_manager/config/data_loaders.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/data_loader_manager/config/data_loaders.json
@@ -11,7 +11,7 @@
             "metadata": {
               "label": "Text Data Loader",
               "description": "Dataloader that can be used to load supported file types as `TextDocument`s.\nCurrently only supports `pdf`, `docx`, `markdown`, `html`, and `pptx` file types.",
-              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.11.3.png"
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.11.2.png"
             },
             "codedata": {
               "node": "DATA_LOADER",


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-integrator/issues/1693

Components published against a newer patch of the same ballerina/ai minor version (e.g. `ballerina/ai` 1.11.2 when the distribution ships 1.11.1) were incorrectly excluded by the version filter in `getLatestCompatibleModules`. Within the same major.minor, patch bumps are backward-compatible and the dependency resolver can pull the needed patch from Central, so these components should be visible.

Changes:
- `getLatestCompatibleModules` now filters by major.minor only (new `compareMajorMinor`), so 1.11.2-keyed modules are included for users on 1.11.1 (fixes `ballerinax/ai.microsoft.sharepoint` not appearing in Ballerina 2201.13.3 but appearing in 2201.13.4)
- Refresh dependent_modules_fallback.json with entries for ballerina/ai 1.10.0, 1.11.0, and 1.11.2 (ai.pinecone, `ai.googleapis.vertex`, `ai.anthropic`, `ai.memory.redis`, `ai.microsoft.sharepoint`, `ai.openrouter`, `ai.milvus`, `ai.ollama`)


https://github.com/user-attachments/assets/e22fa755-b738-4ecf-ae6c-c3e17837be99
