### PR TITLE
[1.7.3 hotfix] Protect JSON-RPC stream and bump version to 1.7.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=1.7.2
+version=1.7.3
 name=ballerina-language-server
 ballerinaLangVersion=2201.13.4
 

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     
     implementation "com.google.code.gson:gson:${gsonVersion}"
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:${eclipseLsp4jVersion}"
+
+    testImplementation "org.testng:testng:${testngVersion}"
 }
 
 jar {
@@ -36,4 +38,8 @@ jar {
                 'Main-Class': 'org.ballerinalang.langserver.launchers.stdio.Main'
         )
     }
+}
+
+test {
+    useTestNG()
 }

--- a/launcher/src/main/java/org/ballerinalang/langserver/launchers/stdio/Main.java
+++ b/launcher/src/main/java/org/ballerinalang/langserver/launchers/stdio/Main.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp4j.jsonrpc.Launcher;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -47,9 +48,7 @@ public final class Main {
 
     public static void startServer(InputStream in, OutputStream out)
             throws InterruptedException, ExecutionException {
-        // Disable writing ballerina central calls to stdout to avoid conflicting with LS client communicating
-        // over stdout with the LS
-        System.getProperty("enableOutputStream", "false");
+        protectJsonRpcStream();
 
         BallerinaLanguageServer server = new BallerinaLanguageServer();
         Launcher<ExtendedLanguageClient> launcher = Launcher.createLauncher(server,
@@ -58,5 +57,19 @@ public final class Main {
         server.connect(client);
         Future<?> startListening = launcher.startListening();
         startListening.get();
+    }
+
+    /**
+     * Protects the JSON-RPC stream used by the language server.
+     * <p>
+     * The stdio launcher communicates with the LS client over stdout. Any stray write to stdout (e.g. Ballerina
+     * central pull progress, warnings, or third-party dependency logs) corrupts the JSON-RPC frames and causes the
+     * client connection to error out. This method disables the central client output stream and redirects
+     * {@link System#out} to {@link System#err} so that such writes can never reach the protocol stream. lsp4j keeps
+     * writing to the original stdout stream captured before this method is invoked.
+     */
+    static void protectJsonRpcStream() {
+        System.setProperty("enableOutputStream", "false");
+        System.setOut(new PrintStream(System.err, true));
     }
 }

--- a/launcher/src/test/java/org/ballerinalang/langserver/launchers/stdio/MainTest.java
+++ b/launcher/src/test/java/org/ballerinalang/langserver/launchers/stdio/MainTest.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.launchers.stdio;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Tests for {@link Main#protectJsonRpcStream()}, which guards the JSON-RPC (stdout) stream of the stdio launcher
+ * against stray writes that would otherwise corrupt the protocol and crash the client connection.
+ *
+ * @since 1.0.0
+ */
+public class MainTest {
+
+    private static final String ENABLE_OUTPUT_STREAM = "enableOutputStream";
+
+    private PrintStream originalOut;
+    private PrintStream originalErr;
+    private String originalProperty;
+
+    @BeforeMethod
+    public void captureGlobalState() {
+        originalOut = System.out;
+        originalErr = System.err;
+        originalProperty = System.getProperty(ENABLE_OUTPUT_STREAM);
+    }
+
+    @AfterMethod
+    public void restoreGlobalState() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+        if (originalProperty == null) {
+            System.clearProperty(ENABLE_OUTPUT_STREAM);
+        } else {
+            System.setProperty(ENABLE_OUTPUT_STREAM, originalProperty);
+        }
+    }
+
+    @Test(description = "The central client output stream should be disabled to keep stdout free of pull output")
+    public void testDisablesCentralOutputStream() {
+        // Simulate a code path (e.g. a CLI CompileTask) that previously enabled the central output stream.
+        System.setProperty(ENABLE_OUTPUT_STREAM, "true");
+
+        Main.protectJsonRpcStream();
+
+        Assert.assertEquals(System.getProperty(ENABLE_OUTPUT_STREAM), "false",
+                "protectJsonRpcStream() must force the central output stream property to 'false'");
+    }
+
+    @Test(description = "Stray System.out writes must be redirected to stderr, not the JSON-RPC stdout stream")
+    public void testRedirectsStdoutToStderr() {
+        ByteArrayOutputStream stdoutBuffer = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderrBuffer = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(stdoutBuffer, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(stderrBuffer, true, StandardCharsets.UTF_8));
+
+        Main.protectJsonRpcStream();
+
+        // A stray write that a dependency (central client, compiler, etc.) might emit.
+        System.out.println("googleapis.gmail pulled from central successfully");
+
+        String protocolStream = stdoutBuffer.toString(StandardCharsets.UTF_8);
+        String diagnosticStream = stderrBuffer.toString(StandardCharsets.UTF_8);
+
+        Assert.assertTrue(protocolStream.isEmpty(),
+                "Nothing must reach the original stdout (JSON-RPC) stream, but found: " + protocolStream);
+        Assert.assertTrue(diagnosticStream.contains("googleapis.gmail pulled from central successfully"),
+                "Stray stdout writes must be redirected to stderr, but stderr was: " + diagnosticStream);
+    }
+
+    @Test(description = "The original stdout reference (used by lsp4j) must remain writable after protection")
+    public void testOriginalStdoutRemainsUsableForProtocol() {
+        ByteArrayOutputStream protocolBuffer = new ByteArrayOutputStream();
+        PrintStream protocolStream = new PrintStream(protocolBuffer, true, StandardCharsets.UTF_8);
+        System.setOut(protocolStream);
+        System.setErr(new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
+
+        // Capture the original stdout the way Main#main does before invoking startServer/protectJsonRpcStream.
+        PrintStream capturedForLsp4j = System.out;
+
+        Main.protectJsonRpcStream();
+
+        // lsp4j writes to the captured stream, which must still point at the real protocol sink.
+        capturedForLsp4j.print("{\"jsonrpc\":\"2.0\"}");
+
+        Assert.assertEquals(protocolBuffer.toString(StandardCharsets.UTF_8), "{\"jsonrpc\":\"2.0\"}",
+                "The stdout reference captured before protection must still write to the protocol stream");
+    }
+}

--- a/launcher/src/test/java/org/ballerinalang/langserver/launchers/stdio/MainTest.java
+++ b/launcher/src/test/java/org/ballerinalang/langserver/launchers/stdio/MainTest.java
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets;
  * Tests for {@link Main#protectJsonRpcStream()}, which guards the JSON-RPC (stdout) stream of the stdio launcher
  * against stray writes that would otherwise corrupt the protocol and crash the client connection.
  *
- * @since 1.0.0
+ * @since 1.7.3
  */
 public class MainTest {
 


### PR DESCRIPTION
## Purpose

Hotfix on top of `v1.7.2` backporting the JSON-RPC stream protection from #954, plus a version bump to `1.7.3`.

Fixes: https://github.com/wso2/product-integrator/issues/1790

## Changes

- Backport of #954 (`protectJsonRpcStream()`): redirects `System.out` to `System.err` and forces `enableOutputStream=false` so stray writes (central pull progress, dependency logs) can't corrupt the JSON-RPC frames on stdout.
- Adds `MainTest` covering the stdout protection behaviour.
- Bumps `version` in `gradle.properties` from `1.7.2` to `1.7.3`.

## Notes

Base branch `hotfix/connector-failure-1.7.2` is reset to the `v1.7.2` release tag, so this PR's diff is exactly the hotfix + version bump.
