### PR TITLE
Fix empty type list when the file is absent

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/DocumentContext.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/DocumentContext.java
@@ -179,7 +179,7 @@ public class DocumentContext {
 
         // Resolve the module that the file belongs to. WorkspaceManager.module() cannot resolve a path that does not
         // exist on disk. Hence, the parent directory is used for such a file.
-        Path modulePath = Files.isDirectory(inputFilePath) ? inputFilePath : inputFilePath.getParent();
+        Path modulePath = Files.exists(inputFilePath) ? inputFilePath : inputFilePath.getParent();
         if (modulePath == null) {
             throw new IllegalStateException("Module not found for the file: " + inputFilePath);
         }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/DocumentContext.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/DocumentContext.java
@@ -23,15 +23,18 @@ import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.flowmodelgenerator.core.utils.FileSystemUtils;
 import io.ballerina.modelgenerator.commons.CommonUtils;
-import io.ballerina.modelgenerator.commons.PackageUtil;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
+import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManagerProxy;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -88,9 +91,9 @@ public class DocumentContext {
             return Optional.of(project);
         }
         try {
-            project = workspaceManager().loadProject(inputFilePath);
+            project = FileSystemUtils.resolveProject(workspaceManager(), inputFilePath);
             return Optional.of(project);
-        } catch (Exception ignored) {
+        } catch (RuntimeException | WorkspaceDocumentException | EventSyncException ignored) {
             return Optional.empty();
         }
     }
@@ -152,8 +155,13 @@ public class DocumentContext {
         if (initialized) {
             return;
         }
+
+        Optional<Project> optProject = project();
+        if (optProject.isEmpty()) {
+            throw new IllegalStateException("Project not found for the file: " + inputFilePath);
+        }
+
         // Check if the document exists
-        PackageUtil.loadProject(workspaceManager(), inputFilePath);
         Optional<Document> inputDoc;
         try {
             inputDoc = workspaceManager.document(inputFilePath);
@@ -169,17 +177,18 @@ public class DocumentContext {
             return;
         }
 
-        // Generate the reserved file if not exists
-        Optional<Module> optModule = workspaceManager().module(inputFilePath);
+        // Resolve the module that the file belongs to. WorkspaceManager.module() cannot resolve a path that does not
+        // exist on disk. Hence, the parent directory is used for such a file.
+        Path modulePath = Files.isDirectory(inputFilePath) ? inputFilePath : inputFilePath.getParent();
+        if (modulePath == null) {
+            throw new IllegalStateException("Module not found for the file: " + inputFilePath);
+        }
+        Optional<Module> optModule = workspaceManager().module(modulePath);
         if (optModule.isPresent()) {
             module = optModule.get();
         } else {
             // Get the default module if not exists
-            Optional<Project> project = project();
-            if (project.isEmpty()) {
-                throw new IllegalStateException("Project not found for the file: " + inputFilePath);
-            }
-            module = project.get().currentPackage().getDefaultModule();
+            module = optProject.get().currentPackage().getDefaultModule();
         }
 
         // If the file is not found, it defaults to the end of a random file. Although we can create a
@@ -193,7 +202,7 @@ public class DocumentContext {
         }
         DocumentId documentId = documentIds.iterator().next();
         document = module.document(documentId);
-        filePath = inputFilePath.resolve(document.name());
+        filePath = modulePath.resolve(document.name());
         fileUri = CommonUtils.getExprUri(filePath.toString());
         initialized = true;
     }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config14.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config14.json
@@ -1,0 +1,329 @@
+{
+  "description": "",
+  "source": "data_mapper/config.bal",
+  "typeConstraint": "",
+  "position": {
+    "line": 0,
+    "offset": 0
+  },
+  "completions": [
+    {
+      "label": "Employee",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Employee"
+    },
+    {
+      "label": "Location",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Represents a geographical location.\n"
+      },
+      "insertText": "Location"
+    },
+    {
+      "label": "Person",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Person"
+    },
+    {
+      "label": "http:Client",
+      "labelDetails": {
+        "detail": "Used Variable Types",
+        "description": "Class"
+      },
+      "kind": "Interface",
+      "insertText": "http:Client"
+    },
+    {
+      "label": "table<Input> key(name) & readonly",
+      "labelDetails": {
+        "detail": "Used Variable Types",
+        "description": "Intersection"
+      },
+      "kind": "TypeParameter",
+      "insertText": "table<Input> key(name) & readonly"
+    },
+    {
+      "label": "Input & readonly",
+      "labelDetails": {
+        "detail": "Used Variable Types",
+        "description": "Intersection"
+      },
+      "kind": "TypeParameter",
+      "insertText": "Input & readonly"
+    },
+    {
+      "label": "Address",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Address"
+    },
+    {
+      "label": "Input",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Input"
+    },
+    {
+      "label": "Admission",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Admission"
+    },
+    {
+      "label": "Output",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Output"
+    },
+    {
+      "label": "Input",
+      "labelDetails": {
+        "detail": "Used Variable Types",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Input"
+    },
+    {
+      "label": "string",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "String"
+      },
+      "kind": "TypeParameter",
+      "insertText": "string"
+    },
+    {
+      "label": "int",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Int"
+      },
+      "kind": "TypeParameter",
+      "insertText": "int"
+    },
+    {
+      "label": "float",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Float"
+      },
+      "kind": "TypeParameter",
+      "insertText": "float"
+    },
+    {
+      "label": "decimal",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Decimal"
+      },
+      "kind": "TypeParameter",
+      "insertText": "decimal"
+    },
+    {
+      "label": "boolean",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Boolean"
+      },
+      "kind": "TypeParameter",
+      "insertText": "boolean"
+    },
+    {
+      "label": "()",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Nil"
+      },
+      "kind": "TypeParameter",
+      "insertText": "()"
+    },
+    {
+      "label": "byte",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Byte"
+      },
+      "kind": "TypeParameter",
+      "insertText": "byte"
+    },
+    {
+      "label": "byte[]",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Array"
+      },
+      "kind": "TypeParameter",
+      "insertText": "byte[]"
+    },
+    {
+      "label": "map<json>",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Map"
+      },
+      "kind": "TypeParameter",
+      "insertText": "map<json>"
+    },
+    {
+      "label": "map<string>",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Map"
+      },
+      "kind": "TypeParameter",
+      "insertText": "map<string>"
+    },
+    {
+      "label": "json[]",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Array"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json[]"
+    },
+    {
+      "label": "string[]",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Array"
+      },
+      "kind": "TypeParameter",
+      "insertText": "string[]"
+    },
+    {
+      "label": "record",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "record"
+    },
+    {
+      "label": "function",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Function"
+      },
+      "kind": "TypeParameter",
+      "insertText": "function"
+    },
+    {
+      "label": "future",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Future"
+      },
+      "kind": "TypeParameter",
+      "insertText": "future"
+    },
+    {
+      "label": "typedesc",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Typedesc"
+      },
+      "kind": "TypeParameter",
+      "insertText": "typedesc"
+    },
+    {
+      "label": "handle",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Handle"
+      },
+      "kind": "TypeParameter",
+      "insertText": "handle"
+    },
+    {
+      "label": "stream",
+      "labelDetails": {
+        "detail": "Behaviour Types",
+        "description": "Stream"
+      },
+      "kind": "TypeParameter",
+      "insertText": "stream"
+    },
+    {
+      "label": "error",
+      "labelDetails": {
+        "detail": "Error Types",
+        "description": "Error"
+      },
+      "kind": "Event",
+      "insertText": "error"
+    },
+    {
+      "label": "json",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Json"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json"
+    },
+    {
+      "label": "xml",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Xml"
+      },
+      "kind": "TypeParameter",
+      "insertText": "xml"
+    },
+    {
+      "label": "anydata",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Anydata"
+      },
+      "kind": "TypeParameter",
+      "insertText": "anydata"
+    },
+    {
+      "label": "any",
+      "labelDetails": {
+        "detail": "Other Types",
+        "description": "Any"
+      },
+      "kind": "TypeParameter",
+      "insertText": "any"
+    },
+    {
+      "label": "readonly",
+      "labelDetails": {
+        "detail": "Other Types",
+        "description": "Readonly"
+      },
+      "kind": "TypeParameter",
+      "insertText": "readonly"
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Resolve the module of an expression editor request when the requested file is absent, so that the types of the package are returned for a file that is yet to be created.

Fixes : https://github.com/wso2/product-integrator/issues/1977

`expressionEditor/types` failed whenever the requested file did not exist in the package:

```
ProjectException: '<package>/config.bal' does not exist
    at io.ballerina.projects.util.ProjectPaths.packageRoot(ProjectPaths.java:61)
    at PackageUtil.loadProject(PackageUtil.java:232)
    at DocumentContext.initialize(DocumentContext.java:156)
    at DocumentContext.semanticModel(DocumentContext.java:112)
    at TypesGenerator.getTypes(TypesGenerator.java:117)
```

`ExpressionEditorService.types()` swallows the failure and returns an empty completion list, so no type is offered for such a file, not even a built-in one.

`DocumentContext.initialize()` already falls back to a document of the module when the requested path holds no document of its own. That fallback was unreachable, since `PackageUtil.loadProject()` throws for a path that is not on disk before it is reached, and two steps of the fallback assume a path that exists: `WorkspaceManager.module()` rejects an absent path the same way, and the fallback document path was resolved against the requested file, which yields `<file>/<document>` for a file path.

## Approach
The request is scoped to the module rather than to a single file. The types visible at the start of a file that is yet to be created are the ones visible in its module, so the requested path only has to identify the module, and the file itself does not have to exist.

- `project()` resolves the project through `FileSystemUtils.resolveProject()`, which loads the project that a path belongs to without creating the file when it is absent. When the file exists, the project is loaded from the file itself, which preserves the existing behaviour. Otherwise it is loaded from the parent directory of the path, since `ProjectPaths.packageRoot()` resolves the package root of any directory within the package while rejecting a path that is not on disk.
- `initialize()` loads the project through `project()` instead of `PackageUtil.loadProject()`, and reuses it for the default module lookup that follows.
- The module and the fallback document path are resolved against the directory of the requested path: the path itself when it is a directory, which preserves the existing behaviour, and its parent directory otherwise.
- `project()` catches the exceptions that `resolveProject()` throws instead of `Exception`, which SpotBugs flags once the call is to a method of the same module.

The requested file is not created on disk, so the request remains read only.

## Tests
Added `types/config/config14.json`, which requests the types for the absent `data_mapper/config.bal` and asserts that the types of the module are returned along with the built-in ones. The test reproduces the failure on the current `hotfix/1.7.4-bal-ext-fixes` branch, where the response holds no completion item at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes `expressionEditor/types` requests for files that do not exist. The request now resolves the project and module from the requested path and returns module and built-in types. Existing-file behavior remains unchanged.

Adds a test fixture for the missing `data_mapper/config.bal` file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->