### PR TITLE
Add offline fallback to a locally available package version

### DIFF
--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/FunctionDataBuilder.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/FunctionDataBuilder.java
@@ -137,6 +137,8 @@ public class FunctionDataBuilder {
     private static final String PULLING_THE_MODULE_MESSAGE = "Pulling the module '%s' from the central";
     private static final String MODULE_PULLING_FAILED_MESSAGE = "Failed to pull the module: %s";
     private static final String MODULE_PULLING_SUCCESS_MESSAGE = "Successfully pulled the module: %s";
+    private static final String MODULE_FALLBACK_MESSAGE =
+            "Could not pull the module '%s' from the central. Using the locally available version '%s'";
 
     private static final String CLIENT_SYMBOL = "Client";
 
@@ -394,14 +396,17 @@ public class FunctionDataBuilder {
             if (moduleInfo.isComplete() &&
                     PackageUtil.isModuleUnresolved(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version())) {
                 notifyClient(MessageType.Info, PULLING_THE_MODULE_MESSAGE);
+                boolean pulled = false;
                 try {
                     if (semanticModel == null) {
                         deriveSemanticModel();
+                        pulled = semanticModel != null;
                     }
                 } catch (Exception e) {
                     // Pulling the requested version from the central failed (e.g., no network access). Fall back to a
                     // locally available version of the package below before reporting a failure.
                 }
+                String requestedVersion = moduleInfo.version();
                 if (semanticModel == null) {
                     // Fallback: resolve whatever version of the package is available in the local bala cache.
                     Package localPackage = PackageUtil.resolveLocalPackage(
@@ -413,8 +418,10 @@ public class FunctionDataBuilder {
                 }
                 if (semanticModel == null) {
                     notifyClient(MessageType.Error, MODULE_PULLING_FAILED_MESSAGE);
-                } else {
+                } else if (pulled) {
                     notifyClient(MessageType.Info, MODULE_PULLING_SUCCESS_MESSAGE);
+                } else {
+                    notifyFallback(requestedVersion);
                 }
             }
         }
@@ -1194,6 +1201,17 @@ public class FunctionDataBuilder {
             String signature =
                     String.format("%s/%s:%s", moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version());
             lsClientLogger.notifyClient(messageType, String.format(message, signature));
+        }
+    }
+
+    private void notifyFallback(String requestedVersion) {
+        if (lsClientLogger != null) {
+            String requestedSignature =
+                    String.format("%s/%s:%s", moduleInfo.org(), moduleInfo.packageName(), requestedVersion);
+            String resolvedSignature =
+                    String.format("%s/%s:%s", moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version());
+            lsClientLogger.notifyClient(MessageType.Info,
+                    String.format(MODULE_FALLBACK_MESSAGE, requestedSignature, resolvedSignature));
         }
     }
 

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/FunctionDataBuilder.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/FunctionDataBuilder.java
@@ -394,8 +394,22 @@ public class FunctionDataBuilder {
             if (moduleInfo.isComplete() &&
                     PackageUtil.isModuleUnresolved(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version())) {
                 notifyClient(MessageType.Info, PULLING_THE_MODULE_MESSAGE);
+                try {
+                    if (semanticModel == null) {
+                        deriveSemanticModel();
+                    }
+                } catch (Exception e) {
+                    // Pulling the requested version from the central failed (e.g., no network access). Fall back to a
+                    // locally available version of the package below before reporting a failure.
+                }
                 if (semanticModel == null) {
-                    deriveSemanticModel();
+                    // Fallback: resolve whatever version of the package is available in the local bala cache.
+                    Package localPackage = PackageUtil.resolveLocalPackage(
+                            moduleInfo.org(), moduleInfo.packageName()).orElse(null);
+                    if (localPackage != null) {
+                        resolvedPackage(localPackage);
+                        updateModuleInfo();
+                    }
                 }
                 if (semanticModel == null) {
                     notifyClient(MessageType.Error, MODULE_PULLING_FAILED_MESSAGE);

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -407,6 +407,52 @@ public class PackageUtil {
     }
 
     /**
+     * Resolves a package using only the local bala cache, without any network access. When the exact version is not
+     * available, the resolver returns the version available in the local cache for the given organization and package.
+     * This is intended as an offline fallback when the requested version cannot be pulled from the central repository.
+     *
+     * @param org  The organization name of the package
+     * @param name The name of the package
+     * @return An Optional containing the locally available Package if found, empty Optional otherwise
+     */
+    public static Optional<Package> resolveLocalPackage(String org, String name) {
+        try {
+            ResolutionRequest resolutionRequest = ResolutionRequest.from(
+                    PackageDescriptor.from(PackageOrg.from(org), PackageName.from(name)));
+            PackageResolver packageResolver =
+                    getSampleProject().projectEnvironmentContext().getService(PackageResolver.class);
+
+            // Resolve the metadata offline to obtain the concrete version available in the local cache
+            Optional<PackageMetadataResponse> pkgMetadata = packageResolver.resolvePackageMetadata(
+                            Collections.singletonList(resolutionRequest),
+                            ResolutionOptions.builder().setOffline(true).build()).stream()
+                    .filter(response -> response.resolutionStatus() == ResolutionResponse.ResolutionStatus.RESOLVED)
+                    .findFirst();
+            if (pkgMetadata.isEmpty()) {
+                return Optional.empty();
+            }
+
+            // Resolve the package offline using the concrete descriptor resolved above
+            Optional<ResolutionResponse> resolutionResponse = packageResolver.resolvePackages(
+                            Collections.singletonList(ResolutionRequest.from(pkgMetadata.get().resolvedDescriptor())),
+                            ResolutionOptions.builder().setOffline(true).build()).stream()
+                    .filter(response -> response.resolutionStatus() == ResolutionResponse.ResolutionStatus.RESOLVED)
+                    .findFirst();
+            if (resolutionResponse.isEmpty()) {
+                return Optional.empty();
+            }
+
+            Path balaPath = resolutionResponse.get().resolvedPackage().project().sourceRoot();
+            ProjectEnvironmentBuilder defaultBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
+            defaultBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
+            BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath);
+            return Optional.ofNullable(balaProject.currentPackage());
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
      * Determines if a function is local to the current workspace project.
      *
      * @param workspaceManager The workspace manager

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/PackageUtil.java
@@ -447,7 +447,7 @@ public class PackageUtil {
             defaultBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
             BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath);
             return Optional.ofNullable(balaProject.currentPackage());
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Optional.empty();
         }
     }


### PR DESCRIPTION
## Purpose

When resolving an external module for a specific package version, the language server fails outright if the requested version is neither present in the local bala cache nor pullable from Ballerina Central (e.g. when there is no network access).

For example, requesting `ballerinax/redis:3.2.2` while offline with only `redis:3.2.1` cached locally results in a hard failure, even though a usable version of the package is available on disk.

This PR adds an offline fallback: when the requested version cannot be pulled, the resolver falls back to a version of the same package that is already available in the local cache.

Fixes https://github.com/wso2/product-integrator/issues/1762 

## Changes

- **`PackageUtil.resolveLocalPackage(org, name)`** — new helper that resolves a package using an offline (`setOffline(true)`), version-less resolution request, returning the locally available version (or empty if none exists).
- **`FunctionDataBuilder`** — the central pull (`deriveSemanticModel()`) is now wrapped in a `try/catch`. If the pull fails, the builder attempts `resolveLocalPackage(...)` before reporting a failure. On success, `updateModuleInfo()` syncs `moduleInfo` to the version that was actually resolved, so the generated `FunctionData` and import statements reflect the real version used.
- Added a distinct fallback notification (Info) that names both the requested and the resolved version, so the substitution is explicit rather than silently reported as a successful pull.

## Behavior

- The fallback fires **only after** the latest-version lookup (when no version is specified) and the central pull have run — so the existing "pull latest version" path is unaffected.
- Wrapping `deriveSemanticModel()` also fixes a pre-existing gap where the thrown exception bypassed the intended "Failed to pull the module" notification.
- If no version of the package exists locally, behavior is unchanged (resolution still fails as before).