### PR TITLE
Resolve types from the module when the requested file is absent

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/FileSystemUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/FileSystemUtils.java
@@ -22,6 +22,8 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.modelgenerator.commons.PackageUtil;
 import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectException;
@@ -121,6 +123,59 @@ public class FileSystemUtils {
         Package currentPackage = project.currentPackage();
         return PackageUtil.getCompilation(currentPackage)
                 .getSemanticModel(currentPackage.getDefaultModule().moduleId());
+    }
+
+    /**
+     * Represents the document and the semantic model of a module.
+     *
+     * @param document      a document belonging to the module
+     * @param semanticModel the semantic model of the module
+     * @since 1.0.0
+     */
+    public record ModuleModel(Document document, SemanticModel semanticModel) {
+    }
+
+    /**
+     * Resolves the document and the semantic model of the module that the given path belongs to, without creating the
+     * file when it is absent.
+     * <p>
+     * If the file exists, its own document and semantic model are returned. Otherwise, the package is located from the
+     * parent directory of the path, and a document of the resolved module is returned instead. This suits requests that
+     * are scoped to a module rather than to a single file, such as retrieving every type of a package.
+     *
+     * @param workspaceManager the workspace manager used to load the project
+     * @param filePath         the path of the file, which need not exist on disk
+     * @return the module model, or empty if the resolved module holds no documents
+     * @throws ProjectException           if the package of the given path cannot be located
+     * @throws WorkspaceDocumentException if an error occurs while loading the project
+     * @throws EventSyncException         if an error occurs while publishing the project update event
+     */
+    public static Optional<ModuleModel> resolveModuleModel(WorkspaceManager workspaceManager, Path filePath)
+            throws WorkspaceDocumentException, EventSyncException {
+        if (Files.exists(filePath)) {
+            workspaceManager.loadProject(filePath);
+            Optional<Document> document = workspaceManager.document(filePath);
+            if (document.isPresent()) {
+                return Optional.of(new ModuleModel(document.get(), getSemanticModel(workspaceManager, filePath)));
+            }
+        }
+
+        Path parentPath = filePath.getParent();
+        if (parentPath == null) {
+            return Optional.empty();
+        }
+
+        // ProjectPaths.packageRoot() resolves the package root of any directory within the package. Hence, the parent
+        // directory is used to locate the project of a file that does not exist on disk.
+        Project project = workspaceManager.loadProject(parentPath);
+        Package currentPackage = project.currentPackage();
+        Module module = workspaceManager.module(parentPath).orElseGet(currentPackage::getDefaultModule);
+        Optional<DocumentId> documentId = module.documentIds().stream().findFirst();
+        if (documentId.isEmpty()) {
+            return Optional.empty();
+        }
+        SemanticModel semanticModel = PackageUtil.getCompilation(currentPackage).getSemanticModel(module.moduleId());
+        return Optional.of(new ModuleModel(module.document(documentId.get()), semanticModel));
     }
 
     /**

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/TypesManagerService.java
@@ -19,6 +19,7 @@
 package io.ballerina.flowmodelgenerator.extension;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonObject;
@@ -134,17 +135,17 @@ public class TypesManagerService implements ExtendedLanguageServerService {
             try {
                 Path filePath = PathUtil.convertUriStringToPath(request.filePath());
                 WorkspaceManager workspaceManager = this.workspaceManagerProxy.get(request.filePath());
-                workspaceManager.loadProject(filePath);
-                Optional<Document> document = workspaceManager.document(filePath);
-                Optional<SemanticModel> semanticModel = workspaceManager.semanticModel(filePath);
-                if (document.isEmpty() || semanticModel.isEmpty()) {
+                Optional<FileSystemUtils.ModuleModel> moduleModel =
+                        FileSystemUtils.resolveModuleModel(workspaceManager, filePath);
+                if (moduleModel.isEmpty()) {
+                    response.setTypes(new JsonArray());
                     return response;
                 }
-                TypesManager typesManager = new TypesManager(document.get());
-                JsonElement allTypes = typesManager.getAllTypes(semanticModel.get());
+                TypesManager typesManager = new TypesManager(moduleModel.get().document());
+                JsonElement allTypes = typesManager.getAllTypes(moduleModel.get().semanticModel());
                 response.setTypes(allTypes);
             } catch (Throwable e) {
-                throw new RuntimeException(e);
+                response.setError(e);
             }
             return response;
         });

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_types/config/get_all_types4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_types/config/get_all_types4.json
@@ -1,0 +1,408 @@
+{
+  "filePath": "test_pack4/types.bal",
+  "description": "Get all types of a package that does not contain a types.bal file",
+  "types": [
+    {
+      "name": "Coordinates",
+      "editable": true,
+      "metadata": {
+        "label": "Coordinates",
+        "description": ""
+      },
+      "codedata": {
+        "node": "RECORD",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 0,
+            "offset": 5
+          },
+          "endLine": {
+            "line": 0,
+            "offset": 16
+          }
+        }
+      },
+      "properties": {
+        "name": {
+          "metadata": {
+            "label": "Type name",
+            "description": "Unique name to identify the type"
+          },
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "value": "Coordinates",
+          "optional": false,
+          "editable": false,
+          "advanced": false,
+          "hidden": false
+        },
+        "isPublic": {
+          "metadata": {
+            "label": "public",
+            "description": "Make visible across the project"
+          },
+          "types": [
+            {
+              "fieldType": "FLAG",
+              "selected": true
+            }
+          ],
+          "value": "false",
+          "optional": true,
+          "editable": true,
+          "advanced": false,
+          "hidden": false
+        },
+        "description": {
+          "metadata": {
+            "label": "Type description",
+            "description": "Detailed description about the type"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "value": "",
+          "optional": false,
+          "editable": true,
+          "advanced": false,
+          "hidden": false
+        },
+        "isArray": {
+          "metadata": {
+            "label": "Is array type",
+            "description": "Is this type an array or list value"
+          },
+          "types": [
+            {
+              "fieldType": "FLAG",
+              "selected": true
+            }
+          ],
+          "value": "false",
+          "optional": true,
+          "editable": true,
+          "advanced": true,
+          "hidden": false
+        },
+        "arraySize": {
+          "metadata": {
+            "label": "Size of the array",
+            "description": "Array dimensions"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "value": "",
+          "optional": true,
+          "editable": true,
+          "advanced": true,
+          "hidden": false
+        }
+      },
+      "members": [
+        {
+          "kind": "FIELD",
+          "refs": [],
+          "type": "decimal",
+          "typeName": "decimal",
+          "name": "latitude",
+          "optional": false,
+          "readonly": false,
+          "isGraphqlId": false,
+          "docs": "",
+          "annotationAttachments": [],
+          "selected": false
+        },
+        {
+          "kind": "FIELD",
+          "refs": [],
+          "type": "decimal",
+          "typeName": "decimal",
+          "name": "longitude",
+          "optional": false,
+          "readonly": false,
+          "isGraphqlId": false,
+          "docs": "",
+          "annotationAttachments": [],
+          "selected": false
+        }
+      ],
+      "includes": [],
+      "annotationAttachments": [],
+      "allowAdditionalFields": false
+    },
+    {
+      "name": "Region",
+      "editable": true,
+      "metadata": {
+        "label": "Region",
+        "description": ""
+      },
+      "codedata": {
+        "node": "ENUM",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 10,
+            "offset": 5
+          },
+          "endLine": {
+            "line": 10,
+            "offset": 11
+          }
+        }
+      },
+      "properties": {
+        "name": {
+          "metadata": {
+            "label": "Type name",
+            "description": "Unique name to identify the type"
+          },
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "value": "Region",
+          "optional": false,
+          "editable": false,
+          "advanced": false,
+          "hidden": false
+        },
+        "isArray": {
+          "metadata": {
+            "label": "Is array type",
+            "description": "Is this type an array or list value"
+          },
+          "types": [
+            {
+              "fieldType": "FLAG",
+              "selected": true
+            }
+          ],
+          "value": "false",
+          "optional": true,
+          "editable": true,
+          "advanced": true,
+          "hidden": false
+        },
+        "arraySize": {
+          "metadata": {
+            "label": "Size of the array",
+            "description": "Array dimensions"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "value": "",
+          "optional": false,
+          "editable": false,
+          "advanced": false,
+          "hidden": false
+        },
+        "description": {
+          "metadata": {
+            "label": "Type description",
+            "description": "Detailed description about the type"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "value": "",
+          "optional": false,
+          "editable": true,
+          "advanced": false,
+          "hidden": false
+        }
+      },
+      "members": [
+        {
+          "kind": "NAME",
+          "refs": [],
+          "type": "\"NORTH\"",
+          "typeName": "\"NORTH\"",
+          "name": "NORTH",
+          "optional": false,
+          "readonly": false,
+          "isGraphqlId": false,
+          "selected": false
+        },
+        {
+          "kind": "NAME",
+          "refs": [],
+          "type": "\"SOUTH\"",
+          "typeName": "\"SOUTH\"",
+          "name": "SOUTH",
+          "optional": false,
+          "readonly": false,
+          "isGraphqlId": false,
+          "selected": false
+        }
+      ],
+      "allowAdditionalFields": false
+    },
+    {
+      "name": "City",
+      "editable": true,
+      "metadata": {
+        "label": "City",
+        "description": ""
+      },
+      "codedata": {
+        "node": "RECORD",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 5,
+            "offset": 5
+          },
+          "endLine": {
+            "line": 5,
+            "offset": 9
+          }
+        }
+      },
+      "properties": {
+        "name": {
+          "metadata": {
+            "label": "Type name",
+            "description": "Unique name to identify the type"
+          },
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "value": "City",
+          "optional": false,
+          "editable": false,
+          "advanced": false,
+          "hidden": false
+        },
+        "isPublic": {
+          "metadata": {
+            "label": "public",
+            "description": "Make visible across the project"
+          },
+          "types": [
+            {
+              "fieldType": "FLAG",
+              "selected": true
+            }
+          ],
+          "value": "false",
+          "optional": true,
+          "editable": true,
+          "advanced": false,
+          "hidden": false
+        },
+        "description": {
+          "metadata": {
+            "label": "Type description",
+            "description": "Detailed description about the type"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "value": "",
+          "optional": false,
+          "editable": true,
+          "advanced": false,
+          "hidden": false
+        },
+        "isArray": {
+          "metadata": {
+            "label": "Is array type",
+            "description": "Is this type an array or list value"
+          },
+          "types": [
+            {
+              "fieldType": "FLAG",
+              "selected": true
+            }
+          ],
+          "value": "false",
+          "optional": true,
+          "editable": true,
+          "advanced": true,
+          "hidden": false
+        },
+        "arraySize": {
+          "metadata": {
+            "label": "Size of the array",
+            "description": "Array dimensions"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "value": "",
+          "optional": true,
+          "editable": true,
+          "advanced": true,
+          "hidden": false
+        }
+      },
+      "members": [
+        {
+          "kind": "FIELD",
+          "refs": [],
+          "type": "string",
+          "typeName": "string",
+          "name": "name",
+          "optional": false,
+          "readonly": false,
+          "isGraphqlId": false,
+          "docs": "",
+          "annotationAttachments": [],
+          "selected": false
+        },
+        {
+          "kind": "FIELD",
+          "refs": [
+            "Coordinates"
+          ],
+          "type": "Coordinates",
+          "typeName": "Coordinates",
+          "name": "location",
+          "optional": false,
+          "readonly": false,
+          "isGraphqlId": false,
+          "docs": "",
+          "annotationAttachments": [],
+          "imports": {
+            "test_pack4": "testorg/test_pack4:0.1.0"
+          },
+          "selected": false
+        }
+      ],
+      "includes": [],
+      "annotationAttachments": [],
+      "allowAdditionalFields": false
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_types/source/test_pack4/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_types/source/test_pack4/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testorg"
+name = "test_pack4"
+version = "0.1.0"
+distribution = "2201.11.0"
+
+[build-options]
+observabilityIncluded = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_types/source/test_pack4/main.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_types/source/test_pack4/main.bal
@@ -1,0 +1,17 @@
+type Coordinates record {|
+    decimal latitude;
+    decimal longitude;
+|};
+
+type City record {|
+    string name;
+    Coordinates location;
+|};
+
+enum Region {
+    NORTH,
+    SOUTH
+}
+
+public function main() {
+}


### PR DESCRIPTION
## Purpose
Resolve types from the module when the requested file is absent.

Fixes : https://github.com/wso2/product-integrator/issues/1938

`typesManager/getTypes` failed with an internal error whenever the requested file did not exist in the package:

```
ProjectException: '<package>/types.bal' does not exist
    at io.ballerina.projects.util.ProjectPaths.packageRoot(ProjectPaths.java:61)
    at BallerinaWorkspaceManager.computeProjectRoot(BallerinaWorkspaceManager.java:1529)
    at BallerinaWorkspaceManager.loadProject(BallerinaWorkspaceManager.java:230)
    at TypesManagerService.lambda$getTypes$0(TypesManagerService.java:137)
```

The handler loaded the project from the requested file path, and `ProjectPaths.packageRoot()` throws for a path that is not on disk. The request therefore failed while resolving the package, before reading anything. The guard that follows it, which returns an empty response when the document or the semantic model is missing, was never reached in this case.

This affects any package that was not created through `initializer/createFiles`, since `types.bal` is one of the files that creates — for example a package created with `bal new` or imported from outside the Integrator.

## Approach
The types returned by this API are module scoped rather than file scoped, as they are collected through `SemanticModel.moduleSymbols()`. The requested path therefore only identifies the module to inspect, and the file itself does not have to exist.

- Added `FileSystemUtils.resolveModuleModel()`, which returns the document and the semantic model of the module that a path belongs to. When the file exists, its own document and semantic model are used, which preserves the existing behaviour. Otherwise the project is located from the parent directory of the path, since `ProjectPaths.packageRoot()` resolves the package root of any directory within the package, and the module resolved for that directory is used. Any document of that module represents it, because the type collection derives module level information from it.
- Failures are reported through the response error instead of being rethrown, consistent with `deleteType` and `verifyTypeDelete` in the same service. This changes what a caller observes for an unrecoverable request: the response now carries `errorMsg` and `stacktrace` instead of failing the JSON-RPC call.

The requested file is not created on disk, so the request remains read only.

## Tests
Added `test_pack4`, a package that declares its types in `main.bal` and has no `types.bal`, along with `get_all_types4.json` asserting that a request for the absent `test_pack4/types.bal` returns the types of the module.
