### PR TITLE
Fix FUNCTION_CALL node inserted outside AgentTool body when import is required

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/SourceBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/SourceBuilder.java
@@ -113,9 +113,9 @@ public class SourceBuilder {
             NodeKind nodeKind = codedata.node();
             if (filePath.endsWith(AGENTS_BAL) && (nodeKind == NodeKind.FUNCTION_DEFINITION
                     || nodeKind == NodeKind.CLASS_INIT
-                    || nodeKind == NodeKind.RESOURCE_ACTION_CALL
+                    || ((nodeKind == NodeKind.RESOURCE_ACTION_CALL
                     || nodeKind == NodeKind.REMOTE_ACTION_CALL
-                    || nodeKind == NodeKind.FUNCTION_CALL)) {
+                    || nodeKind == NodeKind.FUNCTION_CALL) && codedata.lineRange() == null))) {
                 nodeKind = NodeKind.AGENT;
             }
             this.filePath = resolvePath(filePath, nodeKind, codedata.lineRange(), codedata.isNew());

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/agentsmanager/SourceGeneratorTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/agentsmanager/SourceGeneratorTest.java
@@ -59,7 +59,8 @@ public class SourceGeneratorTest extends AbstractLSTest {
                 {Path.of("agent_call_source_with_variables.json")},
                 {Path.of("agent_model_source_ballerina.json")},
                 {Path.of("agent_model_source_default.json")},
-                {Path.of("memory_manager_source.json")}
+                {Path.of("memory_manager_source.json")},
+                {Path.of("agent_tool_function_call_source.json")}
         };
     }
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_tool_function_call_source.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_tool_function_call_source.json
@@ -1,0 +1,87 @@
+{
+  "source": "agent_15/agents.bal",
+  "description": "Add a function call node inside an empty AgentTool function body (requires new import)",
+  "diagram": {
+    "id": "31",
+    "metadata": {
+      "label": "utcNow",
+      "description": "Returns the UTC representing the current time.",
+      "icon": ""
+    },
+    "codedata": {
+      "node": "FUNCTION_CALL",
+      "org": "ballerina",
+      "module": "time",
+      "packageName": "time",
+      "symbol": "utcNow",
+      "isNew": true,
+      "lineRange": {
+        "fileName": "agents.bal",
+        "startLine": {
+          "line": 3,
+          "offset": 30
+        },
+        "endLine": {
+          "line": 3,
+          "offset": 30
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "type": {
+        "metadata": {
+          "label": "Result Type",
+          "description": "Type of the variable"
+        },
+        "value": "time:Utc",
+        "placeholder": "var",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "codedata": {}
+      },
+      "variable": {
+        "metadata": {
+          "label": "Result",
+          "description": "Name of the result variable"
+        },
+        "value": "timeUtc",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "agent_15/agents.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "import ballerina/time;"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 30
+          },
+          "end": {
+            "line": 3,
+            "character": 30
+          }
+        },
+        "newText": "\ntime:Utc timeUtc = time:utcNow();"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/remote_action_tool.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/remote_action_tool.json
@@ -135,17 +135,6 @@
       "object": "Client",
       "symbol": "get",
       "version": "2.13.2",
-      "lineRange": {
-        "fileName": "main.bal",
-        "startLine": {
-          "line": 33,
-          "offset": 16
-        },
-        "endLine": {
-          "line": 33,
-          "offset": 97
-        }
-      },
       "isNew": true,
       "sourceCode": "// action call - http get call\n                json response = check currencyClient->get(\"/latest?base=\" + 'from + \"&to=\" + to);"
     },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/remote_action_tool5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/remote_action_tool5.json
@@ -134,18 +134,7 @@
       "module": "googleapis.gmail",
       "object": "Client",
       "symbol": "get",
-      "isNew": true,
-      "lineRange": {
-        "fileName": "agents.bal",
-        "startLine": {
-          "line": 11,
-          "offset": 0
-        },
-        "endLine": {
-          "line": 11,
-          "offset": 0
-        }
-      }
+      "isNew": true
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/remote_action_tool6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/remote_action_tool6.json
@@ -134,18 +134,7 @@
       "module": "github",
       "object": "Client",
       "symbol": "get",
-      "isNew": true,
-      "lineRange": {
-        "fileName": "agents.bal",
-        "startLine": {
-          "line": 13,
-          "offset": 0
-        },
-        "endLine": {
-          "line": 13,
-          "offset": 0
-        }
-      }
+      "isNew": true
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/remote_action_tool7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/remote_action_tool7.json
@@ -135,18 +135,7 @@
       "packageName": "birctesting",
       "object": "Client",
       "symbol": "get",
-      "isNew": true,
-      "lineRange": {
-        "fileName": "agents.bal",
-        "startLine": {
-          "line": 3,
-          "offset": 0
-        },
-        "endLine": {
-          "line": 3,
-          "offset": 0
-        }
-      }
+      "isNew": true
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/source/agent_15/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/source/agent_15/Ballerina.toml
@@ -1,0 +1,5 @@
+[package]
+org = "org"
+name = "agent_15"
+version = "0.1.0"
+distribution = "2201.12.7"

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/source/agent_15/agents.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/source/agent_15/agents.bal
@@ -1,0 +1,5 @@
+import ballerina/ai;
+
+@ai:AgentTool
+isolated function testTool() {
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/wso2/product-integrator/issues/1681

- When adding a node inside a newly created `@ai:AgentTool` function that requires a new import (e.g. `time:utcNow()` needing `import ballerina/time;`), the node was inserted **after** the closing `}` of the function instead of inside it.
- Root cause: in `SourceBuilder`, `FUNCTION_CALL` nodeKind was unconditionally overridden to `AGENT` when the file was `agents.bal`, causing `resolvePath` to ignore the provided `lineRange` and use end-of-file as the insertion point.
- Fix: only apply the `AGENT` override for `FUNCTION_CALL`, `RESOURCE_ACTION_CALL`, and `REMOTE_ACTION_CALL` when `lineRange` is `null`. When `lineRange` is provided it points to the exact insertion point inside the function body and must be respected.


https://github.com/user-attachments/assets/02d67d84-5d79-4708-b1a7-e6e196b8e7ca


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue where inserting nodes (such as function calls requiring new imports) into existing `@ai`:AgentTool functions would place the node at the end of the file instead of within the function body.

## Changes Made

Modified `SourceBuilder.java` to conditionally apply the `AGENT` node kind override for `FUNCTION_CALL`, `RESOURCE_ACTION_CALL`, and `REMOTE_ACTION_CALL` nodes only when `lineRange` is null. When `lineRange` is explicitly provided, it is now respected as the intended insertion point within the function body, rather than being overridden to use the end-of-file location.

## Outcome

This change improves the reliability and accuracy of code generation when adding nodes that require new module imports to existing agent tool functions, while preserving the correct behavior for creating new module-level agent tool functions at the end of agents.bal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->