### PR TITLE
Handle empty packageNames in getNodeTemplate API

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectionActionProvider.java
@@ -236,8 +236,7 @@ public class ConnectionActionProvider {
     }
 
     private ConnectorContext createContext(Codedata codedata, Project project) {
-        ModuleInfo moduleInfo = new ModuleInfo(codedata.org(),
-                codedata.packageName() == null ? codedata.module() : codedata.packageName(),
+        ModuleInfo moduleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
         Package resolvedPackage = resolvePackage(moduleInfo, project).orElse(null);
         SemanticModel semanticModel = resolveSemanticModel(moduleInfo, project, resolvedPackage);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Codedata.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Codedata.java
@@ -64,6 +64,19 @@ public record Codedata(NodeKind node, String org, String module, String packageN
         return sb.toString();
     }
 
+    /**
+     * Returns the package name of the codedata, and the module when the package name is absent.
+     * <p>
+     * The codedata of a node that is derived from the source does not carry the package name, since
+     * {@code CodeAnalyzer} assigns the package name to the module. A request that is built out of such a node
+     * therefore holds no package name, and the package cannot be resolved without this fallback.
+     *
+     * @return the package name to resolve the package with
+     */
+    public String resolvePackageName() {
+        return packageName == null || packageName.isEmpty() ? module : packageName;
+    }
+
     public String getImportSignature() {
         return org + "/" + module;
     }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ChunkerBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ChunkerBuilder.java
@@ -81,7 +81,7 @@ public class ChunkerBuilder extends CallBuilder {
     @Override
     public void setConcreteTemplateData(TemplateContext context) {
         Codedata codedata = context.codedata();
-        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.packageName(),
+        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
 
         FunctionData functionData = new FunctionDataBuilder().parentSymbolType(codedata.object())

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataLoaderBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataLoaderBuilder.java
@@ -77,7 +77,7 @@ public class DataLoaderBuilder extends CallBuilder {
     @Override
     public void setConcreteTemplateData(NodeBuilder.TemplateContext context) {
         Codedata codedata = context.codedata();
-        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.packageName(),
+        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
 
         FunctionData functionData = new FunctionDataBuilder().parentSymbolType(codedata.object())

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/EmbeddingProviderBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/EmbeddingProviderBuilder.java
@@ -99,7 +99,7 @@ public class EmbeddingProviderBuilder extends CallBuilder {
     @Override
     public void setConcreteTemplateData(NodeBuilder.TemplateContext context) {
         Codedata codedata = context.codedata();
-        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.packageName(),
+        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
 
         FunctionData functionData = new FunctionDataBuilder().moduleInfo(codedataModuleInfo).userModuleInfo(moduleInfo)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/KnowledgeBaseBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/KnowledgeBaseBuilder.java
@@ -82,7 +82,7 @@ public class KnowledgeBaseBuilder extends CallBuilder {
     @Override
     public void setConcreteTemplateData(NodeBuilder.TemplateContext context) {
         Codedata codedata = context.codedata();
-        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.packageName(),
+        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
 
         FunctionData functionData = new FunctionDataBuilder().parentSymbolType(codedata.object())

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/MemoryBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/MemoryBuilder.java
@@ -68,7 +68,7 @@ public class MemoryBuilder extends CallBuilder {
     @Override
     public void setConcreteTemplateData(TemplateContext context) {
         Codedata codedata = context.codedata();
-        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.packageName(),
+        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
 
         FunctionData functionData = new FunctionDataBuilder().moduleInfo(codedataModuleInfo).userModuleInfo(moduleInfo)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ModelProviderBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ModelProviderBuilder.java
@@ -98,7 +98,7 @@ public class ModelProviderBuilder extends CallBuilder {
     @Override
     public void setConcreteTemplateData(TemplateContext context) {
         Codedata codedata = context.codedata();
-        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.packageName(),
+        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
 
         FunctionData functionData = new FunctionDataBuilder().moduleInfo(codedataModuleInfo).userModuleInfo(moduleInfo)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
@@ -125,11 +125,13 @@ public class NewConnectionBuilder extends CallBuilder {
         Codedata codedata = context.codedata();
         FunctionData functionData;
 
+        String packageName = codedata.packageName() == null || codedata.packageName().isEmpty() ?
+                codedata.module() : codedata.packageName();
+
         FunctionDataBuilder functionDataBuilder = new FunctionDataBuilder()
                 .parentSymbolType(codedata.object())
                 .name(codedata.symbol())
-                .moduleInfo(new ModuleInfo(codedata.org(), codedata.packageName(), codedata.module(),
-                        codedata.version()))
+                .moduleInfo(new ModuleInfo(codedata.org(), packageName, codedata.module(), codedata.version()))
                 .lsClientLogger(context.lsClientLogger())
                 .functionResultKind(FunctionData.Kind.CONNECTOR)
                 .userModuleInfo(moduleInfo)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnectionBuilder.java
@@ -125,13 +125,11 @@ public class NewConnectionBuilder extends CallBuilder {
         Codedata codedata = context.codedata();
         FunctionData functionData;
 
-        String packageName = codedata.packageName() == null || codedata.packageName().isEmpty() ?
-                codedata.module() : codedata.packageName();
-
         FunctionDataBuilder functionDataBuilder = new FunctionDataBuilder()
                 .parentSymbolType(codedata.object())
                 .name(codedata.symbol())
-                .moduleInfo(new ModuleInfo(codedata.org(), packageName, codedata.module(), codedata.version()))
+                .moduleInfo(new ModuleInfo(codedata.org(), codedata.resolvePackageName(), codedata.module(),
+                        codedata.version()))
                 .lsClientLogger(context.lsClientLogger())
                 .functionResultKind(FunctionData.Kind.CONNECTOR)
                 .userModuleInfo(moduleInfo)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ShortTermMemoryStoreBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ShortTermMemoryStoreBuilder.java
@@ -68,7 +68,7 @@ public class ShortTermMemoryStoreBuilder extends CallBuilder {
     @Override
     public void setConcreteTemplateData(TemplateContext context) {
         Codedata codedata = context.codedata();
-        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.packageName(),
+        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
 
         FunctionData functionData = new FunctionDataBuilder().moduleInfo(codedataModuleInfo).userModuleInfo(moduleInfo)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/VectorStoreBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/VectorStoreBuilder.java
@@ -82,7 +82,7 @@ public class VectorStoreBuilder extends CallBuilder {
     @Override
     public void setConcreteTemplateData(NodeBuilder.TemplateContext context) {
         Codedata codedata = context.codedata();
-        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.packageName(),
+        ModuleInfo codedataModuleInfo = new ModuleInfo(codedata.org(), codedata.resolvePackageName(),
                 codedata.module(), codedata.version());
 
         FunctionData functionData = new FunctionDataBuilder()

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/new_connection-http-no-package-name.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/new_connection-http-no-package-name.json
@@ -4,14 +4,13 @@
     "line": 52,
     "offset": 4
   },
-  "description": "",
+  "description": "Node template of an existing connection whose codedata carries no package name",
   "codedata": {
     "node": "NEW_CONNECTION",
     "org": "ballerina",
     "module": "http",
     "object": "Client",
-    "symbol": "init",
-    "version": "2.16.6"
+    "symbol": "init"
   },
   "output": {
     "id": "31",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/new_connection-http2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/new_connection-http2.json
@@ -1,0 +1,855 @@
+{
+  "source": "data_mapper/main.bal",
+  "position": {
+    "line": 52,
+    "offset": 4
+  },
+  "description": "",
+  "codedata": {
+    "node": "NEW_CONNECTION",
+    "org": "ballerina",
+    "module": "http",
+    "object": "Client",
+    "symbol": "init",
+    "version": "2.16.6"
+  },
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "HTTP",
+      "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.6.png"
+    },
+    "codedata": {
+      "node": "NEW_CONNECTION",
+      "org": "ballerina",
+      "module": "http",
+      "packageName": "http",
+      "object": "Client",
+      "symbol": "init",
+      "version": "2.16.6",
+      "isNew": true
+    },
+    "returning": false,
+    "properties": {
+      "url": {
+        "metadata": {
+          "label": "Url",
+          "description": "URL of the target service"
+        },
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "string",
+            "selected": false
+          }
+        ],
+        "placeholder": "\"\"",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false,
+        "codedata": {
+          "kind": "REQUIRED",
+          "originalName": "url"
+        }
+      },
+      "httpVersion": {
+        "metadata": {
+          "label": "HTTP Version",
+          "description": "HTTP protocol version supported by the client"
+        },
+        "types": [
+          {
+            "fieldType": "SINGLE_SELECT",
+            "options": [
+              {
+                "label": "2.0",
+                "value": "\"2.0\""
+              },
+              {
+                "label": "1.1",
+                "value": "\"1.1\""
+              },
+              {
+                "label": "1.0",
+                "value": "\"1.0\""
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:HttpVersion",
+            "selected": false
+          }
+        ],
+        "placeholder": "\"2.0\"",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "httpVersion"
+        },
+        "defaultValue": "\"2.0\""
+      },
+      "http1Settings": {
+        "metadata": {
+          "label": "HTTP1 Settings",
+          "description": "HTTP/1.x specific settings"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:ClientHttp1Settings",
+            "typeMembers": [
+              {
+                "type": "ClientHttp1Settings",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:ClientHttp1Settings",
+            "selected": false
+          }
+        ],
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "http1Settings"
+        },
+        "defaultValue": "{}"
+      },
+      "http2Settings": {
+        "metadata": {
+          "label": "HTTP2 Settings",
+          "description": "HTTP/2 specific settings"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:ClientHttp2Settings",
+            "typeMembers": [
+              {
+                "type": "ClientHttp2Settings",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:ClientHttp2Settings",
+            "selected": false
+          }
+        ],
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "http2Settings"
+        },
+        "defaultValue": "{}"
+      },
+      "timeout": {
+        "metadata": {
+          "label": "Timeout",
+          "description": "Maximum time(in seconds) to wait for a response before the request times out"
+        },
+        "types": [
+          {
+            "fieldType": "NUMBER",
+            "ballerinaType": "decimal",
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "decimal",
+            "selected": false
+          }
+        ],
+        "placeholder": "0.0d",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "timeout"
+        },
+        "defaultValue": "0.0d"
+      },
+      "forwarded": {
+        "metadata": {
+          "label": "Forwarded",
+          "description": "The choice of setting `Forwarded`/`X-Forwarded-For` header, when acting as a proxy"
+        },
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "string",
+            "selected": false
+          }
+        ],
+        "placeholder": "\"\"",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "forwarded"
+        },
+        "defaultValue": "\"\""
+      },
+      "followRedirects": {
+        "metadata": {
+          "label": "Follow Redirects",
+          "description": "HTTP redirect handling configurations (with 3xx status codes)"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:FollowRedirects",
+            "typeMembers": [
+              {
+                "type": "FollowRedirects",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:FollowRedirects?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "followRedirects"
+        },
+        "defaultValue": "()"
+      },
+      "poolConfig": {
+        "metadata": {
+          "label": "Pool Config",
+          "description": "Configurations associated with the request connection pool"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:PoolConfiguration",
+            "typeMembers": [
+              {
+                "type": "PoolConfiguration",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:PoolConfiguration?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "poolConfig"
+        },
+        "defaultValue": "()"
+      },
+      "cache": {
+        "metadata": {
+          "label": "Cache",
+          "description": "HTTP response caching related configurations"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:CacheConfig",
+            "typeMembers": [
+              {
+                "type": "CacheConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:CacheConfig",
+            "selected": false
+          }
+        ],
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "cache"
+        },
+        "defaultValue": "{}"
+      },
+      "compression": {
+        "metadata": {
+          "label": "Compression",
+          "description": "Enable request/response compression (using `accept-encoding` header)"
+        },
+        "types": [
+          {
+            "fieldType": "SINGLE_SELECT",
+            "options": [
+              {
+                "label": "AUTO",
+                "value": "\"AUTO\""
+              },
+              {
+                "label": "ALWAYS",
+                "value": "\"ALWAYS\""
+              },
+              {
+                "label": "NEVER",
+                "value": "\"NEVER\""
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:Compression",
+            "selected": false
+          }
+        ],
+        "placeholder": "\"AUTO\"",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "compression"
+        },
+        "defaultValue": "\"AUTO\""
+      },
+      "auth": {
+        "metadata": {
+          "label": "Auth",
+          "description": "Client authentication options (Basic, Bearer token, OAuth, etc.)"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:CredentialsConfig|http:BearerTokenConfig|http:JwtIssuerConfig|http:OAuth2ClientCredentialsGrantConfig|http:OAuth2PasswordGrantConfig|http:OAuth2RefreshTokenGrantConfig|http:OAuth2JwtBearerGrantConfig",
+            "typeMembers": [
+              {
+                "type": "CredentialsConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              },
+              {
+                "type": "BearerTokenConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              },
+              {
+                "type": "JwtIssuerConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              },
+              {
+                "type": "OAuth2ClientCredentialsGrantConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              },
+              {
+                "type": "OAuth2PasswordGrantConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              },
+              {
+                "type": "OAuth2RefreshTokenGrantConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              },
+              {
+                "type": "OAuth2JwtBearerGrantConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:ClientAuthConfig?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "auth"
+        },
+        "defaultValue": "()"
+      },
+      "circuitBreaker": {
+        "metadata": {
+          "label": "Circuit Breaker",
+          "description": "Circuit breaker configurations to prevent cascading failures"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:CircuitBreakerConfig",
+            "typeMembers": [
+              {
+                "type": "CircuitBreakerConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:CircuitBreakerConfig?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "circuitBreaker"
+        },
+        "defaultValue": "()"
+      },
+      "retryConfig": {
+        "metadata": {
+          "label": "Retry Config",
+          "description": "Automatic retry settings for failed requests"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:RetryConfig",
+            "typeMembers": [
+              {
+                "type": "RetryConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:RetryConfig?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "retryConfig"
+        },
+        "defaultValue": "()"
+      },
+      "cookieConfig": {
+        "metadata": {
+          "label": "Cookie Config",
+          "description": "Cookie handling settings for session management"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:CookieConfig",
+            "typeMembers": [
+              {
+                "type": "CookieConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:CookieConfig?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "cookieConfig"
+        },
+        "defaultValue": "()"
+      },
+      "responseLimits": {
+        "metadata": {
+          "label": "Response Limits",
+          "description": "Limits for response size and headers (to prevent memory issues)"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:ResponseLimitConfigs",
+            "typeMembers": [
+              {
+                "type": "ResponseLimitConfigs",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:ResponseLimitConfigs",
+            "selected": false
+          }
+        ],
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "responseLimits"
+        },
+        "defaultValue": "{}"
+      },
+      "proxy": {
+        "metadata": {
+          "label": "Proxy",
+          "description": "Proxy server settings if requests need to go through a proxy"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:ProxyConfig",
+            "typeMembers": [
+              {
+                "type": "ProxyConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:ProxyConfig?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "proxy"
+        },
+        "defaultValue": "()"
+      },
+      "validation": {
+        "metadata": {
+          "label": "Validation",
+          "description": "Enable automatic payload validation for request/response data against constraints"
+        },
+        "types": [
+          {
+            "fieldType": "FLAG",
+            "ballerinaType": "boolean",
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "boolean",
+            "selected": false
+          }
+        ],
+        "placeholder": "false",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "validation"
+        },
+        "defaultValue": "false"
+      },
+      "socketConfig": {
+        "metadata": {
+          "label": "Socket Config",
+          "description": "Low-level socket settings (timeouts, buffer sizes, etc.)"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:ClientSocketConfig",
+            "typeMembers": [
+              {
+                "type": "ClientSocketConfig",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:ClientSocketConfig",
+            "selected": false
+          }
+        ],
+        "placeholder": "{}",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "socketConfig"
+        },
+        "defaultValue": "{}"
+      },
+      "laxDataBinding": {
+        "metadata": {
+          "label": "Lax Data Binding",
+          "description": "Enable relaxed data binding on the client side.\nWhen enabled:\n- `null` values in JSON are allowed to be mapped to optional fields\n- missing fields in JSON are allowed to be mapped as `null` values"
+        },
+        "types": [
+          {
+            "fieldType": "FLAG",
+            "ballerinaType": "boolean",
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "boolean",
+            "selected": false
+          }
+        ],
+        "placeholder": "false",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "laxDataBinding"
+        },
+        "defaultValue": "false"
+      },
+      "secureSocket": {
+        "metadata": {
+          "label": "Secure Socket",
+          "description": "SSL/TLS security settings for HTTPS connections"
+        },
+        "types": [
+          {
+            "fieldType": "RECORD_MAP_EXPRESSION",
+            "ballerinaType": "http:ClientSecureSocket",
+            "typeMembers": [
+              {
+                "type": "ClientSecureSocket",
+                "packageInfo": "ballerina:http:2.16.6",
+                "packageName": "http",
+                "kind": "RECORD_TYPE",
+                "selected": false
+              }
+            ],
+            "selected": false
+          },
+          {
+            "fieldType": "EXPRESSION",
+            "ballerinaType": "http:ClientSecureSocket?",
+            "selected": false
+          }
+        ],
+        "placeholder": "()",
+        "optional": true,
+        "editable": true,
+        "advanced": true,
+        "hidden": false,
+        "codedata": {
+          "kind": "INCLUDED_FIELD",
+          "originalName": "secureSocket"
+        },
+        "defaultValue": "()"
+      },
+      "type": {
+        "metadata": {
+          "label": "Result Type",
+          "description": "Type of the variable"
+        },
+        "types": [
+          {
+            "fieldType": "TYPE",
+            "selected": true
+          }
+        ],
+        "value": "http:Client",
+        "placeholder": "var",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": true,
+        "codedata": {},
+        "imports": {
+          "http": "ballerina/http"
+        }
+      },
+      "variable": {
+        "metadata": {
+          "label": "Connection Name",
+          "description": "Name of the connection"
+        },
+        "types": [
+          {
+            "fieldType": "IDENTIFIER",
+            "selected": true
+          }
+        ],
+        "value": "httpClient1",
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      },
+      "scope": {
+        "metadata": {
+          "label": "Connection Scope",
+          "description": "Scope of the connection, Global or Local"
+        },
+        "types": [
+          {
+            "fieldType": "ENUM",
+            "selected": true
+          }
+        ],
+        "value": "Global",
+        "optional": false,
+        "editable": true,
+        "advanced": true,
+        "hidden": true
+      },
+      "checkError": {
+        "metadata": {
+          "label": "Check Error",
+          "description": "Terminate on error"
+        },
+        "types": [
+          {
+            "fieldType": "FLAG",
+            "selected": true
+          }
+        ],
+        "value": true,
+        "optional": false,
+        "editable": false,
+        "advanced": true,
+        "hidden": true
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/source/data_mapper/main.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/source/data_mapper/main.bal
@@ -48,3 +48,7 @@ function processEmployeeStatus(Status status, Department dept, Priority priority
     string statusMsg = string `Status: ${status}, Department: ${dept}, Priority: ${priority}, Value: ${value.toString()}`;
     return statusMsg;
 }
+
+function testHttp() returns error? {
+    http:Client ordersClient = check new ("http://localhost:9090");
+}


### PR DESCRIPTION
## Purpose
Fixes : https://github.com/wso2/product-integrator/issues/1978

Fall back to the module when the requested codedata carries no package name, so that the node template of a connection can be resolved from the model of an existing connection.

`flowDesignService/getNodeTemplate` failed whenever the requested codedata had no package name:

```
No versions found for the package: ballerina/null
    at io.ballerina.centralconnector.RestClient.latestPackageVersion(RestClient.java:124)
    at io.ballerina.modelgenerator.commons.FunctionDataBuilder.build(FunctionDataBuilder.java:392)
    at NewConnectionBuilder.setConcreteTemplateData(NewConnectionBuilder.java:161)
```

The codedata of a connection that is derived from the source does not carry the package name. `CodeAnalyzer` builds it with the organization, the module, the object and the symbol alone, and the module holds the package name:

```java
.codedata()
    .org(org)
    .module(packageName)
    .object(name)
    .symbol(NewConnectionBuilder.INIT_SYMBOL);
```

The visualizer sends that codedata back as it is when the node of an existing connection is selected, which is the case for a connection that is declared inside a function. `NewConnectionBuilder` then mapped it into a `ModuleInfo` with a null package name, and since the codedata of such a node holds no version either, `FunctionDataBuilder` requested the latest version of `ballerina/null` from the central and the request failed before the template was built.

The connectors that are picked from the side panel are unaffected, since `ConnectorSearchCommand` sets both the package name and the version on the codedata of a search result.

## Approach
`setConcreteTemplateData()` resolves the package name from the module when it is absent or empty. This is safe for the affected nodes, since `CodeAnalyzer` already assigns the package name to the module, so the two hold the same value. A request that carries a package name is unaffected, and the requested file is not modified, so the request remains read only.

## Tests
Added `node_template/config/new_connection-http2.json`, which requests the node template of a connection with codedata that carries no package name, at a position inside a function of `data_mapper/main.bal`. This mirrors the codedata that the visualizer sends for a connection that is declared inside a function. The test reproduces the reported failure on the current `hotfix/1.7.4-bal-ext-fixes` branch, where the request fails with the error above.

Added the `testHttp()` function to `data_mapper/main.bal` to hold such a connection. The version is pinned in the requested codedata so that the recorded output stays stable against the version drift of the package in the central.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fix `getNodeTemplate` handling when `codedata.packageName()` is absent or empty by using the module name as the package name.
- Preserve existing behavior when a package name is provided.
- Add an HTTP/2 connection template and a `testHttp()` regression scenario with a pinned HTTP version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->