### PR TITLE
Use declared service type for object-typed services in design model

### DIFF
--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/CodeAnalyzer.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/CodeAnalyzer.java
@@ -154,7 +154,8 @@ public class CodeAnalyzer extends NodeVisitor {
             ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) serviceSymbol.get();
             displayName = getDisplayName(serviceDeclarationSymbol.annotAttachments());
             Optional<TypeSymbol> typeDescriptor = serviceDeclarationSymbol.typeDescriptor();
-            if (typeDescriptor.isPresent() && typeDescriptor.get().getModule().isPresent()) {
+            if (serviceDeclarationNode.typeDescriptor().isPresent()
+                    && typeDescriptor.isPresent() && typeDescriptor.get().getModule().isPresent()) {
                 TypeSymbol typeSymbol = typeDescriptor.get();
                 serviceType = CommonUtils.getTypeSignature(typeSymbol,
                         CommonUtils.ModuleInfo.from(typeSymbol.getModule().get().id()));

--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/CodeAnalyzer.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/CodeAnalyzer.java
@@ -149,8 +149,16 @@ public class CodeAnalyzer extends NodeVisitor {
     public void visit(ServiceDeclarationNode serviceDeclarationNode) {
         Optional<Symbol> serviceSymbol = this.semanticModel.symbol(serviceDeclarationNode);
         String displayName = null;
+        String serviceType = null;
         if (serviceSymbol.isPresent()) {
-            displayName = getDisplayName(((ServiceDeclarationSymbol) serviceSymbol.get()).annotAttachments());
+            ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) serviceSymbol.get();
+            displayName = getDisplayName(serviceDeclarationSymbol.annotAttachments());
+            Optional<TypeSymbol> typeDescriptor = serviceDeclarationSymbol.typeDescriptor();
+            if (typeDescriptor.isPresent() && typeDescriptor.get().getModule().isPresent()) {
+                TypeSymbol typeSymbol = typeDescriptor.get();
+                serviceType = CommonUtils.getTypeSignature(typeSymbol,
+                        CommonUtils.ModuleInfo.from(typeSymbol.getModule().get().id()));
+            }
         }
         String absoluteResourcePath = String.join("", serviceDeclarationNode.absoluteResourcePath()
                 .stream().map(Node::toSourceCode).toList());
@@ -158,6 +166,7 @@ public class CodeAnalyzer extends NodeVisitor {
         String sortText = lineRange.fileName() + lineRange.startLine().line();
         IntermediateModel.ServiceModel serviceModel = new IntermediateModel.ServiceModel(
                 displayName, absoluteResourcePath, sortText, getLocation(lineRange));
+        serviceModel.serviceType = serviceType;
         this.currentServiceModel = serviceModel;
         intermediateModel.serviceModelMap.put(String.valueOf(lineRange.hashCode()), serviceModel);
 

--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/DesignModelGenerator.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/DesignModelGenerator.java
@@ -166,7 +166,8 @@ public class DesignModelGenerator {
             if (size > 0) {
                 Listener listener = allAttachedListeners.get(0);
                 service.setIcon(listener.getIcon());
-                service.setType(getServiceType(listener.getType()));
+                service.setType(serviceModel.serviceType != null ? serviceModel.serviceType
+                        : getServiceType(listener.getType()));
                 for (int i = 0; i < size; i++) {
                     listener = allAttachedListeners.get(i);
                     listener.getAttachedServices().add(service.getUuid());

--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/IntermediateModel.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/IntermediateModel.java
@@ -60,6 +60,7 @@ public class IntermediateModel {
         protected String absolutePath;
         protected String displayName;
         protected String sortText;
+        protected String serviceType;
         protected final List<String> namedListeners = new ArrayList<>();
         protected final List<Listener> anonListeners = new ArrayList<>();
 


### PR DESCRIPTION
## Purpose

Fixes the service type shown in the design diagram for object-typed (event-trigger) services.

<img width="560" height="207" alt="image" src="https://github.com/user-attachments/assets/31c45d92-f517-4f09-899b-04ea2f4c47f5" />


For a service like:

```ballerina
service hubspot:CompanyService on hubspotListener {
    remote function onCompanyCreation(hubspot:WebhookEvent event) returns error? { ... }
}
```

the design model (`designModelService/getDesignModel`) returned `"type": "hubspot:Service"`, so the diagram showed **hubspot:Service** instead of **hubspot:CompanyService**.

## Root cause

`DesignModelGenerator` derived the service `type` solely from the attached listener's type:

```java
// "hubspot:Listener" -> "hubspot:Service"
return listenerType.split(":")[0] + ":" + SERVICE;
```

This is fine for path-based services (`service /path on httpListener`), which have no explicit type descriptor, but it discards the declared type for object-typed services.

## Changes

- `IntermediateModel.ServiceModel`: added a `serviceType` field.
- `CodeAnalyzer.visit(ServiceDeclarationNode)`: capture the declared service type via `ServiceDeclarationSymbol.typeDescriptor()` using the same `CommonUtils.getTypeSignature(...)` used for listeners (yields `hubspot:CompanyService`). Left null when there is no explicit type descriptor.
- `DesignModelGenerator`: prefer the declared type when present, fall back to the listener-derived type otherwise.

Result: object-typed services now report their real type (e.g. `hubspot:CompanyService`), consistent with the listener's `hubspot:Listener` label. Path-based services (HTTP, etc.) are unchanged.

## Testing

- `./gradlew :architecture-model-generator:architecture-model-generator-core:compileJava` passes.
- Full `DesignModelGeneratorTest` suite passes, confirming HTTP/path-based services still produce their existing `*:Service` types via the fallback path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes the service type representation in design diagrams for event-triggered services. Previously, services declared with an explicit type (e.g., `service hubspot:CompanyService on hubspotListener`) would display using the listener's type instead of their declared type.

## Changes

**IntermediateModel.java**: Added a `serviceType` field to the `ServiceModel` class to store the declared service type.

**CodeAnalyzer.java**: Updated the `visit(ServiceDeclarationNode)` method to capture the declared service type from the semantic type descriptor and populate the new field in `ServiceModel`.

**DesignModelGenerator.java**: Modified the generation logic to prioritize the declared service type when available, with fallback to the listener-derived type for services without an explicit type declaration. This ensures object-typed services display their declared type while path-based services remain unchanged.

## Outcome

Object-typed services now correctly display their declared service type in design diagrams, improving the accuracy of architectural representations for event-driven services. Path-based services continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->