### PR TITLE
Fix "Failed to pull unresolved modules" loop caused by missing transitive dependency balas

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -15,15 +15,27 @@
  */
 package org.ballerinalang.langserver.command.executors;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import io.ballerina.projects.CompilationOptions;
+import io.ballerina.projects.DependencyManifest;
+import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.Settings;
+import io.ballerina.projects.internal.bala.DependencyGraphJson;
+import io.ballerina.projects.internal.model.Dependency;
+import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.central.client.CentralAPIClient;
+import org.ballerinalang.central.client.exceptions.CentralClientException;
+import org.ballerinalang.central.client.exceptions.PackageAlreadyExistsException;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.codeaction.providers.imports.PullModuleCodeAction;
 import org.ballerinalang.langserver.command.CommandUtil;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.PathUtil;
+import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
@@ -47,13 +59,28 @@ import org.eclipse.lsp4j.WorkDoneProgressCreateParams;
 import org.eclipse.lsp4j.WorkDoneProgressEnd;
 import org.eclipse.lsp4j.WorkDoneProgressReport;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.wso2.ballerinalang.util.RepoUtils;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static io.ballerina.projects.util.ProjectUtils.getAccessTokenOfCLI;
+import static io.ballerina.projects.util.ProjectUtils.initializeProxy;
 
 /**
  * Command executor for pulling a package from central.
@@ -66,6 +93,15 @@ public class PullModuleExecutor implements LSCommandExecutor {
     public static final String COMMAND = "PULL_MODULE";
     private static final String TITLE_PULL_MODULE = "Pull Module";
     private static final String PULL_MODULE_TASK_PREFIX = "pull-module-";
+
+    // Built-in packages (lang libs, jballerina.java, etc.) carry this version and have no balas.
+    private static final String BUILT_IN_PACKAGE_VERSION = "0.0.0";
+    // Safety cap for the number of missing balas pulled within a single request.
+    private static final int MAX_MISSING_BALA_PULLS = 25;
+    // Guards against concurrent/re-entrant pulls for the same project. The PROJECT_UPDATE event
+    // published in stage 4 below is also consumed by ResolveCompilationErrorsSubscriber, which
+    // starts another pull for the same project, creating an endless pull loop on failures.
+    private static final Set<String> PULL_IN_PROGRESS_PROJECTS = ConcurrentHashMap.newKeySet();
 
     /**
      * {@inheritDoc}
@@ -116,7 +152,6 @@ public class PullModuleExecutor implements LSCommandExecutor {
     public static CompletableFuture<Void> resolveModules(String fileUri, ExtendedLanguageClient languageClient,
                                                          WorkspaceManager workspaceManager,
                                                          LanguageServerContext languageServerContext, boolean sticky) {
-        // TODO Prevent running parallel tasks for the same project in future
         String taskId = PULL_MODULE_TASK_PREFIX + UUID.randomUUID();
         Path filePath = PathUtil.getPathFromURI(fileUri)
                 .orElseThrow(() -> new UserErrorException("Couldn't determine file path"));
@@ -124,6 +159,16 @@ public class PullModuleExecutor implements LSCommandExecutor {
                 .orElseThrow(() -> new UserErrorException("Couldn't find project to pull modules"));
 
         LSClientLogger clientLogger = LSClientLogger.getInstance(languageServerContext);
+
+        // Prevent parallel/re-entrant pull tasks for the same project. Without this, the
+        // PROJECT_UPDATE event published by a running pull re-triggers another pull via
+        // ResolveCompilationErrorsSubscriber, causing an endless pull storm when pulls fail.
+        String projectKey = project.sourceRoot().toString();
+        if (!PULL_IN_PROGRESS_PROJECTS.add(projectKey)) {
+            clientLogger.logTrace("Skipped pulling modules since a pull is already in progress for project: "
+                    + projectKey);
+            return CompletableFuture.completedFuture(null);
+        }
         return CompletableFuture
                 .runAsync(() -> {
                     clientLogger.logTrace("Started pulling modules for project: " + project.sourceRoot().toString());
@@ -144,11 +189,43 @@ public class PullModuleExecutor implements LSCommandExecutor {
                 .thenRunAsync(() -> {
                     CompilationOptions.CompilationOptionsBuilder optionsBuilder = CompilationOptions.builder();
                     optionsBuilder.setOffline(false).setSticky(sticky);
-                    project.currentPackage().getResolution(optionsBuilder.build());
+                    CompilationOptions options = optionsBuilder.build();
+
+                    // For workspace projects, currentPackage() returns only the first member package.
+                    // Resolve every member online so that missing (transitive) balas are pulled for all
+                    // packages in the workspace. Single-member workspaces and non-workspace projects are
+                    // handled by the same path since the list then contains exactly one project.
+                    BallerinaCompilerApi compilerApi = BallerinaCompilerApi.getInstance();
+                    List<Project> memberProjects = compilerApi.isWorkspaceProject(project)
+                            ? compilerApi.getWorkspaceProjectsInOrder(project)
+                            : List.of(project);
+                    if (memberProjects.isEmpty()) {
+                        // Defensive fallback: preserve the previous behavior.
+                        memberProjects = List.of(project);
+                    }
+
+                    // Repair the local bala cache first: pull any dependency bala that is recorded in
+                    // Dependencies.toml or in a cached bala's dependency-graph.json but is missing from
+                    // the local repository. The resolution below cannot repair such gaps by itself,
+                    // because its online dependency graph is unified to the locked versions and never
+                    // requests the bala-recorded (as-built) versions demanded by offline compilations.
+                    for (Project memberProject : memberProjects) {
+                        // TODO: Remove the following path once
+                        //  https://github.com/ballerina-platform/ballerina-lang/issues/44275 gets fixed
+                        repairMissingDependencyBalas(memberProject, clientLogger);
+                    }
+
+                    // Run all resolutions first so that every member's missing modules are pulled from
+                    // central, even if a subsequent member compilation fails.
+                    for (Project memberProject : memberProjects) {
+                        memberProject.currentPackage().getResolution(options);
+                    }
                     // BIR issues are not captured during resolution, causing the pull module executor to incorrectly
                     // report that modules were pulled successfully. To remedy this, we now include the compilation
                     // step so that the executor accounts for BIR errors when generating the final status.
-                    project.currentPackage().getCompilation();
+                    for (Project memberProject : memberProjects) {
+                        memberProject.currentPackage().getCompilation();
+                    }
                 })
                 .thenRunAsync(() -> {
                     try {
@@ -202,6 +279,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
                     }
                 })
                 .whenComplete((result, t) -> {
+                    PULL_IN_PROGRESS_PROJECTS.remove(projectKey);
                     boolean failed = true;
                     if (t != null) {
                         clientLogger.logError(LSContextOperation.WS_EXEC_CMD,
@@ -241,6 +319,148 @@ public class PullModuleExecutor implements LSCommandExecutor {
                     languageClient.notifyProgress(new ProgressParams(Either.forLeft(taskId),
                             Either.forLeft(endNotification)));
                 });
+    }
+
+    /**
+     * Repairs the local bala cache for the given project by pulling any dependency bala that is
+     * required but missing from the local repository.
+     * <p>
+     * The required set is computed deterministically, without compiling:
+     * <ol>
+     * <li>the packages locked in Dependencies.toml ({@code dependencyManifest().packages()}), and</li>
+     * <li>transitively, every package recorded in the {@code dependency-graph.json} of each cached
+     * bala — the as-built versions a bala's BIR demands at load time (e.g., ballerina/cache:3.10.0
+     * requires ballerina/task:2.7.0 even when Dependencies.toml locks task to a newer version).</li>
+     * </ol>
+     * Offline compilations crash with a {@code BLangCompilerException} when such a bala is missing,
+     * and the resolution-based pull cannot repair the gap because its online dependency graph is
+     * unified to the locked versions and never requests the as-built version.
+     *
+     * @param project      the (member) project to repair the cache for
+     * @param clientLogger the client logger
+     */
+    private static void repairMissingDependencyBalas(Project project, LSClientLogger clientLogger) {
+        Path balaCacheRoot = RepoUtils.createAndGetHomeReposPath()
+                .resolve(ProjectConstants.REPOSITORIES_DIR)
+                .resolve(ProjectConstants.CENTRAL_REPOSITORY_CACHE_NAME)
+                .resolve(ProjectConstants.BALA_DIR_NAME);
+
+        // Seed the work queue with the packages locked in Dependencies.toml.
+        Deque<String[]> workQueue = new ArrayDeque<>();
+        DependencyManifest dependencyManifest = project.currentPackage().dependencyManifest();
+        if (dependencyManifest == null || dependencyManifest.packages() == null) {
+            return;
+        }
+        for (DependencyManifest.Package pkg : dependencyManifest.packages()) {
+            workQueue.add(new String[]{pkg.org().value(), pkg.name().value(), pkg.version().toString()});
+        }
+
+        Set<String> visited = new HashSet<>();
+        int pullCount = 0;
+        while (!workQueue.isEmpty()) {
+            String[] pkg = workQueue.poll();
+            String org = pkg[0];
+            String name = pkg[1];
+            String version = pkg[2];
+            if (BUILT_IN_PACKAGE_VERSION.equals(version) || !visited.add(org + "/" + name + ":" + version)) {
+                // Built-in packages (lang libs, jballerina.java, etc.) have no balas.
+                continue;
+            }
+
+            Path balaVersionDir = balaCacheRoot.resolve(org).resolve(name).resolve(version);
+            if (!Files.isDirectory(balaVersionDir)) {
+                if (pullCount >= MAX_MISSING_BALA_PULLS) {
+                    clientLogger.logTrace("Skipped pulling missing bala '" + org + "/" + name + ":" + version
+                            + "' since the maximum number of pulls per request has been reached");
+                    continue;
+                }
+                pullCount++;
+                clientLogger.logTrace("Pulling missing bala '" + org + "/" + name + ":" + version
+                        + "' from Ballerina central");
+                try {
+                    pullModuleFromCentral(org, name, version);
+                } catch (CentralClientException e) {
+                    // Continue with the remaining packages; the compilation will surface the
+                    // failure for this one through the regular error flow.
+                    clientLogger.logTrace("Failed to pull bala '" + org + "/" + name + ":" + version
+                            + "' from Ballerina central: " + e.getMessage());
+                    continue;
+                }
+            }
+
+            // Walk this bala's dependency graph to find the as-built versions it demands.
+            for (Dependency dependency : readBalaDependencyGraph(balaVersionDir, clientLogger)) {
+                workQueue.add(new String[]{dependency.getOrg(), dependency.getName(), dependency.getVersion()});
+            }
+        }
+    }
+
+    /**
+     * Reads the package dependency graph recorded in a cached bala's {@code dependency-graph.json}.
+     * A bala is extracted into {@code <org>/<name>/<version>/<platform>/}, so the platform
+     * directory is located first.
+     *
+     * @param balaVersionDir the bala version directory in the local cache
+     * @param clientLogger   the client logger
+     * @return the packages recorded in the dependency graph, or an empty list if unreadable
+     */
+    private static List<Dependency> readBalaDependencyGraph(Path balaVersionDir, LSClientLogger clientLogger) {
+        if (!Files.isDirectory(balaVersionDir)) {
+            return List.of();
+        }
+        try (DirectoryStream<Path> platformDirs = Files.newDirectoryStream(balaVersionDir, Files::isDirectory)) {
+            for (Path platformDir : platformDirs) {
+                Path dependencyGraphJson = platformDir.resolve(ProjectConstants.DEPENDENCY_GRAPH_JSON);
+                if (!Files.exists(dependencyGraphJson)) {
+                    continue;
+                }
+                try (BufferedReader reader = Files.newBufferedReader(dependencyGraphJson)) {
+                    DependencyGraphJson graph = new Gson().fromJson(reader, DependencyGraphJson.class);
+                    if (graph != null && graph.getPackageDependencyGraph() != null) {
+                        return graph.getPackageDependencyGraph();
+                    }
+                }
+            }
+        } catch (IOException | JsonSyntaxException e) {
+            clientLogger.logTrace("Failed to read dependency graph of bala '" + balaVersionDir + "': "
+                    + e.getMessage());
+        }
+        return List.of();
+    }
+
+    /**
+     * Pulls the given package version directly from Ballerina central into the local bala cache.
+     * This is the same download path used by `bal pull`.
+     *
+     * @param orgName     the organization name
+     * @param packageName the package name
+     * @param version     the exact package version to pull
+     * @throws CentralClientException if the download fails
+     */
+    private static void pullModuleFromCentral(String orgName, String packageName, String version)
+            throws CentralClientException {
+        Path packagePathInBalaCache = RepoUtils.createAndGetHomeReposPath()
+                .resolve(ProjectConstants.REPOSITORIES_DIR)
+                .resolve(ProjectConstants.CENTRAL_REPOSITORY_CACHE_NAME)
+                .resolve(ProjectConstants.BALA_DIR_NAME)
+                .resolve(orgName)
+                .resolve(packageName);
+        Settings settings = RepoUtils.readSettings();
+        CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
+                initializeProxy(settings.getProxy()), settings.getProxy().username(),
+                settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                settings.getCentral().getConnectTimeout(),
+                settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                settings.getCentral().getCallTimeout(), settings.getCentral().getMaxRetries());
+        String supportedPlatform = Arrays.stream(JvmTarget.values())
+                .map(JvmTarget::code)
+                .collect(Collectors.joining(","));
+        try {
+            client.pullPackage(orgName, packageName, version, packagePathInBalaCache, supportedPlatform,
+                    RepoUtils.getBallerinaVersion(), false);
+        } catch (PackageAlreadyExistsException e) {
+            // A concurrent pull has already fetched this bala. Treat it as a success.
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1807

### Problem

Some workspace projects and integration packages get stuck in an endless loop of `Failed to pull unresolved modules!` notifications, with every LS operation failing with an error such as:

```
failed to load the module 'ballerina/x:1.0.0' from its BIR due to:
cannot resolve module ballerina/y:0.1.0
```

**Root cause:** the local bala cache is missing a bala version that is *not* recorded in any manifest.

Consider a package `x` that depends on `y`. `x:1.0.0` was **built against** `y:0.1.0`, so its bala (both `dependency-graph.json` and the compiled BIR) pins `y:0.1.0`. Later, dependency resolution upgraded `y`, so the package's `Dependencies.toml` locks `y = 0.2.0`:

```
Package ──> x:1.0.0 ──(as-built pin in x's bala)──> y:0.1.0   ← missing from local cache
                └─────(Dependencies.toml lock)────> y:0.2.0   ← present in local cache
```

If `y:0.1.0` disappears from the local bala cache (interrupted pull, cache cleanup, AV interference), offline and online resolution disagree for the same lockfile:

- **Offline resolution** (all normal LS compiles) settles the graph on the bala-recorded `y:0.1.0`; the bala is missing, `offline=true` forbids downloading it, the node is silently dropped, and loading `x`'s BIR crashes with a `BLangCompilerException` instead of a diagnostic.
- **Online resolution** (the "Pull Module" repair) unifies to the locked `y:0.2.0`, finds everything cached, and downloads nothing — so the repair always "succeeds" at doing nothing.

Three defects compound this into the visible loop:

1. `PullModuleExecutor` resolved only `project.currentPackage()`, which for workspace projects is the **first member only** — other members were never resolved online.
2. No mechanism could ever fetch a bala-recorded (as-built) version that no manifest mentions.
3. The pull's own `PROJECT_UPDATE` event is consumed by `ResolveCompilationErrorsSubscriber`, which starts the next pull → **self-sustaining pull storm**.

```mermaid
sequenceDiagram
    participant C as LS compile (offline)
    participant S as ResolveCompilationErrorsSubscriber
    participant P as PullModuleExecutor
    participant R as Resolution (online)
    C->>C: graph wants y:0.1.0 (as-built pin)<br/>bala missing → BLangCompilerException
    C->>S: PROJECT_UPDATE
    S->>P: resolveModules(sticky=true)
    P->>R: getResolution(offline=false)
    R-->>P: graph unified to y:0.2.0 (locked)<br/>nothing to pull ✗
    P->>C: verification compile (offline)
    C->>S: PROJECT_UPDATE (from pull stage 4)
    Note over S,P: loop repeats forever
```

## Approach

All in `PullModuleExecutor`:

1. **Resolve all workspace members** in stage 2 via `BallerinaCompilerApi.getWorkspaceProjectsInOrder(project)` instead of `currentPackage()` (first member only). Non-workspace projects and older distributions keep the previous single-project path.
2. **Deterministic bala cache repair** before resolution: walk the packages locked in `Dependencies.toml` (`dependencyManifest().packages()`) and, transitively, the `dependency-graph.json` of every cached bala; any referenced bala missing from `~/.ballerina/repositories/central.ballerina.io/bala/` is pulled directly from central (same download path as `bal pull`; exact version; `PackageAlreadyExistsException` treated as success; capped per request). This is the only way to obtain as-built versions that no manifest records, and it requires no compilation failure to act.
3. **Per-project pull serialization**: a concurrent set keyed by `project.sourceRoot()` prevents a running pull from being re-entered by its own `PROJECT_UPDATE` event, ending the storm even when a pull genuinely fails.

### Notes

- The underlying offline/online resolution divergence is a ballerina-lang issue (`ResolutionEngine.completeDependencyGraph` consults only user-specified dependencies for unresolved nodes, and UNRESOLVED metadata responses are dropped silently). This PR is the LS-side remediation; an upstream issue will be filed separately.
- **Repro:** delete the as-built pinned version from the local cache (e.g. `rm -rf ~/.ballerina/repositories/central.ballerina.io/bala/<org>/y/0.1.0`) in a project whose lockfile pins `x:1.0.0` with `y` locked to a newer version, then open the project in VS Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change improves Pull Module stability by preventing repeated pull re-entry for the same project, resolving workspace members more completely, and repairing missing cached bala dependencies before online resolution runs.

It now walks locked dependencies and cached bala dependency graphs to fetch missing package versions directly from Central, which helps unblock projects that were getting stuck due to incomplete local cache state. It also serializes pull tasks per project so `PROJECT_UPDATE` events cannot trigger overlapping pull work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->