### PR TITLE
Address review suggestions on the connector search project resolution

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/FileSystemUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/FileSystemUtils.java
@@ -139,8 +139,8 @@ public class FileSystemUtils {
      * Loads the project that the given path belongs to, without creating the file when it is absent.
      * <p>
      * If the file exists, the project is loaded from the file itself. Otherwise, it is located from the parent
-     * directory of the path. This suits requests that are scoped to a project rather than to a single file, such as
-     * searching for the available connectors while the file that holds them is yet to be created.
+     * directory of the path. This suits any request that is scoped to a project rather than to a single file, and for
+     * which the path merely identifies the project — for example, searching the nodes available in a project.
      *
      * @param workspaceManager the workspace manager used to load the project
      * @param filePath         the path of the file, which need not exist on disk
@@ -195,7 +195,9 @@ public class FileSystemUtils {
             return Optional.empty();
         }
 
-        Project project = resolveProject(workspaceManager, filePath);
+        // ProjectPaths.packageRoot() resolves the package root of any directory within the package. Hence, the parent
+        // directory is used to locate the project of a file that does not exist on disk.
+        Project project = workspaceManager.loadProject(parentPath);
         Package currentPackage = project.currentPackage();
         Module module = workspaceManager.module(parentPath).orElseGet(currentPackage::getDefaultModule);
         Optional<DocumentId> documentId = module.documentIds().stream().findFirst();

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/FlowModelGeneratorService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/FlowModelGeneratorService.java
@@ -667,9 +667,15 @@ public class FlowModelGeneratorService implements ExtendedLanguageServerService 
             try {
                 Path filePath = Path.of(request.filePath());
                 WorkspaceManager workspaceManager = this.workspaceManagerProxy.get();
-                // The search is scoped to the project rather than to the requested file, and the file need not exist
-                // on disk yet (e.g., searching for connectors before connections.bal is created). Hence, resolve the
-                // project without requiring the file, instead of creating it.
+                // Every search kind is scoped to the project rather than to the requested file, so the path only
+                // identifies the project to search in and the file need not exist on disk. Hence, resolve the project
+                // without requiring the file, instead of creating it. A connector search before connections.bal is
+                // created is one such case, but the relaxation is general and is not specific to that kind.
+                //
+                // A kind that uses the position now proceeds with a position pointing into a file that does not
+                // exist, instead of failing while the project is resolved. Such a position matches no node of the
+                // project, since the commands compare it against the line ranges of the existing sources, so it
+                // simply narrows nothing.
                 Project project = FileSystemUtils.resolveProject(workspaceManager, filePath);
                 SearchCommand.Kind searchKind = SearchCommand.Kind.valueOf(request.searchKind());
                 LineRange position = request.position();


### PR DESCRIPTION
## Purpose
Address the review suggestions on https://github.com/ballerina-platform/ballerina-language-server/pull/977, which is already merged.

Follows up on : https://github.com/ballerina-platform/ballerina-language-server/pull/977#issuecomment-5139207325

No functional change. `FileSystemUtils.resolveProject()` and its use in `flowDesignService/search` stay as merged; this restores the code #973 introduced and clarifies the intent of the relaxation.

## Approach
**`resolveModuleModel()` no longer delegates to `resolveProject()`.** The delegation was not behaviour preserving. When the file exists but `WorkspaceManager.document()` is empty, the merged code reached `resolveProject()` with `Files.exists() == true`, so the project was loaded from the file rather than from its parent directory, and `ProjectPaths.packageRoot()` rejects an existing regular file that is not a `.bal` source. The method is restored to the `loadProject(parentPath)` call it had in #973, so that method is now byte identical to what was merged there. This also removes the duplicated `loadProject()` the delegation caused, since the file-exists path called it once and discarded the result before `resolveProject()` called it again.

**The comment in `search()` is reworded as general.** The relaxation applies to every `SearchCommand.Kind` rather than to `CONNECTOR` alone, so the comment no longer reads as if the fallback were connector specific. A connector search before `connections.bal` exists is kept as an example of the case.

The comment also records what the relaxation means for a kind that uses the position. Such a request now proceeds with a position pointing into a file that does not exist, instead of failing while the project is resolved. The commands match the position against the line ranges of the existing sources — `AgentToolSearchCommand`, for instance, compares `fnLineRange.fileName()` with `position.fileName()` to skip the function being edited — so a position in an absent file matches nothing and narrows nothing.

The javadoc of `resolveProject()` drops its connector specific example for the same reason.

## Tests
No new tests, as there is no functional change. `SearchTest` and the `typesmanager` suites that cover `resolveModuleModel` pass: 258 tests, 0 failures. Checkstyle passes on both changed modules.
