### PR TITLE
Fix module prefix stripped from object-typed service types in design model

### DIFF
--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/CodeAnalyzer.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/CodeAnalyzer.java
@@ -155,10 +155,11 @@ public class CodeAnalyzer extends NodeVisitor {
             displayName = getDisplayName(serviceDeclarationSymbol.annotAttachments());
             Optional<TypeSymbol> typeDescriptor = serviceDeclarationSymbol.typeDescriptor();
             if (serviceDeclarationNode.typeDescriptor().isPresent()
-                    && typeDescriptor.isPresent() && typeDescriptor.get().getModule().isPresent()) {
+                    && typeDescriptor.isPresent() && typeDescriptor.get().getModule().isPresent()
+                    && serviceDeclarationSymbol.getModule().isPresent()) {
                 TypeSymbol typeSymbol = typeDescriptor.get();
                 serviceType = CommonUtils.getTypeSignature(typeSymbol,
-                        CommonUtils.ModuleInfo.from(typeSymbol.getModule().get().id()));
+                        CommonUtils.ModuleInfo.from(serviceDeclarationSymbol.getModule().get().id()));
             }
         }
         String absoluteResourcePath = String.join("", serviceDeclarationNode.absoluteResourcePath()

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/hubspot_trigger_service.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/hubspot_trigger_service.json
@@ -1,0 +1,159 @@
+{
+  "description": "Object-typed HubSpot trigger service keeps its declared module-qualified type (hubspot:CompanyService)",
+  "projectPath": "project_12",
+  "output": {
+    "designModel": {
+      "connections": [],
+      "listeners": [
+        {
+          "symbol": "hubspotListener",
+          "location": {
+            "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal",
+            "startLine": {
+              "line": 2,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 2,
+              "offset": 113
+            }
+          },
+          "attachedServices": [
+            "009a8f69-a564-7ae6-e40b-4aebf2bf8a39"
+          ],
+          "kind": "NAMED",
+          "type": "hubspot:Listener",
+          "args": [
+            {
+              "key": "listenerConfig",
+              "value": "{clientSecret: \"secret\", callbackURL: \"http://localhost:8090\"}"
+            }
+          ],
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_trigger.hubspot_0.12.0.png",
+          "uuid": "f6b029f0-719f-f488-25e2-26c2725d0f11",
+          "enableFlowModel": true,
+          "sortText": "main.bal2"
+        }
+      ],
+      "services": [
+        {
+          "location": {
+            "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal",
+            "startLine": {
+              "line": 4,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 22,
+              "offset": 1
+            }
+          },
+          "attachedListeners": [
+            "f6b029f0-719f-f488-25e2-26c2725d0f11"
+          ],
+          "connections": [],
+          "functions": [],
+          "remoteFunctions": [
+            {
+              "name": "onCompanyCreation",
+              "location": {
+                "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal",
+                "startLine": {
+                  "line": 5,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 6,
+                  "offset": 5
+                }
+              },
+              "connections": []
+            },
+            {
+              "name": "onCompanyDeletion",
+              "location": {
+                "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal",
+                "startLine": {
+                  "line": 8,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 9,
+                  "offset": 5
+                }
+              },
+              "connections": []
+            },
+            {
+              "name": "onCompanyPropertychange",
+              "location": {
+                "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal",
+                "startLine": {
+                  "line": 11,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 12,
+                  "offset": 5
+                }
+              },
+              "connections": []
+            },
+            {
+              "name": "onCompanyAssociationchange",
+              "location": {
+                "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal",
+                "startLine": {
+                  "line": 14,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 15,
+                  "offset": 5
+                }
+              },
+              "connections": []
+            },
+            {
+              "name": "onCompanyMerge",
+              "location": {
+                "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal",
+                "startLine": {
+                  "line": 17,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 18,
+                  "offset": 5
+                }
+              },
+              "connections": []
+            },
+            {
+              "name": "onCompanyRestore",
+              "location": {
+                "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal",
+                "startLine": {
+                  "line": 20,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 21,
+                  "offset": 5
+                }
+              },
+              "connections": []
+            }
+          ],
+          "resourceFunctions": [],
+          "absolutePath": "",
+          "type": "hubspot:CompanyService",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_trigger.hubspot_0.12.0.png",
+          "uuid": "009a8f69-a564-7ae6-e40b-4aebf2bf8a39",
+          "enableFlowModel": true,
+          "sortText": "main.bal4"
+        }
+      ]
+    }
+  }
+}

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/hubspot_trigger_service.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/hubspot_trigger_service.json
@@ -29,7 +29,7 @@
               "value": "{clientSecret: \"secret\", callbackURL: \"http://localhost:8090\"}"
             }
           ],
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_trigger.hubspot_0.12.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_trigger.hubspot_0.11.0.png",
           "uuid": "f6b029f0-719f-f488-25e2-26c2725d0f11",
           "enableFlowModel": true,
           "sortText": "main.bal2"
@@ -148,7 +148,7 @@
           "resourceFunctions": [],
           "absolutePath": "",
           "type": "hubspot:CompanyService",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_trigger.hubspot_0.12.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_trigger.hubspot_0.11.0.png",
           "uuid": "009a8f69-a564-7ae6-e40b-4aebf2bf8a39",
           "enableFlowModel": true,
           "sortText": "main.bal4"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/mcp_service.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/mcp_service.json
@@ -1,0 +1,68 @@
+{
+  "description": "MCP object-typed service retains its module-qualified type (mcp:Service) in the design model",
+  "projectPath": "project_11",
+  "output": {
+    "designModel": {
+      "connections": [],
+      "listeners": [
+        {
+          "symbol": "mcpListener",
+          "location": {
+            "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/service.bal",
+            "startLine": {
+              "line": 2,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 2,
+              "offset": 46
+            }
+          },
+          "attachedServices": [
+            "9d7deb9b-633a-1087-8a9b-1ee7fd1091ec"
+          ],
+          "kind": "NAMED",
+          "type": "mcp:Listener",
+          "args": [
+            {
+              "key": "listenTo",
+              "value": "8080"
+            }
+          ],
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_mcp_1.1.0.png",
+          "uuid": "5d4e7555-da87-4523-317b-8497e9d819f0",
+          "enableFlowModel": true,
+          "sortText": "service.bal2"
+        }
+      ],
+      "services": [
+        {
+          "location": {
+            "filePath": "/Users/danniles/Documents/Projects/WSO2/wso2-integrator/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/service.bal",
+            "startLine": {
+              "line": 4,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 5,
+              "offset": 1
+            }
+          },
+          "attachedListeners": [
+            "5d4e7555-da87-4523-317b-8497e9d819f0"
+          ],
+          "connections": [],
+          "functions": [],
+          "remoteFunctions": [],
+          "resourceFunctions": [],
+          "absolutePath": "/mcp ",
+          "type": "mcp:Service",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_mcp_1.1.0.png",
+          "uuid": "9d7deb9b-633a-1087-8a9b-1ee7fd1091ec",
+          "enableFlowModel": true,
+          "sortText": "service.bal4"
+        }
+      ]
+    }
+  }
+}

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/mcp_service.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/mcp_service.json
@@ -29,7 +29,7 @@
               "value": "8080"
             }
           ],
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_mcp_1.1.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_mcp_1.0.3.png",
           "uuid": "5d4e7555-da87-4523-317b-8497e9d819f0",
           "enableFlowModel": true,
           "sortText": "service.bal2"
@@ -57,7 +57,7 @@
           "resourceFunctions": [],
           "absolutePath": "/mcp ",
           "type": "mcp:Service",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_mcp_1.1.0.png",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_mcp_1.0.3.png",
           "uuid": "9d7deb9b-633a-1087-8a9b-1ee7fd1091ec",
           "enableFlowModel": true,
           "sortText": "service.bal4"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/Ballerina.toml
@@ -8,4 +8,4 @@ bi = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.1.0"
+version = "1.0.3"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/Ballerina.toml
@@ -4,3 +4,8 @@ name = "mcp_service"
 version = "0.1.0"
 
 bi = true
+
+[[dependency]]
+org = "ballerina"
+name = "mcp"
+version = "1.1.0"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/Ballerina.toml
@@ -1,0 +1,6 @@
+[package]
+org = "wso2"
+name = "mcp_service"
+version = "0.1.0"
+
+bi = true

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/service.bal
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_11/service.bal
@@ -1,0 +1,6 @@
+import ballerina/mcp;
+
+listener mcp:Listener mcpListener = new (8080);
+
+service mcp:Service /mcp on mcpListener {
+}

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/Ballerina.toml
@@ -4,3 +4,8 @@ name = "hubspot_trigger"
 version = "0.1.0"
 
 bi = true
+
+[[dependency]]
+org = "ballerinax"
+name = "trigger.hubspot"
+version = "0.12.0"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/Ballerina.toml
@@ -8,4 +8,4 @@ bi = true
 [[dependency]]
 org = "ballerinax"
 name = "trigger.hubspot"
-version = "0.12.0"
+version = "0.11.0"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/Ballerina.toml
@@ -1,0 +1,6 @@
+[package]
+org = "wso2"
+name = "hubspot_trigger"
+version = "0.1.0"
+
+bi = true

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_12/main.bal
@@ -1,0 +1,23 @@
+import ballerinax/trigger.hubspot;
+
+listener hubspot:Listener hubspotListener = new ({clientSecret: "secret", callbackURL: "http://localhost:8090"});
+
+service hubspot:CompanyService on hubspotListener {
+    remote function onCompanyCreation(hubspot:WebhookEvent event) returns error? {
+    }
+
+    remote function onCompanyDeletion(hubspot:WebhookEvent event) returns error? {
+    }
+
+    remote function onCompanyPropertychange(hubspot:WebhookEvent event) returns error? {
+    }
+
+    remote function onCompanyAssociationchange(hubspot:WebhookEvent event) returns error? {
+    }
+
+    remote function onCompanyMerge(hubspot:WebhookEvent event) returns error? {
+    }
+
+    remote function onCompanyRestore(hubspot:WebhookEvent event) returns error? {
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1810

This PR fixes the try-it not working for MCP services.

Object-typed services (e.g. `mcp:Service`) were returned by `getDesignModel` with a bare `"Service"` type instead of the module-qualified `"mcp:Service"`. Consumers that identify a service's protocol from the type string (such as the VS Code extension's Try It feature) could no longer detect these services, so Try It silently did nothing for MCP.

## Cause

For object-typed services the declared service type is rendered via `getTypeSignature(type, referenceModule)`. That helper omits the module prefix when the type belongs to the same module as `referenceModule`. The reference passed was the **type's own module**, which makes the type always look "local", so the prefix was always dropped — leaving just `"Service"`.

## Why it only affected MCP

Two conditions had to line up, and MCP was the only case that hit both:

1. **The service must be object-typed** (declares an explicit type descriptor). MCP/event-trigger services are written as `service mcp:Service /mcp on mcpListener`, so they run this code path. Path-based HTTP/GraphQL services (`service /api on ...`) have no type descriptor and fall back to the listener-derived type, so they were unaffected.
2. **The module name must be single-segment.** `getTypeSignature` compares the last segment of the type's module path against the reference package name, so the prefix is only stripped for single-word module names like `mcp` (or `http`). The object-typed case the original change was tested against (a HubSpot connector) has a multi-segment module name, so its prefix survived and the bug went unnoticed.

## Fix

Render the service type relative to the **module where the service is declared** instead of the type's own module. The prefix-stripping decision then becomes the correct one ("is this type local to the code that declares the service?"):

- Cross-module types (`mcp:Service`, `http:Service`, ...) keep their prefix.
- The multi-segment object-typed case (e.g. HubSpot) is unchanged — the fix produces the same output there as before.
- Types declared in the same module as the service are still rendered unqualified.

## Tests

Adds two `getDesignModel` tests for the object-typed path, which previously had no coverage:

- `project_11` / `mcp_service.json` — a single-module MCP service (`service mcp:Service ...`), asserting the type is `mcp:Service`. This is the exact regression: without the fix it comes back as `Service`.
- `project_12` / `hubspot_trigger_service.json` — a real event-trigger service using the `ballerinax/trigger.hubspot` connector (`service hubspot:CompanyService on hubspotListener`), asserting the type is `hubspot:CompanyService`. This guards the object-typed feature (the exact case the original change targeted) against regressions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated design model generation so object-typed services keep the correct module-qualified type from the context where the service is declared (instead of being rendered as an unqualified/bare type). This preserves cross-module identifiers such as `mcp:Service`, restoring correct MCP service recognition for protocol-aware consumers (e.g., Try It).

Added test coverage for:
- A single-module MCP service scenario
- A cross-module object-typed service scenario
<!-- end of auto-generated comment: release notes by coderabbit.ai -->