### PR TITLE
Report expression bodied resource accessors as resources

### DIFF
--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/artifactsgenerator/ModuleNodeTransformer.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/artifactsgenerator/ModuleNodeTransformer.java
@@ -92,17 +92,6 @@ public class ModuleNodeTransformer extends NodeTransformer<Optional<Artifact>> {
             functionBuilder
                     .name(AUTOMATION_FUNCTION_NAME)
                     .type(Artifact.Type.AUTOMATION);
-        } else if (functionDefinitionNode.functionBody().kind() == SyntaxKind.EXPRESSION_FUNCTION_BODY) {
-            if (BallerinaCompilerApi.getInstance()
-                    .isNaturalExpressionBody((ExpressionFunctionBodyNode) functionDefinitionNode.functionBody())) {
-                functionBuilder
-                        .name(functionName)
-                        .type(Artifact.Type.NP_FUNCTION);
-            } else {
-                functionBuilder
-                        .name(functionName)
-                        .type(Artifact.Type.DATA_MAPPER);
-            }
         } else if (functionDefinitionNode.functionBody().kind() == SyntaxKind.EXTERNAL_FUNCTION_BODY) {
             return Optional.empty();
         } else if (functionDefinitionNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
@@ -114,6 +103,17 @@ public class ModuleNodeTransformer extends NodeTransformer<Optional<Artifact>> {
             functionBuilder
                     .name(functionName)
                     .type(Artifact.Type.REMOTE);
+        } else if (functionDefinitionNode.functionBody().kind() == SyntaxKind.EXPRESSION_FUNCTION_BODY) {
+            if (BallerinaCompilerApi.getInstance()
+                    .isNaturalExpressionBody((ExpressionFunctionBodyNode) functionDefinitionNode.functionBody())) {
+                functionBuilder
+                        .name(functionName)
+                        .type(Artifact.Type.NP_FUNCTION);
+            } else {
+                functionBuilder
+                        .name(functionName)
+                        .type(Artifact.Type.DATA_MAPPER);
+            }
         } else {
             functionBuilder
                     .name(functionName)

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/http.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/http.json
@@ -1,0 +1,162 @@
+{
+  "source": "new_proj/main.bal",
+  "description": "",
+  "packageName": "proj329",
+  "output": {
+    "Variables": {
+      "additions": {
+        "products": {
+          "id": "products",
+          "location": {
+            "fileName": "main.bal",
+            "startLine": {
+              "line": 11,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 15,
+              "offset": 2
+            }
+          },
+          "type": "VARIABLE",
+          "name": "products",
+          "scope": "Global",
+          "visibility": "module",
+          "children": {}
+        }
+      }
+    },
+    "Types": {
+      "additions": {
+        "Product": {
+          "id": "Product",
+          "location": {
+            "fileName": "main.bal",
+            "startLine": {
+              "line": 2,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 7,
+              "offset": 3
+            }
+          },
+          "type": "TYPE",
+          "name": "Product",
+          "scope": "Global",
+          "visibility": "public",
+          "children": {}
+        }
+      }
+    },
+    "Entry Points": {
+      "additions": {
+        "-611393306": {
+          "id": "-611393306",
+          "location": {
+            "fileName": "main.bal",
+            "startLine": {
+              "line": 17,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 35,
+              "offset": 1
+            }
+          },
+          "type": "SERVICE",
+          "name": "HTTP Service - /products",
+          "scope": "Global",
+          "visibility": "module",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.6.png",
+          "module": "http",
+          "children": {
+            "get#[string productId]": {
+              "id": "get#[string productId]",
+              "location": {
+                "fileName": "main.bal",
+                "startLine": {
+                  "line": 21,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 26,
+                  "offset": 5
+                }
+              },
+              "type": "RESOURCE",
+              "name": "[string productId]",
+              "accessor": "get",
+              "scope": "Global",
+              "visibility": "module",
+              "children": {}
+            },
+            "get#.": {
+              "id": "get#.",
+              "location": {
+                "fileName": "main.bal",
+                "startLine": {
+                  "line": 19,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 19,
+                  "offset": 70
+                }
+              },
+              "type": "RESOURCE",
+              "name": ".",
+              "accessor": "get",
+              "scope": "Global",
+              "visibility": "module",
+              "children": {}
+            },
+            "post#.": {
+              "id": "post#.",
+              "location": {
+                "fileName": "main.bal",
+                "startLine": {
+                  "line": 28,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 34,
+                  "offset": 5
+                }
+              },
+              "type": "RESOURCE",
+              "name": ".",
+              "accessor": "post",
+              "scope": "Global",
+              "visibility": "module",
+              "children": {}
+            }
+          }
+        }
+      }
+    },
+    "Configurations": {
+      "additions": {
+        "port": {
+          "id": "port",
+          "location": {
+            "fileName": "main.bal",
+            "startLine": {
+              "line": 9,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 9,
+              "offset": 29
+            }
+          },
+          "type": "CONFIGURABLE",
+          "name": "port",
+          "scope": "Global",
+          "visibility": "module",
+          "children": {}
+        }
+      }
+    }
+  }
+}

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/source/new_proj/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/source/new_proj/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "wso2"
+name = "proj329"
+version = "0.1.0"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/source/new_proj/main.bal
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/source/new_proj/main.bal
@@ -1,0 +1,36 @@
+import ballerina/http;
+
+public type Product record {|
+    string id;
+    string name;
+    decimal price;
+    int stock;
+|};
+
+configurable int port = 9093;
+
+final map<Product> products = {
+    "SKU-1": {id: "SKU-1", name: "Widget", price: 19.99, stock: 120},
+    "SKU-2": {id: "SKU-2", name: "Gadget", price: 149.99, stock: 45},
+    "SKU-3": {id: "SKU-3", name: "Sprocket", price: 5.50, stock: 500}
+};
+
+service /products on new http:Listener(port) {
+
+    resource function get .() returns Product[] => products.toArray(); // this doesn't show up
+
+    resource function get [string productId]() returns Product|http:NotFound {
+        if products.hasKey(productId) {
+            return products.get(productId);
+        }
+        return http:NOT_FOUND;
+    }
+
+    resource function post .(@http:Payload Product product) returns http:Created|http:Conflict {
+        if products.hasKey(product.id) {
+            return http:CONFLICT;
+        }
+        products[product.id] = product;
+        return http:CREATED;
+    }
+}


### PR DESCRIPTION
## Purpose
Report a resource accessor that is written with an expression body as a resource of its service, instead of as a data mapper.

Fixes : https://github.com/wso2/product-integrator/issues/1966

A resource accessor whose body is an expression was published as a `DATA_MAPPER` artifact:

```ballerina
service /products on new http:Listener(port) {

    resource function get .() returns Product[] => products.toArray();

    resource function get [string productId]() returns Product|http:NotFound {
        ...
    }
}
```

The first accessor was published as

```json
"get": { "id": "get", "type": "DATA_MAPPER", "name": "get", ... }
```

while its block bodied siblings were published as resources. Since the artifact carried neither the `accessor` nor the resource path, it also lost the `<accessor>#<path>` id that identifies a resource, so it did not appear as a resource of the service in the view.

## Approach
`ModuleNodeTransformer.transform(FunctionDefinitionNode)` decided the artifact type from the function body kind before the node kind:

```
main                       -> AUTOMATION
EXPRESSION_FUNCTION_BODY   -> NP_FUNCTION / DATA_MAPPER   // matched here
EXTERNAL_FUNCTION_BODY     -> skipped
RESOURCE_ACCESSOR_DEFINITION -> RESOURCE                  // never reached
remote qualifier           -> REMOTE
```

An expression bodied accessor matched the second branch and never reached the resource branch. A remote function written the same way was misclassified for the same reason, one branch further down.

The resource and remote checks now come ahead of the expression body check, so what the function is decides its type rather than how its body is written. The external body check is also lifted to just after `main`. That is behaviour neutral, because a function body cannot be both an expression body and an external body, and it keeps external bodied functions skipped exactly as before. The only behaviour changes are therefore the two intended ones:

- an expression bodied resource accessor is now `RESOURCE`, with its accessor and resource path set
- an expression bodied remote function is now `REMOTE`

One consequence worth noting: a resource accessor with a natural expression body is now reported as `RESOURCE` rather than `NP_FUNCTION`, on the same reasoning that it belongs to the service it is declared in.

## Tests
Added `new_proj`, a package whose HTTP service declares one expression bodied accessor alongside block bodied ones, and `publish_artifacts/config/http.json` asserting that it is published as

```json
"get#.": { "id": "get#.", "type": "RESOURCE", "name": ".", "accessor": "get", ... }
```

The expected artifacts are written by hand rather than generated, so the assertion is checked against the intended shape. The `architecture-model-generator` suites pass and checkstyle is clean.
